### PR TITLE
Use logical return values where applicable

### DIFF
--- a/Generator/Utils/FieldInfo.cs
+++ b/Generator/Utils/FieldInfo.cs
@@ -72,6 +72,7 @@ public record FieldInfo(SimpleFieldKind Kind, string TypeName, int Length = 0, T
                     SimpleFieldKind.Primitive => UnderlyingType.TypeName.Equals("void", StringComparison.InvariantCultureIgnoreCase) ?
                         "ptr" :
                         UnderlyingType.GetDllCallType(useNakedPointer) + '*',
+                    SimpleFieldKind.NativeTypedef or SimpleFieldKind.HRESULT => UnderlyingType.GetDllCallType(true) + "*",
                     _ => "ptr"
                 };
             }

--- a/Generator/Utils/FieldSignatureDecoder.cs
+++ b/Generator/Utils/FieldSignatureDecoder.cs
@@ -12,6 +12,13 @@ public static class FieldSignatureDecoder
     /// </summary>
     private static readonly Dictionary<string, MetadataReader> _assemblyReaders = [];
 
+    /// <summary>
+    /// List of namespaces of types which we are external to Windows.Win32 and which we don't
+    /// want to resolve. These are all WinRT types, the only place this is ever applicable is in
+    /// the WinRT Interop Apis
+    /// </summary>
+    private static readonly string[] excludeNamespaces = ["Windows.UI", "Windows.Foundation", "Windows.Graphics", "Windows.Storage"];
+
     public static FieldInfo DecodeFieldType(MetadataReader reader, FieldDefinition fieldDef)
     {
         var blob = reader.GetBlobReader(fieldDef.Signature);
@@ -26,8 +33,14 @@ public static class FieldSignatureDecoder
     {
         var td = reader.GetTypeDefinition(tdHandle);
         string typeName = reader.GetString(td.Name);
+        string typeNamespace = reader.GetString(td.Namespace);
 
-        if (typeName == "HRESULT")
+        if(excludeNamespaces.Any(typeNamespace.StartsWith))
+        {
+            Debug.WriteLine($"Treating Win32 external {typeNamespace}.{typeName} as a pointer");
+            return new FieldInfo(SimpleFieldKind.Pointer, typeName, 0, td);
+        }
+        else if (typeName == "HRESULT")
         {
             return new FieldInfo(SimpleFieldKind.HRESULT, "HRESULT", 0, td, null, reader);
         }

--- a/Generator/Utils/ParameterDecoder.cs
+++ b/Generator/Utils/ParameterDecoder.cs
@@ -17,7 +17,7 @@ public class ParameterDecoder
         {
             // Return type might be parameter at sequenceNumber 0
             result.Add(new AhkParameter(
-                retParam.Name.IsNil ? "" : reader.GetString(retParam.Name),
+                "result",
                 0,
                 sig.ReturnType,
                 retParam.Attributes,
@@ -27,7 +27,7 @@ public class ParameterDecoder
         else
         {
             result.Add(new AhkParameter(
-                "Return Value",
+                "result",
                 0,
                 sig.ReturnType,
                 System.Reflection.ParameterAttributes.None,

--- a/Generator/model/AhkComMethod.cs
+++ b/Generator/model/AhkComMethod.cs
@@ -54,6 +54,7 @@ class AhkComMethod : AhkMethod
             sb.AppendLine();
         }
 
+        AppendOutputParamMarshallingCode(sb);
         sb.AppendLine($"        {BuildDllCallCall("")}");
 
         if (SetsLastError)
@@ -64,10 +65,7 @@ class AhkComMethod : AhkMethod
             sb.AppendLine();
         }
 
-        if (HasReturnValue)
-        {
-            sb.AppendLine($"        return result");
-        }
+        AppendReturnStatement(sb);
         sb.AppendLine($"    }}");
     }
 
@@ -101,7 +99,7 @@ class AhkComMethod : AhkMethod
         StringBuilder sb = new();
 
         // ComCall can check HRESULTs for us
-        if (HasReturnValue)
+        if (FuncHasReturnValue)
             sb.Append("result := ");
 
         // https://www.autohotkey.com/docs/v2/lib/ComCall.htm
@@ -114,7 +112,7 @@ class AhkComMethod : AhkMethod
         }
 
         // Calling convention / return type
-        if (CallingConvention == MethodImportAttributes.CallingConventionCDecl || HasReturnValue)
+        if (CallingConvention == MethodImportAttributes.CallingConventionCDecl || FuncHasReturnValue)
         {
             sb.Append(", \"");
             if (CallingConvention == MethodImportAttributes.CallingConventionCDecl)
@@ -122,7 +120,7 @@ class AhkComMethod : AhkMethod
                 sb.Append("CDecl ");
             }
 
-            if (HasReturnValue)
+            if (FuncHasReturnValue)
                 sb.Append(ShouldThrowForReturnValue()? "HRESULT" : parameters[0].FieldInfo.GetDllCallType(false));
 
             sb.Append('"');
@@ -142,6 +140,30 @@ class AhkComMethod : AhkMethod
             .Where(m => (m.Name == Name) && (m.VTableIndex < VTableIndex))
             .Count();
 
-        return counter > 0? Name + counter : Name;
+        return counter > 0 ? Name + counter : Name;
+    }
+
+    private protected override AhkParameter? GetOutputParameter()
+    {
+        if (!parameters[0].IsHRESULT || CanReturnErrorsAsSuccess)
+        {
+            return null;
+        }
+
+        AhkParameter outParam = default;
+        outParam = parameters.SingleOrDefault(p => p.IsReturnValue);
+
+        if(outParam == default)
+        {
+            IEnumerable<AhkParameter> candidateParams = parameters
+                .Where(p => p.IsOutParam && !p.IsInParam)
+                .Where(p => p.IsPtrToPrimitive || p.IsPtrToStruct || p.IsPtrToCom || p.IsPtrToHandle(mr));
+            if (candidateParams.Count() == 1)
+            {
+                outParam = candidateParams.Single();
+            }
+        }
+
+        return (outParam == default) ? null : outParam;
     }
 }

--- a/Generator/model/AhkMethod.cs
+++ b/Generator/model/AhkMethod.cs
@@ -26,9 +26,23 @@ class AhkMethod
     // This will almost always be identical to Name, but isn't required to be
     public string EntryPoint => import.Name.IsNil? "" : mr.GetString(import.Name);
 
-    public bool HasReturnValue => !(parameters[0].FieldInfo.Kind == SimpleFieldKind.Primitive && parameters[0].FieldInfo.TypeName == "Void");
+    public bool PreserveSig => CustomAttributes.Any(c => c.Name is "PreserveSigAttribute");
+
+    public bool CanReturnErrorsAsSuccess => CustomAttributes.Any(c => c.Name is "CanReturnErrorsAsSuccessAttribute");
+
+    /// <summary>
+    /// Does the function have a non-void return value? Note that it may not, but we could
+    /// still have an output parameter
+    /// </summary>
+    public bool FuncHasReturnValue => !(parameters[0].FieldInfo.Kind == SimpleFieldKind.Primitive && parameters[0].FieldInfo.TypeName == "Void");
 
     private protected readonly List<AhkParameter> parameters = [];
+
+    /// <summary>
+    /// The logical return value of the function, if any (e.g. the [RetVal] param for Com methods,
+    /// or an [out] param if we're confident that we don't want the user to allocate it)
+    /// </summary>
+    private protected AhkParameter? outputParameter;
 
     private readonly List<CAInfo> CustomAttributes;
 
@@ -42,6 +56,7 @@ class AhkMethod
 
         import = methodDef.GetImport();
         parameters = ParameterDecoder.DecodeParameters(mr, methodDef);
+        outputParameter = GetOutputParameter();
     }
 
     public virtual void ToAhk(StringBuilder sb)
@@ -99,6 +114,7 @@ class AhkMethod
             sb.AppendLine();
         }
 
+        AppendOutputParamMarshallingCode(sb);
         sb.AppendLine($"        {BuildDllCallCall(epIsOrd? "procAddr" : $"\"{DLLName}\\{EntryPoint}\"")}");
 
         if (epIsOrd)
@@ -116,46 +132,83 @@ class AhkMethod
             sb.AppendLine();
         }
 
-        if (HasReturnValue)
-            AppendReturnStatement(sb, parameters[0]);
+        AppendReturnStatement(sb);
 
         sb.AppendLine($"    }}");
     }
 
-    private void AppendReturnStatement(StringBuilder sb, AhkParameter returnValue)
+    private protected void AppendOutputParamMarshallingCode(StringBuilder sb)
+    {
+        if (!outputParameter.HasValue)
+        {
+            return;
+        }
+
+        AhkParameter outParam = outputParameter.Value;
+        if (outParam.CustomAttributes.HasFlag(CustomParamAttributes.SizedBuffer))
+        {
+            // We need to create a buffer with some size
+            Parameter param = methodDef.GetParameters()
+                .Select(mr.GetParameter)
+                .Single(p => mr.StringComparer.Equals(p.Name, outParam.Name));
+            CAInfo memSize = CustomAttributeDecoder.DecodeAll(mr, param)
+                .Single(p => p.Name == "MemorySizeAttribute");
+            short bytesParamIndex = (short)(memSize.Attr.NamedArguments.Single(arg => arg.Name == "BytesParamIndex").Value ?? throw new NullReferenceException());
+
+            // bytesParamIndex + 1 because we include the return value as a param
+            sb.AppendLine($"        {outParam.Name} := Buffer({parameters[bytesParamIndex + 1].Name}, 0)");
+        }
+        else if (outParam.IsPtrToStruct || outParam.IsPtrToHandle(mr))
+        {
+            sb.AppendLine($"        {outParam.Name} := {outParam.FieldInfo.UnderlyingType?.TypeName}()");
+        }
+    }
+
+    private protected void AppendReturnStatement(StringBuilder sb)
     {
         // The function returns an HRESULT and we should check to see if we need to throw
-        if (ShouldThrowForReturnValue())
+        if (ShouldThrowForReturnValue() && this is not AhkComMethod)
         {
             sb.AppendLine($"        if(result != 0)");
             sb.AppendLine($"            throw OSError(result)");
             sb.AppendLine();
         }
 
-        // We need to wrap handles and decide ownership & validity
-        if (returnValue.IsHandle(mr))
+        if (!FuncHasReturnValue && outputParameter is null)
         {
-            TypeDefinition returnValueType = returnValue.FieldInfo.TypeDef ?? throw new NullReferenceException();
+            return;
+        }
 
-            if (returnValue.HasIgnoreIfReturn)
+        AhkParameter fnRetVal = outputParameter ?? parameters[0];
+
+        // We need to wrap handles and decide ownership & validity
+        if (fnRetVal.IsHandle(mr))
+        {
+            TypeDefinition returnValueType = fnRetVal.FieldInfo.TypeDef ?? throw new NullReferenceException();
+
+            if (fnRetVal.HasIgnoreIfReturn)
             {
                 var conditions = CustomAttributeDecoder.DecodeAll(mr, returnValueType)
                     .Where(attr => attr.Name == "IgnoreIfReturnAttribute")
                     .Select(info => info.Attr.FixedArguments[0].Value)
-                    .Select(v => $"result == {(long)(v ?? throw new NullReferenceException())}");
+                    .Select(v => $"{fnRetVal.Name} == {(long)(v ?? throw new NullReferenceException())}");
                 string orStatement = string.Join(" || ", conditions);
 
                 sb.AppendLine($"        if({orStatement})");
-                sb.AppendLine($"            return {returnValue.Name}.Invalid()");
+                sb.AppendLine($"            return {fnRetVal.Name}.Invalid()");
                 sb.AppendLine();
             }
 
             string fieldName = mr.GetString(mr.GetFieldDefinition(returnValueType.GetFields().First()).Name);
-            sb.AppendLine($"        return {returnValue.GetTypeDefName(mr)}({{{fieldName}: result}}, {returnValue.ScriptOwned})");
+            sb.AppendLine($"        return {fnRetVal.GetTypeDefName(mr)}({{{fieldName}: {fnRetVal.Name}}}, {fnRetVal.ScriptOwned})");
+        }
+        else if (fnRetVal.IsPtrToCom)
+        {
+            sb.AppendLine($"        return {fnRetVal.FieldInfo.UnderlyingType?.TypeName}({fnRetVal.Name})");
         }
         else
         {
-            sb.AppendLine("        return result");
+            sb.AppendLine($"        return {fnRetVal.Name}");
         }
     }
 
@@ -163,7 +216,7 @@ class AhkMethod
     {
         StringBuilder conversions = new();
 
-        foreach (AhkParameter param in parameters[1..])
+        foreach (AhkParameter param in parameters[1..].Where(p => !p.Reserved && p != outputParameter))
         {
             string? typeName = param.GetTypeDefName(mr);
 
@@ -184,7 +237,7 @@ class AhkMethod
     {
         StringBuilder code = new();
 
-        foreach (AhkParameter param in parameters[1..].Where(p => !p.Reserved))
+        foreach (AhkParameter param in parameters[1..].Where(p => !p.Reserved && p != outputParameter))
         {
             // Allow pointers to primitives to be either VarRefs or raw pointers. If we only use asterisk marshalling, it's
             // impossible to ever pass null to a method, and users may want to pass pointers to e.g. buffers
@@ -197,6 +250,27 @@ class AhkMethod
         }
 
         return code;
+    }
+
+    private protected virtual AhkParameter? GetOutputParameter()
+    {
+        // If we have PreserveSig OR the function doesn't return an HRESULT, don't collapse
+        // [out] parameters
+        if(PreserveSig || CanReturnErrorsAsSuccess || !parameters[0].IsHRESULT)
+        {
+            return null;
+        }
+
+        AhkParameter outParam = default;
+        IEnumerable<AhkParameter> candidateParams = parameters
+            .Where(p => p.IsOutParam && !p.IsInParam)
+            .Where(p => p.IsPtrToPrimitive || p.IsPtrToHandle(mr) || p.IsPtrToCom);     // Only consider scalar, handle, and com output pointers
+        if (candidateParams.Count() == 1)
+        {
+            outParam = candidateParams.Single();
+        }
+
+        return (outParam == default) ? null : outParam;
     }
 
     /// <summary>
@@ -219,9 +293,24 @@ class AhkMethod
         }
 
         // If the return type is a handle, we need to import the handle
-        if (HasReturnValue && parameters[0].IsHandle(mr))
+        if (FuncHasReturnValue && parameters[0].IsHandle(mr))
         {
-            referencedTypes.Add(AhkStruct.GetFqn(mr, parameters[0].FieldInfo.TypeDef ?? throw new NullReferenceException()));
+            referencedTypes.Add(AhkType.GetFqn(mr, parameters[0].FieldInfo.TypeDef 
+                ?? throw new NullReferenceException()));
+        }
+
+        // If we have an output parameter, import its type if it's in the Win32Metadata
+        if(outputParameter != null)
+        {
+            FieldInfo? underlying = outputParameter?.FieldInfo.UnderlyingType;
+            bool mustImport = underlying?.Kind is SimpleFieldKind.Struct or SimpleFieldKind.COM;
+
+            if(mustImport && (underlying?.Reader == null || underlying?.Reader == mr))
+            {
+                TypeDefinition? td = underlying?.TypeDef;
+                if(td.HasValue)
+                    referencedTypes.Add(AhkType.GetFqn(mr, td.Value));
+            }
         }
 
         return referencedTypes;
@@ -234,7 +323,7 @@ class AhkMethod
     private protected virtual string BuildDllCallCall(string entry)
     {
         StringBuilder sb = new();
-        if (HasReturnValue)
+        if (FuncHasReturnValue)
             sb.Append("result := ");
 
         sb.Append($"DllCall({entry}");
@@ -246,7 +335,7 @@ class AhkMethod
         }
 
         // Calling convention / return type
-        if (CallingConvention == MethodImportAttributes.CallingConventionCDecl || HasReturnValue)
+        if (CallingConvention == MethodImportAttributes.CallingConventionCDecl || FuncHasReturnValue)
         {
             sb.Append(", \"");
             if (CallingConvention == MethodImportAttributes.CallingConventionCDecl)
@@ -254,8 +343,8 @@ class AhkMethod
                 sb.Append("CDecl ");
             }
 
-            if (HasReturnValue)
-                sb.Append(parameters[0].FieldInfo.GetDllCallType(false));
+            if (FuncHasReturnValue)
+                sb.Append(parameters[0].FieldInfo.GetDllCallType(true));
 
             sb.Append('"');
         }
@@ -268,6 +357,7 @@ class AhkMethod
         return string.Join(", ", parameters
             .Slice(1, parameters.Count - 1)                 // Skip param 0, the return value
             .Where(p => !p.Reserved)   // Skip reserved params and explicit return values
+            .Where(p => p != outputParameter)
             .Select(p => p.Name)
         );
     }
@@ -284,11 +374,12 @@ class AhkMethod
             bool isString = param.FieldInfo.TypeDef.HasValue && mr.GetString(param.FieldInfo.TypeDef.Value.Name) is "PWSTR" or "PSTR";
             string dllCallType = isString ? "ptr" : param.FieldInfo.GetDllCallType(false);
 
-            string marshalAs = (param.IsPtrToPrimitive && !param.Reserved) ? $"{param.Name}Marshal" : $"\"{dllCallType}\"";
+            string marshalAs = (param.IsPtrToPrimitive && !param.Reserved && param != outputParameter) ? $"{param.Name}Marshal" : $"\"{dllCallType}\"";
+            string passAs = (param == outputParameter && (param.IsPtrToPrimitive || param.IsPtrToCom)) ? $"&{param.Name} := 0" : param.Name;
 
             argList.Append(marshalAs);
             argList.Append(", ");
-            argList.Append(param.Name);
+            argList.Append(passAs);
 
             // TODO default value, optional values
 
@@ -314,7 +405,7 @@ class AhkMethod
         {
             AhkParameter param = parameters[i];
 
-            if (param.Reserved)
+            if (param.Reserved || param == outputParameter)
                 continue;
 
             sb.Append($"     * @param {{{param.FieldInfo.AhkType}}} {param.Name} ");
@@ -325,9 +416,23 @@ class AhkMethod
             sb.AppendLine();
         }
 
-        if (HasReturnValue)
+        if (FuncHasReturnValue || outputParameter != null)
         {
-            sb.AppendLine($"     * @returns {{{parameters[0].FieldInfo.AhkType}}} {AhkType.EscapeDocs(apiDetails?.ReturnValue, "    ")}");
+            if (outputParameter != null)
+            {
+                AhkParameter param = outputParameter.Value;
+                string? actualValueName = param.IsPtr ? param.FieldInfo.UnderlyingType?.AhkType : param.FieldInfo.AhkType;
+                sb.Append($"     * @returns {{{actualValueName}}} ");
+                if (apiDetails?.Parameters.TryGetValue(param.Name, out string? docString) ?? false)
+                {
+                    sb.Append(AhkType.EscapeDocs(docString, "    "));
+                }
+                sb.AppendLine();
+            }
+            else
+            {
+                sb.AppendLine($"     * @returns {{{parameters[0].FieldInfo.AhkType}}} {AhkType.EscapeDocs(apiDetails?.ReturnValue, "    ")}");
+            }
         }
         else
         {

--- a/Generator/model/AhkParameter.cs
+++ b/Generator/model/AhkParameter.cs
@@ -59,7 +59,22 @@ public readonly record struct AhkParameter
     public bool IsClass => FieldInfo.Kind == SimpleFieldKind.Class;
     public bool IsOther => FieldInfo.Kind == SimpleFieldKind.Other;
 
-    public bool IsPtrToPrimitive => IsPtr && (FieldInfo.UnderlyingType?.Kind is SimpleFieldKind.Primitive or SimpleFieldKind.Pointer);
+    public bool IsPtrToPrimitive => IsPtr && (FieldInfo.UnderlyingType?.Kind is SimpleFieldKind.Primitive or SimpleFieldKind.Pointer or SimpleFieldKind.NativeTypedef or SimpleFieldKind.HRESULT);
+
+    public bool IsPtrToCom => IsPtr && (FieldInfo.UnderlyingType?.Kind is SimpleFieldKind.COM);
+
+    public bool IsPtrToNativeTypedef => IsPtr && (FieldInfo.UnderlyingType?.Kind is SimpleFieldKind.NativeTypedef);
+    public bool IsPtrToStruct => IsPtr && (FieldInfo.UnderlyingType?.Kind is SimpleFieldKind.Struct);
+
+    public bool IsPtrToString => IsPtr && (FieldInfo.UnderlyingType?.Kind is SimpleFieldKind.String);
+
+    public bool IsPtrToHandle(MetadataReader mr)
+    {
+        if (!IsPtr || FieldInfo.UnderlyingType?.TypeDef == null)
+            return false;
+
+        return AhkStruct.IsHandle(mr, FieldInfo.UnderlyingType?.TypeDef ?? throw new NullReferenceException());
+    }
 
     public bool IsHandle(MetadataReader mr)
     {


### PR DESCRIPTION
Generated functions will allocate the logical return value if one of the following conditions are met:
	1. The parameter has a [RetVal] attribute (Com methods only)
	2. There is exactly one [out] parameter, AND... 2.1. It is a scalar value OR 2.2. It is a handle value Com interfaces will always allocate their output variables if they have them. This change primarilly affects Com interfaces, since most Win32 APIs do not have obvious return values.