### PR TITLE
Initial AHK v2.1 support

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "csharpier": {
+      "version": "1.2.6",
+      "commands": [
+        "csharpier"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.csharpierrc.yaml
+++ b/.csharpierrc.yaml
@@ -1,0 +1,1 @@
+printWidth: 120

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  csharpier:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x' # Use your project's version
+
+      - run: dotnet tool restore
+      - run: dotnet csharpier check .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      # Intentionally no `submodules: true` — the AhkWin32projection submodule is managed
+      # separately (SSH) by the generation workflows and is not needed to build/test the generator.
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Run unit tests
+        run: dotnet test Generator.Tests/AhkWin32Structs.Tests.csproj -c Release

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 Generator/bin/*
 Generator/obj/Debug/*
 Generator/obj/*
+
+Generator.Tests/bin/*
+Generator.Tests/obj/*
+Generator.Tests/TestResults/*

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "csharpier.csharpier-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,9 @@
 {
     "dotnet.defaultSolution": "AhkWin32Structs.sln",
-    "git.ignoreLimitWarning": true
+    "git.ignoreLimitWarning": true,
+    "[csharp]": {
+        "editor.defaultFormatter": "csharpier.csharpier-vscode",
+        "editor.formatOnSave": true
+    },
+    "csharpier.enableFormatOnSave": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "dotnet.defaultSolution": "AhkWin32Structs.sln"
+    "dotnet.defaultSolution": "AhkWin32Structs.sln",
+    "git.ignoreLimitWarning": true
 }

--- a/AhkWin32Structs.sln
+++ b/AhkWin32Structs.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AhkWin32Structs", "Generator\AhkWin32Structs.csproj", "{ED90BAEA-FFE5-42D7-8F45-9012FD8E7A0A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AhkWin32Structs.Tests", "Generator.Tests\AhkWin32Structs.Tests.csproj", "{B7E2A1C4-5D3F-4E8A-9C6B-1F0A2D3E4B5C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,18 @@ Global
 		{ED90BAEA-FFE5-42D7-8F45-9012FD8E7A0A}.Release|x64.Build.0 = Release|Any CPU
 		{ED90BAEA-FFE5-42D7-8F45-9012FD8E7A0A}.Release|x86.ActiveCfg = Release|Any CPU
 		{ED90BAEA-FFE5-42D7-8F45-9012FD8E7A0A}.Release|x86.Build.0 = Release|Any CPU
+		{B7E2A1C4-5D3F-4E8A-9C6B-1F0A2D3E4B5C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B7E2A1C4-5D3F-4E8A-9C6B-1F0A2D3E4B5C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B7E2A1C4-5D3F-4E8A-9C6B-1F0A2D3E4B5C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B7E2A1C4-5D3F-4E8A-9C6B-1F0A2D3E4B5C}.Debug|x64.Build.0 = Debug|Any CPU
+		{B7E2A1C4-5D3F-4E8A-9C6B-1F0A2D3E4B5C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B7E2A1C4-5D3F-4E8A-9C6B-1F0A2D3E4B5C}.Debug|x86.Build.0 = Debug|Any CPU
+		{B7E2A1C4-5D3F-4E8A-9C6B-1F0A2D3E4B5C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B7E2A1C4-5D3F-4E8A-9C6B-1F0A2D3E4B5C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B7E2A1C4-5D3F-4E8A-9C6B-1F0A2D3E4B5C}.Release|x64.ActiveCfg = Release|Any CPU
+		{B7E2A1C4-5D3F-4E8A-9C6B-1F0A2D3E4B5C}.Release|x64.Build.0 = Release|Any CPU
+		{B7E2A1C4-5D3F-4E8A-9C6B-1F0A2D3E4B5C}.Release|x86.ActiveCfg = Release|Any CPU
+		{B7E2A1C4-5D3F-4E8A-9C6B-1F0A2D3E4B5C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,8 +59,11 @@ Applies modifications to the IR before code generation. Transforms run in order:
 
 1. **Overrides** — YAML-driven one-off corrections (skip types, mark parameters as reserved, set struct-size fields, clone methods between API types). See [Overrides](#overrides).
 2. **Extensions** — YAML-driven code injection (add helper methods, properties, or custom constructors to generated types). See [Extensions](#extensions).
+3. **Cyclic Reference Breaking** - the generator builds the load-time struct dependency graph (value-embed = hard edges, pointer-to-struct = soft edges), runs iterative [Tarjan SCC], and marks every pointer field whose pointee sits in the same non-trivial cluster. We use this graph to break cyclic references during emission which would otherwise prevent the interpreter from loading affected modules.
 
-Both are configured via files in the metadata directory and are applied by mutating the `TypeRegistry` in place. This is the integration point for any manual configuration. Note that reserved name deconfliction happens during *extraction*.
+Overrides and Extensions are configured via files in the metadata directory and are applied by mutating the `TypeRegistry` in place. This is the integration point for any manual configuration. Note that reserved name deconfliction happens during *extraction*.
+
+[Tarjan SCC]: https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
 
 #### Emit
 Walks the `TypeRegistry` and generates `.ahk` files. Each type kind has a dedicated emitter (`EnumEmitter`, `StructEmitter`, `HandleEmitter`, `ApiTypeEmitter`, `ComInterfaceEmitter`). Emission is split into two sub-phases for performance: first, all types are emitted to in-memory strings in parallel; then, files are written to disk with parallel I/O. A `version.ini` file is also written with assembly and package version information, in case consumers want it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,6 +236,7 @@ Each file is a YAML list of type-scoped entries. The `type` key is always requir
 | `methods.<name>.skip` | method | `true` to remove a single method from an `Apis` type. |
 | `methods.<name>.parameters.<name>.add-attributes` | parameter | List of `ParameterFlags` to add (e.g., `Reserved`). |
 | `add-methods` | type (Apis) | List of `{from, name}` entries that clone a method from another `Apis` type into this one. Useful when a function logically belongs in multiple namespaces. |
+| `value-accessor` | type (native typedef or handle) | Customizes the generated `__value` accessor. `getter` is an AHK expression that restores a `__value` getter (omit to keep the default no-getter behavior that preserves type identity); `setter-coerce` is an AHK expression applied to a raw incoming value in the setter's else branch. Aliases: `$field` -> `this.<backingField>`, `$value` -> the setter's `value`. The instance-unwrap branch and `[AlsoUsableFor]` checks are emitted unchanged. **v2.1 emission only** (native typedefs are v2.1-only; v2.0 handles are class-based with no `__value`, so the keys are inert there). |
 
 <details>
 
@@ -277,6 +278,39 @@ Each file is a YAML list of type-scoped entries. The `type` key is always requir
 - type: Windows.Win32.UI.WindowsAndMessaging.SOME_STRUCT
   struct-size-field: lStructSize
 ```
+
+</details>
+
+<details>
+
+<summary><b>Example: make BOOL read and write like a boolean</b></summary>
+
+```yaml
+# BOOL is a 4-byte integer; normalize it to 0/1 on read and write.
+- type: Windows.Win32.Foundation.BOOL
+  value-accessor:
+    getter: "!!$field"            # get => !!this.value
+    setter-coerce: "!!$value"     # else branch: this.value := !!value
+```
+
+This emits:
+
+```ahk
+__value {
+    get => !!this.value
+    set {
+        if (value is BOOL)
+            this.value := value.value
+        else
+            this.value := !!value
+    }
+}
+```
+
+A `getter` that changes the read *type* (e.g. a scalar `CHAR` with `Chr($field)` would read back a
+string) also changes what DllCall marshals when the instance is passed by value — so prefer
+`setter-coerce` alone for character types and reserve `getter` for integer-valued types like `BOOL`
+and `VARIANT_BOOL`.
 
 </details>
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,11 +117,15 @@ Extensions are defined in [YAML](https://yaml.org/) files. The generator will re
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| `add-to` | sequence | The fully qualified names of all types to which code must be added
-| `requires` | sequence | The fully qualified names of all types which must be included in generated files for the extension to work. This should include all types required by your extension, even if the types it extends already include them, as this may change in the future. The generator will not produce duplicate `#Include` statements. <br><br>To indicate that *nothing* needs to be imported, specify an empty sequence: `[]` or omit the key.
-| `code` | string | The actual code to add to the class. Oftentimes this can be written directly into the relevant file and copy/pasted into extension YAML without modification. This code is added to the end of the files specified in `add-to` without modification. <br><br> See [yaml multiline strings](https://yaml-multiline.info/) for details on the syntax, or just use the pipe (`\|`) and don't worry about it. 
+| `add-to` | sequence | The fully qualified names of all types to which code must be added.
+| `imports` | mapping | FQN-keyed map of types/functions the extension references. A `null` or empty value means "whole-file include" (the same effect as the old `requires:` list). A non-empty list of names means "import those specific functions from this `Apis` container"; in v2.1 this emits `#Import "..." { Name1, Name2 }` merged with whatever imports the type already needed, and in v2.0 it falls back to a whole-file include of the `Apis` file. Omit the key entirely if no extra imports are needed.
+| `code` | mapping | A map with required keys `v20` and `v21`. The value for each is either a string of AHK code or the literal `skip` to opt out for that target version. At least one version must be a real code block. <br><br> When v2.0 and v2.1 share the same body, use a YAML anchor: `v20: &shared \|\n  ...\nv21: *shared`. <br><br> See [yaml multiline strings](https://yaml-multiline.info/) for details on the syntax, or just use the pipe (`\|`) and don't worry about it.
 
 A single extension file can only include one extension definition, and said definition can apply to as many types as you want. Note it is not currently possible to extend existing methods like `__New`, though you can add such methods to types that don't already have them.
+
+##### Why per-version `code:`
+
+In v2.0 a free function from another namespace is reached through its `Apis` class — `Foundation.SysStringLen(this)`. In v2.1 the same function is `#Import`ed by name and called bare — `SysStringLen(this)`. Both emitters run against the same extension definition, so the body has to be supplied per target version. If the two bodies are textually identical (because the extension only touches the type's own members or builtins), the YAML anchor pattern lets you write the body once.
 
 <details>
 
@@ -130,20 +134,21 @@ A single extension file can only include one extension definition, and said defi
 ```yaml
 add-to:
   - Windows.Win32.Foundation.BSTR
-requires:
-  - Windows.Win32.Foundation.Apis
-code: |
+
+imports:
+  Windows.Win32.Foundation.Apis:
+    - SysStringLen
+    - SysStringByteLen
+    - SysAllocString
+    - SysReallocString
+
+code:
+  v20: |
     /**
      * @readonly The length of the allocated string in characters, not including the null terminator
      * @type {Integer}
      */
     length => Foundation.SysStringLen(this)
-
-    /**
-     * @readonly The length of the allocated string in bytes, not including the null terminator
-     * @type {Integer}
-     */
-    byteLength => Foundation.SysStringByteLen(this)
 
     /**
      * Creates a new BSTR from an existing AHK string
@@ -153,29 +158,58 @@ code: |
         return Foundation.SysAllocString(str)
     }
 
-    /**
-     * Changes the contents of the BSTR, resizing it if necessary
-     * @param {String} str the new contents of the BSTR
-     */
-    ReAlloc(str){
-        result := Foundation.SysReallocString(this, str)
-        if(result == 0)
-            throw MemoryError("Not enough memory to reallocate string")
+    ; ... etc.
+  v21: |
+    length => SysStringLen(this)
+
+    static Alloc(str){
+        return SysAllocString(str)
     }
 
-    /**
-     * Gets the value of the BSTR as a native AHK string
-     * @returns {String}
-     */
-    ToString(){
-        return StrGet(this.value, this.length, "UTF-16")
+    ; ... etc.
+```
+
+</details>
+
+<details>
+
+<summary><b>Example: shared body via YAML anchor (no cross-namespace calls)</b></summary>
+
+```yaml
+add-to:
+  - Windows.Win32.Foundation.POINT
+  - Windows.Win32.Foundation.POINTL
+
+code:
+  v20: &shared |
+    Value => NumGet(this, "uint64")
+
+    ToString() {
+        return Format("({1}, {2})", this.x, this.y)
     }
+  v21: *shared
+```
+
+</details>
+
+<details>
+
+<summary><b>Example: opting out of one version</b></summary>
+
+```yaml
+add-to:
+  - Windows.Win32.Some.Type
+
+code:
+  v20: |
+    ; ... v2.0-only helper
+  v21: skip
 ```
 
 </details>
 
 #### Aliases
-The generator suports the following aliases, using the `$Name` convention (like bash or PowerShell - this is because `%%` is valid AHK syntax and would make parsing a nightmare). All aliases are case-sensitive.
+The generator suports the following aliases, using the `$Name` convention (like bash or PowerShell - this is because `%name%` is valid AHK syntax and would make parsing a nightmare). All aliases are case-sensitive.
 
 
 Alias | Scope | Description

--- a/Generator.Tests/AhkWin32Structs.Tests.csproj
+++ b/Generator.Tests/AhkWin32Structs.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Generator\AhkWin32Structs.csproj" />
+  </ItemGroup>
+</Project>

--- a/Generator.Tests/CyclicPointerBreakerTests.cs
+++ b/Generator.Tests/CyclicPointerBreakerTests.cs
@@ -1,0 +1,174 @@
+namespace AhkWin32.Generator.Tests;
+
+using AhkWin32.Generator.Model;
+using AhkWin32.Generator.Model.Members;
+using AhkWin32.Generator.Model.Types;
+using AhkWin32.Generator.Tests.Support;
+using AhkWin32.Generator.Transform;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public sealed class CyclicPointerBreakerTests
+{
+    private static CyclicPointerBreaker Breaker(ILogger<CyclicPointerBreaker>? logger = null) =>
+        new(logger ?? NullLogger<CyclicPointerBreaker>.Instance);
+
+    private static FieldMember FieldOf(StructType s, string name) =>
+        s.Members.First(f => f.Name.Equals(name, StringComparison.Ordinal));
+
+    [TestMethod]
+    public void NoSoftEdges_NothingMarked()
+    {
+        // A embeds B by value (hard edge), B is a leaf. No pointer-to-struct fields anywhere,
+        // so the pass should early-return without marking anything.
+        var a = Ir.Struct("Test.A", Ir.Field("b", Ir.StructRefTo("Test.B")));
+        var b = Ir.Struct("Test.B", Ir.Field("value", Ir.Prim("Int32")));
+
+        var registry = new TypeRegistry();
+        registry.Register(a);
+        registry.Register(b);
+
+        Breaker().Apply(registry);
+
+        Assert.IsFalse(FieldOf(a, "b").EmitAsLazyPointer);
+    }
+
+    [TestMethod]
+    public void PointerPlusValueEmbedCycle_MarksOnlyPointer()
+    {
+        // A --*--> B and B --value--> A. The pointer side is the cuttable edge.
+        var a = Ir.Struct("Test.A", Ir.Field("pB", Ir.Ptr(Ir.StructRefTo("Test.B"))));
+        var b = Ir.Struct("Test.B", Ir.Field("a", Ir.StructRefTo("Test.A")));
+
+        var registry = new TypeRegistry();
+        registry.Register(a);
+        registry.Register(b);
+
+        Breaker().Apply(registry);
+
+        Assert.IsTrue(FieldOf(a, "pB").EmitAsLazyPointer, "pointer-on-cycle should be marked lazy");
+        Assert.IsFalse(FieldOf(b, "a").EmitAsLazyPointer, "value-embedded field is not a cuttable edge");
+    }
+
+    [TestMethod]
+    public void MutualPointerCycle_MarksBothPointers()
+    {
+        var a = Ir.Struct("Test.A", Ir.Field("pB", Ir.Ptr(Ir.StructRefTo("Test.B"))));
+        var b = Ir.Struct("Test.B", Ir.Field("pA", Ir.Ptr(Ir.StructRefTo("Test.A"))));
+
+        var registry = new TypeRegistry();
+        registry.Register(a);
+        registry.Register(b);
+
+        Breaker().Apply(registry);
+
+        Assert.IsTrue(FieldOf(a, "pB").EmitAsLazyPointer);
+        Assert.IsTrue(FieldOf(b, "pA").EmitAsLazyPointer);
+    }
+
+    [TestMethod]
+    public void SelfPointer_NotMarked()
+    {
+        // A pointer to one's own struct is a forward reference, not a load-time cycle — and a
+        // self-edge never forms a non-trivial SCC, so it must not be flagged.
+        var a = Ir.Struct("Test.A", Ir.Field("pSelf", Ir.Ptr(Ir.StructRefTo("Test.A"))));
+
+        var registry = new TypeRegistry();
+        registry.Register(a);
+
+        Breaker().Apply(registry);
+
+        Assert.IsFalse(FieldOf(a, "pSelf").EmitAsLazyPointer);
+    }
+
+    [TestMethod]
+    public void AcyclicPointerChain_NothingMarked()
+    {
+        // A --*--> B --*--> C, no back edge. Soft edges exist (so no early return) but no cycle.
+        var a = Ir.Struct("Test.A", Ir.Field("pB", Ir.Ptr(Ir.StructRefTo("Test.B"))));
+        var b = Ir.Struct("Test.B", Ir.Field("pC", Ir.Ptr(Ir.StructRefTo("Test.C"))));
+        var c = Ir.Struct("Test.C", Ir.Field("value", Ir.Prim("Int32")));
+
+        var registry = new TypeRegistry();
+        registry.Register(a);
+        registry.Register(b);
+        registry.Register(c);
+
+        Breaker().Apply(registry);
+
+        Assert.IsFalse(FieldOf(a, "pB").EmitAsLazyPointer);
+        Assert.IsFalse(FieldOf(b, "pC").EmitAsLazyPointer);
+    }
+
+    [TestMethod]
+    public void CycleThroughNestedEmbeddedStruct_MarksInnerPointer()
+    {
+        // A embeds an (unregistered, inlined) nested struct whose field points to B; B embeds A
+        // by value. The cuttable pointer lives inside the nested struct, so CollectEdges must
+        // recurse into EmbeddedStruct.Members to see it.
+        var inner = Ir.Struct("Test.A_Inner", Ir.Field("pB", Ir.Ptr(Ir.StructRefTo("Test.B"))));
+        var a = Ir.Struct("Test.A", Ir.EmbeddedField("inner", inner));
+        var b = Ir.Struct("Test.B", Ir.Field("a", Ir.StructRefTo("Test.A")));
+
+        var registry = new TypeRegistry();
+        registry.Register(a);
+        registry.Register(b);
+
+        Breaker().Apply(registry);
+
+        Assert.IsTrue(FieldOf(inner, "pB").EmitAsLazyPointer);
+    }
+
+    [TestMethod]
+    public void UnbreakableArrayPointerCycle_WarnsAndLeavesUnmarked()
+    {
+        // Cluster {A,B}: A holds an *array* of pointers to B (currently uncuttable), B embeds A
+        // by value. Cluster {C,D}: a normal scalar pointer cycle, present so that softEdges is
+        // non-empty and the pass runs to completion (and so WarnUnbrokenCycles executes).
+        var a = Ir.Struct("Test.A", Ir.Field("pBs", Ir.ArrayOf(Ir.Ptr(Ir.StructRefTo("Test.B")), 4)));
+        var b = Ir.Struct("Test.B", Ir.Field("a", Ir.StructRefTo("Test.A")));
+        var c = Ir.Struct("Test.C", Ir.Field("pD", Ir.Ptr(Ir.StructRefTo("Test.D"))));
+        var d = Ir.Struct("Test.D", Ir.Field("c", Ir.StructRefTo("Test.C")));
+
+        var registry = new TypeRegistry();
+        registry.Register(a);
+        registry.Register(b);
+        registry.Register(c);
+        registry.Register(d);
+
+        var logger = new ListLogger<CyclicPointerBreaker>();
+        Breaker(logger).Apply(registry);
+
+        Assert.IsFalse(FieldOf(a, "pBs").EmitAsLazyPointer, "array-of-pointer is not cut in v1");
+        Assert.IsTrue(FieldOf(c, "pD").EmitAsLazyPointer, "the scalar pointer cluster is still broken");
+        Assert.IsTrue(
+            logger.HasMessageAt(LogLevel.Warning, "no scalar pointer edge"),
+            "the uncuttable cluster should be surfaced as a warning"
+        );
+    }
+
+    [TestMethod]
+    public void SecondApply_IsIdempotent()
+    {
+        var a = Ir.Struct("Test.A", Ir.Field("pB", Ir.Ptr(Ir.StructRefTo("Test.B"))));
+        var b = Ir.Struct("Test.B", Ir.Field("a", Ir.StructRefTo("Test.A")));
+
+        var registry = new TypeRegistry();
+        registry.Register(a);
+        registry.Register(b);
+
+        Breaker().Apply(registry);
+        Assert.IsTrue(FieldOf(a, "pB").EmitAsLazyPointer);
+
+        var logger = new ListLogger<CyclicPointerBreaker>();
+        Breaker(logger).Apply(registry);
+
+        Assert.IsTrue(FieldOf(a, "pB").EmitAsLazyPointer, "the field stays marked");
+        Assert.IsTrue(
+            logger.HasMessageAt(LogLevel.Information, "Marked 0 pointer field(s)"),
+            "a re-run marks no additional fields"
+        );
+    }
+}

--- a/Generator.Tests/OverrideApplierTests.cs
+++ b/Generator.Tests/OverrideApplierTests.cs
@@ -1,0 +1,88 @@
+namespace AhkWin32.Generator.Tests;
+
+using AhkWin32.Generator.Model;
+using AhkWin32.Generator.Model.Types;
+using AhkWin32.Generator.Tests.Support;
+using AhkWin32.Generator.Transform;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public sealed class OverrideApplierTests
+{
+    private string _dir = null!;
+
+    [TestInitialize]
+    public void Init()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), $"overrides-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_dir);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_dir))
+            Directory.Delete(_dir, recursive: true);
+    }
+
+    private void WriteOverride(string yaml) => File.WriteAllText(Path.Combine(_dir, "test.yml"), yaml);
+
+    private OverrideApplier Applier(ILogger<OverrideApplier>? logger = null) =>
+        new(new OverrideReader(NullLogger<OverrideReader>.Instance), logger ?? NullLogger<OverrideApplier>.Instance);
+
+    [TestMethod]
+    public void SkipOverride_RemovesTypeFromRegistry()
+    {
+        var registry = new TypeRegistry();
+        registry.Register(Ir.Struct("Test.Gone", Ir.Field("value", Ir.Prim("Int32"))));
+
+        WriteOverride("- type: Test.Gone\n  skip: true\n");
+        Applier().Apply(registry, _dir);
+
+        Assert.IsFalse(registry.Contains("Test.Gone"));
+    }
+
+    [TestMethod]
+    public void FieldAddAttributes_OrsFlagsOntoMatchingField()
+    {
+        var s = Ir.Struct("Test.A", Ir.Field("dwFlags", Ir.Prim("UInt32")));
+        var registry = new TypeRegistry();
+        registry.Register(s);
+
+        WriteOverride("- type: Test.A\n  fields:\n    dwFlags:\n      add-attributes: [Reserved]\n");
+        Applier().Apply(registry, _dir);
+
+        Assert.IsTrue(s.Members[0].IsReserved, "the Reserved flag should be set on the field");
+    }
+
+    [TestMethod]
+    public void MethodSkip_RemovesMethodFromApiType()
+    {
+        var api = Ir.Api("Test.Apis", Ir.Method("KeepMe", "Test"), Ir.Method("DropMe", "Test"));
+        var registry = new TypeRegistry();
+        registry.Register(api);
+
+        WriteOverride("- type: Test.Apis\n  methods:\n    DropMe:\n      skip: true\n");
+        Applier().Apply(registry, _dir);
+
+        Assert.AreEqual(1, api.Methods.Count);
+        Assert.AreEqual("KeepMe", api.Methods[0].Name);
+    }
+
+    [TestMethod]
+    public void UnmatchedFqn_WarnsAndLeavesRegistryUnchanged()
+    {
+        var registry = new TypeRegistry();
+        registry.Register(Ir.Struct("Test.Present", Ir.Field("value", Ir.Prim("Int32"))));
+
+        WriteOverride("- type: Test.NotHere\n  struct-size-field: cbSize\n");
+        var logger = new ListLogger<OverrideApplier>();
+        Applier(logger).Apply(registry, _dir);
+
+        Assert.IsTrue(registry.Contains("Test.Present"));
+        Assert.AreEqual(1, registry.Count);
+        Assert.IsTrue(logger.HasMessageAt(LogLevel.Warning, "not in registry"));
+    }
+}

--- a/Generator.Tests/ReservedNameConfigTests.cs
+++ b/Generator.Tests/ReservedNameConfigTests.cs
@@ -1,0 +1,30 @@
+namespace AhkWin32.Generator.Tests;
+
+using AhkWin32.Generator.Transform;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public sealed class ReservedNameConfigTests
+{
+    [TestMethod]
+    public void Load_ReturnsCaseInsensitiveSet()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"reserved-{Guid.NewGuid():N}.yml");
+        File.WriteAllText(path, "- HWND\n- Buffer\n- type\n");
+
+        try
+        {
+            HashSet<string> names = ReservedNameConfig.Load(path);
+
+            Assert.AreEqual(3, names.Count);
+            Assert.IsTrue(names.Contains("HWND"));
+            Assert.IsTrue(names.Contains("hwnd"), "lookup must be case-insensitive");
+            Assert.IsTrue(names.Contains("BUFFER"));
+            Assert.IsFalse(names.Contains("NotReserved"));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/Generator.Tests/ResolvedTypeTests.cs
+++ b/Generator.Tests/ResolvedTypeTests.cs
@@ -1,0 +1,80 @@
+namespace AhkWin32.Generator.Tests;
+
+using AhkWin32.Generator.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public sealed class ResolvedTypeTests
+{
+    [DataTestMethod]
+    [DataRow("Int32", 4)]
+    [DataRow("UInt32", 4)]
+    [DataRow("Single", 4)]
+    [DataRow("Int64", 8)]
+    [DataRow("Double", 8)]
+    [DataRow("IntPtr", 8)]
+    [DataRow("Int16", 2)]
+    [DataRow("UInt16", 2)]
+    [DataRow("Byte", 1)]
+    [DataRow("SByte", 1)]
+    public void PrimitiveType_Width(string name, int expected)
+    {
+        Assert.AreEqual(expected, new PrimitiveType(name).Width);
+    }
+
+    [TestMethod]
+    public void PointerType_Width_IsPointerSized_RegardlessOfPointee()
+    {
+        Assert.AreEqual(8, new PointerType(null).Width);
+        Assert.AreEqual(8, new PointerType(new PrimitiveType("Byte")).Width);
+        Assert.AreEqual(8, new PointerType(new StructRef("Test.Big", "Big")).Width);
+    }
+
+    [TestMethod]
+    public void ArrayType_Width_IsLengthTimesElementWidth()
+    {
+        Assert.AreEqual(16, new ArrayType(new PrimitiveType("Byte"), 16).Width);
+        Assert.AreEqual(40, new ArrayType(new PrimitiveType("Int64"), 5).Width);
+    }
+
+    [TestMethod]
+    public void StructRef_Width_Throws()
+    {
+        var sr = new StructRef("Test.A", "A");
+        Assert.ThrowsException<InvalidOperationException>(() => _ = sr.Width);
+    }
+
+    [TestMethod]
+    public void PrimitiveType_Int32_Strings()
+    {
+        var p = new PrimitiveType("Int32");
+        Assert.AreEqual("Integer", p.DisplayName);
+        Assert.AreEqual("int", p.DllCallType);
+        Assert.AreEqual("Int32", p.TypeSpecifier);
+    }
+
+    [TestMethod]
+    public void PointerType_ToStruct_EmitsTypedPtrSpecifier()
+    {
+        var p = new PointerType(new StructRef("Test.Foo", "Foo"));
+        Assert.AreEqual("Pointer<Foo>", p.DisplayName);
+        Assert.AreEqual("ptr", p.DllCallType);
+        Assert.AreEqual("Foo.Ptr", p.TypeSpecifier);
+    }
+
+    [TestMethod]
+    public void PointerType_Opaque_FallsBackToIntPtr()
+    {
+        var p = new PointerType(null);
+        Assert.AreEqual("Pointer", p.DisplayName);
+        Assert.AreEqual("IntPtr", p.TypeSpecifier);
+    }
+
+    [TestMethod]
+    public void ArrayType_Specifier_IndexesElementSpecifier()
+    {
+        var a = new ArrayType(new PrimitiveType("Byte"), 16);
+        Assert.AreEqual("Int8[16]", a.TypeSpecifier);
+        Assert.AreEqual("Array<Integer>", a.DisplayName);
+    }
+}

--- a/Generator.Tests/Support/Ir.cs
+++ b/Generator.Tests/Support/Ir.cs
@@ -1,0 +1,119 @@
+namespace AhkWin32.Generator.Tests.Support;
+
+using AhkWin32.Generator.Model;
+using AhkWin32.Generator.Model.Members;
+using AhkWin32.Generator.Model.Types;
+
+/// <summary>
+/// Terse builders for the IR model types used in tests. The real Model types use
+/// <c>required init</c> properties, so constructing them inline is noisy; these helpers fill
+/// the boilerplate (identity, names, layout) and let a test express only what it cares about.
+/// </summary>
+internal static class Ir
+{
+    /// <summary>Build a <see cref="StructType"/> from an FQN and an ordered list of members.</summary>
+    public static StructType Struct(string fqn, params FieldMember[] members) => Struct(fqn, Architecture.All, members);
+
+    /// <summary>Build a <see cref="StructType"/> for a specific architecture variant.</summary>
+    public static StructType Struct(string fqn, Architecture arch, params FieldMember[] members)
+    {
+        string name = TailName(fqn);
+        return new StructType
+        {
+            Identity = new TypeIdentity(fqn, arch),
+            Name = name,
+            CanonicalName = name,
+            AssemblyName = "Test.Assembly",
+            MetadataVersion = "Test.Assembly v1.0.0",
+            Size = 0,
+            PackingSize = 0,
+            LayoutKind = StructLayoutKind.Sequential,
+            Members = members,
+            IsNested = false,
+        };
+    }
+
+    /// <summary>
+    /// Build a scalar <see cref="FieldMember"/> of the given resolved type. Size is left at 0 —
+    /// the transforms under test key off <see cref="FieldMember.Type"/>, not byte sizes, and some
+    /// resolved types (StructRef) deliberately throw on <c>Width</c>.
+    /// </summary>
+    public static FieldMember Field(string name, ResolvedType type) =>
+        new()
+        {
+            Name = name,
+            Offset = 0,
+            Size = 0,
+            Type = type,
+        };
+
+    /// <summary>
+    /// Build a field that embeds a (nested, unregistered) struct by value. Mirrors how the
+    /// extractor inlines anonymous/nested structs via <see cref="FieldMember.EmbeddedStruct"/>.
+    /// </summary>
+    public static FieldMember EmbeddedField(string name, StructType embedded) =>
+        new()
+        {
+            Name = name,
+            Offset = 0,
+            Size = 0,
+            Type = StructRefTo(embedded.FQN),
+            EmbeddedStruct = embedded,
+        };
+
+    /// <summary>An <see cref="ApiType"/> carrying the given methods (no constants).</summary>
+    public static ApiType Api(string fqn, params MethodMember[] methods)
+    {
+        string name = TailName(fqn);
+        return new ApiType
+        {
+            Identity = TypeIdentity.Universal(fqn),
+            Name = name,
+            CanonicalName = name,
+            AssemblyName = "Test.Assembly",
+            MetadataVersion = "Test.Assembly v1.0.0",
+            Constants = [],
+            Methods = [.. methods],
+        };
+    }
+
+    /// <summary>A minimal <see cref="MethodMember"/> with the given name and a single Void return slot.</summary>
+    public static MethodMember Method(string name, string ns, params ParameterMember[] parameters)
+    {
+        ParameterMember[] all =
+        [
+            new ParameterMember
+            {
+                Name = "returnValue",
+                Type = Prim("Void"),
+                SequenceNumber = 0,
+            },
+            .. parameters,
+        ];
+        return new MethodMember
+        {
+            Name = name,
+            Namespace = ns,
+            Parameters = all,
+        };
+    }
+
+    /// <summary>A method parameter (1-based sequence numbers are assigned by position here).</summary>
+    public static ParameterMember Param(string name, ResolvedType type, int sequence = 1) =>
+        new()
+        {
+            Name = name,
+            Type = type,
+            SequenceNumber = sequence,
+        };
+
+    public static PrimitiveType Prim(string name) => new(name);
+
+    public static PointerType Ptr(ResolvedType? pointee) => new(pointee);
+
+    public static StructRef StructRefTo(string fqn) => new(fqn, TailName(fqn));
+
+    public static ArrayType ArrayOf(ResolvedType element, int length) => new(element, length);
+
+    private static string TailName(string fqn) => fqn.Contains('.') ? fqn[(fqn.LastIndexOf('.') + 1)..] : fqn;
+}

--- a/Generator.Tests/Support/ListLogger.cs
+++ b/Generator.Tests/Support/ListLogger.cs
@@ -1,0 +1,40 @@
+namespace AhkWin32.Generator.Tests.Support;
+
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// A trivial <see cref="ILogger{T}"/> that captures every emitted entry so tests can assert on
+/// logged behavior (e.g. that <c>CyclicPointerBreaker</c> warns about an unbreakable cluster).
+/// </summary>
+internal sealed class ListLogger<T> : ILogger<T>
+{
+    public readonly record struct Entry(LogLevel Level, string Message);
+
+    public List<Entry> Entries { get; } = [];
+
+    public IEnumerable<string> MessagesAt(LogLevel level) =>
+        Entries.Where(e => e.Level == level).Select(e => e.Message);
+
+    public bool HasMessageAt(LogLevel level, string substring) =>
+        MessagesAt(level).Any(m => m.Contains(substring, StringComparison.Ordinal));
+
+    public IDisposable BeginScope<TState>(TState state)
+        where TState : notnull => NullScope.Instance;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter
+    ) => Entries.Add(new Entry(logLevel, formatter(state, exception)));
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+
+        public void Dispose() { }
+    }
+}

--- a/Generator.Tests/TypeRegistryTests.cs
+++ b/Generator.Tests/TypeRegistryTests.cs
@@ -1,0 +1,80 @@
+namespace AhkWin32.Generator.Tests;
+
+using AhkWin32.Generator.Model;
+using AhkWin32.Generator.Model.Types;
+using AhkWin32.Generator.Tests.Support;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public sealed class TypeRegistryTests
+{
+    [TestMethod]
+    public void Register_ThenResolve_RoundTrips()
+    {
+        var s = Ir.Struct("Test.A", Ir.Field("value", Ir.Prim("Int32")));
+        var registry = new TypeRegistry();
+        registry.Register(s);
+
+        Assert.AreSame(s, registry.Resolve("Test.A", Architecture.X64));
+        Assert.AreSame(s, registry.Resolve<StructType>("Test.A", Architecture.X64));
+        Assert.AreEqual(1, registry.Count);
+    }
+
+    [TestMethod]
+    public void ResolveGeneric_FiltersByType()
+    {
+        var s = Ir.Struct("Test.A", Ir.Field("value", Ir.Prim("Int32")));
+        var registry = new TypeRegistry();
+        registry.Register(s);
+
+        // No ApiType registered under this FQN, so the typed resolve returns null.
+        Assert.IsNull(registry.Resolve<ApiType>("Test.A", Architecture.X64));
+    }
+
+    [TestMethod]
+    public void ArchitectureVariants_CoexistAndResolveIndependently()
+    {
+        var x64 = Ir.Struct("Test.A", Architecture.X64, Ir.Field("p", Ir.Prim("IntPtr")));
+        var x86 = Ir.Struct("Test.A", Architecture.X86, Ir.Field("p", Ir.Prim("Int32")));
+
+        var registry = new TypeRegistry();
+        registry.Register(x64);
+        registry.Register(x86);
+
+        Assert.AreEqual(2, registry.Count, "the two arch variants are distinct entries");
+        Assert.AreEqual(2, registry.GetAllVariants("Test.A").Count);
+        Assert.AreSame(x64, registry.Resolve("Test.A", Architecture.X64));
+        Assert.AreSame(x86, registry.Resolve("Test.A", Architecture.X86));
+    }
+
+    [TestMethod]
+    public void Remove_ReturnsVariantCount_AndDropsAllVariants()
+    {
+        var x64 = Ir.Struct("Test.A", Architecture.X64, Ir.Field("p", Ir.Prim("IntPtr")));
+        var x86 = Ir.Struct("Test.A", Architecture.X86, Ir.Field("p", Ir.Prim("Int32")));
+
+        var registry = new TypeRegistry();
+        registry.Register(x64);
+        registry.Register(x86);
+
+        int removed = registry.Remove("Test.A");
+
+        Assert.AreEqual(2, removed);
+        Assert.IsFalse(registry.Contains("Test.A"));
+        Assert.AreEqual(0, registry.Count);
+        Assert.AreEqual(0, registry.Remove("Test.A"), "removing an absent type removes nothing");
+    }
+
+    [TestMethod]
+    public void Contains_DiscriminatesByPresenceAndKind()
+    {
+        var s = Ir.Struct("Test.A", Ir.Field("value", Ir.Prim("Int32")));
+        var registry = new TypeRegistry();
+        registry.Register(s);
+
+        Assert.IsTrue(registry.Contains("Test.A"));
+        Assert.IsTrue(registry.Contains<StructType>("Test.A"));
+        Assert.IsFalse(registry.Contains<ApiType>("Test.A"));
+        Assert.IsFalse(registry.Contains("Test.Missing"));
+    }
+}

--- a/Generator/AhkWin32Structs.csproj
+++ b/Generator/AhkWin32Structs.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>

--- a/Generator/AhkWin32Structs.csproj
+++ b/Generator/AhkWin32Structs.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="Microsoft.Windows.SDK.Win32Docs" Version="0.1.42-alpha" />
     <PackageReference Include="Microsoft.Windows.SDK.Win32Metadata" Version="64.0.22-preview" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageReference Include="TrieNet" Version="1.0.3.26316" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 </Project>

--- a/Generator/AhkWin32Structs.csproj
+++ b/Generator/AhkWin32Structs.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="ConcurrentHashSet" Version="1.3.0" />
-    <PackageReference Include="MessagePack" Version="3.1.4" />
+    <PackageReference Include="MessagePack" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
     <PackageReference Include="Microsoft.Windows.SDK.Win32Docs" Version="0.1.42-alpha" />

--- a/Generator/AhkWin32Structs.csproj
+++ b/Generator/AhkWin32Structs.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ConcurrentHashSet" Version="1.3.0" />
     <PackageReference Include="MessagePack" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />

--- a/Generator/Emit/AhkWriter.cs
+++ b/Generator/Emit/AhkWriter.cs
@@ -1,7 +1,6 @@
 namespace AhkWin32.Generator.Emit;
 
 using AhkWin32.Generator.Metadata;
-
 using System.Text;
 
 /// <summary>
@@ -34,12 +33,27 @@ public sealed class AhkWriter(AhkVersion version = AhkVersion.v20)
         _sb.Append($"#Import \"{path}\"");
         if (names.Any())
         {
-            _sb.Append($" {{{string.Join(", ", names)}}}");
+            _sb.Append($" {{ {string.Join(", ", names)} }}");
         }
         _sb.AppendLine();
     }
 
     public void Import(string path) => Import(path, []);
+
+    /// <summary>
+    /// Write an #Import directive using a path-qualified name and an alias
+    /// </summary>
+    public void ImportAs(string path, string alias, IEnumerable<string> names)
+    {
+        _sb.Append($"#Import \"{path}\", as {alias}");
+        if (names.Any())
+        {
+            _sb.Append($" {{ {string.Join(", ", names)} }}");
+        }
+        _sb.AppendLine();
+    }
+
+    public void ImportAs(string path, string alias) => ImportAs(path, alias, []);
 
     /// <summary>
     /// Write an #Import export directive using a path-qualified name - https://www.autohotkey.com/docs/alpha/lib/_Import.htm.

--- a/Generator/Emit/AhkWriter.cs
+++ b/Generator/Emit/AhkWriter.cs
@@ -207,6 +207,41 @@ public sealed class AhkWriter(AhkVersion version = AhkVersion.v20)
         return new IndentScope(this);
     }
 
+    /// <summary>
+    /// Open an if statement - these always use braces: "if (condition) {"
+    /// </summary>
+    /// <param name="condition">AHK code for the condition to evaluate</param>
+    /// <returns></returns>
+    public IndentScope If(string condition)
+    {
+        _sb.AppendLine($"{Indent}if ({condition}) {{");
+        _indentLevel++;
+        return new IndentScope(this);
+    }
+
+    /// <summary>
+    /// Open an else statement: "else {"
+    /// </summary>
+    /// <returns></returns>
+    public IndentScope Else()
+    {
+        _sb.AppendLine($"{Indent}else {{");
+        _indentLevel++;
+        return new IndentScope(this);
+    }
+
+    /// <summary>
+    /// Open an else-if statement: "else if (condition) {"
+    /// </summary>
+    /// <param name="condition">Condition(s) to evaluate</param>
+    /// <returns></returns>
+    public IndentScope ElseIf(string condition)
+    {
+        _sb.AppendLine($"{Indent}else if (${condition}) {{");
+        _indentLevel++;
+        return new IndentScope(this);
+    }
+
     // --- Content ---
 
     /// <summary>Write a static fat-arrow field: "static NAME => expr".</summary>

--- a/Generator/Emit/AhkWriter.cs
+++ b/Generator/Emit/AhkWriter.cs
@@ -208,6 +208,16 @@ public sealed class AhkWriter(AhkVersion version = AhkVersion.v20)
     }
 
     /// <summary>
+    /// Open a setter block: "set {".
+    /// </summary>
+    public IndentScope SetBlock()
+    {
+        _sb.AppendLine($"{Indent}set {{");
+        _indentLevel++;
+        return new IndentScope(this);
+    }
+
+    /// <summary>
     /// Open an if statement - these always use braces: "if (condition) {"
     /// </summary>
     /// <param name="condition">AHK code for the condition to evaluate</param>

--- a/Generator/Emit/AhkWriter.cs
+++ b/Generator/Emit/AhkWriter.cs
@@ -1,7 +1,7 @@
 namespace AhkWin32.Generator.Emit;
 
-using AhkWin32.Generator.Metadata;
 using System.Text;
+using AhkWin32.Generator.Metadata;
 
 /// <summary>
 /// Indentation-aware text writer for generating AutoHotkey v2 source files.
@@ -25,7 +25,7 @@ public sealed class AhkWriter(AhkVersion version = AhkVersion.v20)
     public void Include(string path) => _sb.AppendLine($"#Include {path}");
 
     /// <summary>
-    /// Write an #Import directive using a path-qualified name - https://www.autohotkey.com/docs/alpha/lib/_Import.htm. 
+    /// Write an #Import directive using a path-qualified name - https://www.autohotkey.com/docs/alpha/lib/_Import.htm.
     /// Requires v2.1-alpha.21+
     /// </summary>
     public void Import(string path, IEnumerable<string> names)
@@ -85,15 +85,13 @@ public sealed class AhkWriter(AhkVersion version = AhkVersion.v20)
     /// Open a class block. Returns an IDisposable that writes the closing brace on Dispose.
     /// Format: "class NAME extends BASE {" or "class NAME {" (always space before brace).
     /// Supports nesting — indent level is always relative.
-    /// 
+    ///
     /// If writer is for v2.1, the class is exported as the default export. This means there can only
     /// be one class per module / file.
     /// </summary>
     public IndentScope Class(string name, string? extends = null)
     {
-        string header = extends != null
-            ? $"class {name} extends {extends}"
-            : $"class {name}";
+        string header = extends != null ? $"class {name} extends {extends}" : $"class {name}";
 
         if (version is AhkVersion.v21)
             header = $"export default {header}";
@@ -111,9 +109,7 @@ public sealed class AhkWriter(AhkVersion version = AhkVersion.v20)
     /// </summary>
     public IndentScope Struct(string name, string? extends = null)
     {
-        string header = extends != null
-            ? $"struct {name} extends {extends}"
-            : $"struct {name}";
+        string header = extends != null ? $"struct {name} extends {extends}" : $"struct {name}";
 
         if (version is AhkVersion.v21 && _indentLevel == 0)
             header = $"export default {header}";
@@ -128,12 +124,14 @@ public sealed class AhkWriter(AhkVersion version = AhkVersion.v20)
     /// </summary>
     public IndentScope Function(string name, string args = "")
     {
-        _sb.AppendLine(version switch
-        {
-            AhkVersion.v20 => $"{Indent}{name}({args}) {{",
-            AhkVersion.v21 => $"{Indent}export {name}({args}) {{",
-            _ => throw new NotImplementedException($"Unsupported AHK version {version.ToFriendlyString()}")
-        });
+        _sb.AppendLine(
+            version switch
+            {
+                AhkVersion.v20 => $"{Indent}{name}({args}) {{",
+                AhkVersion.v21 => $"{Indent}export {name}({args}) {{",
+                _ => throw new NotImplementedException($"Unsupported AHK version {version.ToFriendlyString()}"),
+            }
+        );
 
         _indentLevel++;
         return new IndentScope(this);
@@ -141,18 +139,20 @@ public sealed class AhkWriter(AhkVersion version = AhkVersion.v20)
 
     /// <summary>
     /// Write a top-level variable, like [export global] foo := "bar". If version supports it, variable is exported.
-    /// 
+    ///
     /// Does *not* open a new indentation level. Exports require v2.1-alpha.21+
     /// </summary>
     /// <exception cref="NotImplementedException"></exception>
     public void Variable(string name, string value)
     {
-        _sb.AppendLine(version switch
-        {
-            AhkVersion.v20 => $"{Indent}{name} := {value}",
-            AhkVersion.v21 => $"{Indent}export global {name} := {value}",
-            _ => throw new NotImplementedException($"Unsupported AHK version {version.ToFriendlyString()}")
-        });
+        _sb.AppendLine(
+            version switch
+            {
+                AhkVersion.v20 => $"{Indent}{name} := {value}",
+                AhkVersion.v21 => $"{Indent}export global {name} := {value}",
+                _ => throw new NotImplementedException($"Unsupported AHK version {version.ToFriendlyString()}"),
+            }
+        );
     }
 
     /// <summary>
@@ -210,8 +210,7 @@ public sealed class AhkWriter(AhkVersion version = AhkVersion.v20)
     // --- Content ---
 
     /// <summary>Write a static fat-arrow field: "static NAME => expr".</summary>
-    public void StaticField(string name, string expr)
-        => _sb.AppendLine($"{Indent}static {name} => {expr}");
+    public void StaticField(string name, string expr) => _sb.AppendLine($"{Indent}static {name} => {expr}");
 
     /// <summary>Write a line at the current indent level.</summary>
     public void Line(string code) => _sb.AppendLine($"{Indent}{code}");

--- a/Generator/Emit/AhkWriter.cs
+++ b/Generator/Emit/AhkWriter.cs
@@ -104,6 +104,26 @@ public sealed class AhkWriter(AhkVersion version = AhkVersion.v20)
     }
 
     /// <summary>
+    /// Open a struct block (v2.1 native struct). Returns an IDisposable that writes
+    /// the closing brace on Dispose. Format: "struct NAME {" or "struct NAME extends BASE {".
+    /// `struct` defaults to extending Struct, so an explicit extends is only needed when
+    /// inheriting from another struct subclass.
+    /// </summary>
+    public IndentScope Struct(string name, string? extends = null)
+    {
+        string header = extends != null
+            ? $"struct {name} extends {extends}"
+            : $"struct {name}";
+
+        if (version is AhkVersion.v21 && _indentLevel == 0)
+            header = $"export default {header}";
+
+        _sb.AppendLine($"{Indent}{header} {{");
+        _indentLevel++;
+        return new IndentScope(this);
+    }
+
+    /// <summary>
     /// Open a top-level function.
     /// </summary>
     public IndentScope Function(string name, string args = "")

--- a/Generator/Emit/AhkWriter.cs
+++ b/Generator/Emit/AhkWriter.cs
@@ -1,5 +1,7 @@
 namespace AhkWin32.Generator.Emit;
 
+using AhkWin32.Generator.Metadata;
+
 using System.Text;
 
 /// <summary>
@@ -7,7 +9,7 @@ using System.Text;
 /// Wraps a StringBuilder with indent tracking and convenience methods for
 /// common AHK constructs (classes, properties, static fields, etc.).
 /// </summary>
-public sealed class AhkWriter
+public sealed class AhkWriter(AhkVersion version = AhkVersion.v20)
 {
     private readonly StringBuilder _sb = new(4096);
     private int _indentLevel;
@@ -23,6 +25,43 @@ public sealed class AhkWriter
     /// <summary>Write a #Include directive.</summary>
     public void Include(string path) => _sb.AppendLine($"#Include {path}");
 
+    /// <summary>
+    /// Write an #Import directive using a path-qualified name - https://www.autohotkey.com/docs/alpha/lib/_Import.htm. 
+    /// Requires v2.1-alpha.21+
+    /// </summary>
+    public void Import(string path, IEnumerable<string> names)
+    {
+        _sb.Append($"#Import \"{path}\"");
+        if (names.Any())
+        {
+            _sb.Append($" {{{string.Join(", ", names)}}}");
+        }
+        _sb.AppendLine();
+    }
+
+    public void Import(string path) => Import(path, []);
+
+    /// <summary>
+    /// Write an #Import export directive using a path-qualified name - https://www.autohotkey.com/docs/alpha/lib/_Import.htm.
+    /// Requires v2.1-alpha.24+ if using a wildcard import, otherwise v2.1-alpha.21+
+    /// </summary>
+    public void ReExport(string path, IEnumerable<string> names)
+    {
+        _sb.Append($"#Import export \"{path}\"");
+        if (names.Any())
+        {
+            _sb.Append($" {{{string.Join(", ", names)}}}");
+        }
+        _sb.AppendLine();
+    }
+
+    public void ReExport(string path) => ReExport(path, []);
+
+    /// <summary>
+    /// Write a #Module statement.
+    /// </summary>
+    public void Module(string name) => _sb.AppendLine($"#Module {name}");
+
     // --- Structure ---
 
     /// <summary>Write an empty line.</summary>
@@ -32,6 +71,9 @@ public sealed class AhkWriter
     /// Open a class block. Returns an IDisposable that writes the closing brace on Dispose.
     /// Format: "class NAME extends BASE {" or "class NAME {" (always space before brace).
     /// Supports nesting — indent level is always relative.
+    /// 
+    /// If writer is for v2.1, the class is exported as the default export. This means there can only
+    /// be one class per module / file.
     /// </summary>
     public IndentScope Class(string name, string? extends = null)
     {
@@ -39,9 +81,44 @@ public sealed class AhkWriter
             ? $"class {name} extends {extends}"
             : $"class {name}";
 
+        if (version is AhkVersion.v21)
+            header = $"export default {header}";
+
         _sb.AppendLine($"{Indent}{header} {{");
         _indentLevel++;
         return new IndentScope(this);
+    }
+
+    /// <summary>
+    /// Open a top-level function.
+    /// </summary>
+    public IndentScope Function(string name, string args = "")
+    {
+        _sb.AppendLine(version switch
+        {
+            AhkVersion.v20 => $"{Indent}{name}({args}) {{",
+            AhkVersion.v21 => $"{Indent}export {name}({args}) {{",
+            _ => throw new NotImplementedException($"Unsupported AHK version {version.ToFriendlyString()}")
+        });
+
+        _indentLevel++;
+        return new IndentScope(this);
+    }
+
+    /// <summary>
+    /// Write a top-level variable, like [export global] foo := "bar". If version supports it, variable is exported.
+    /// 
+    /// Does *not* open a new indentation level. Exports require v2.1-alpha.21+
+    /// </summary>
+    /// <exception cref="NotImplementedException"></exception>
+    public void Variable(string name, string value)
+    {
+        _sb.AppendLine(version switch
+        {
+            AhkVersion.v20 => $"{Indent}{name} := {value}",
+            AhkVersion.v21 => $"{Indent}export global {name} := {value}",
+            _ => throw new NotImplementedException($"Unsupported AHK version {version.ToFriendlyString()}")
+        });
     }
 
     /// <summary>

--- a/Generator/Emit/DocCommentWriter.cs
+++ b/Generator/Emit/DocCommentWriter.cs
@@ -89,6 +89,15 @@ public static class DocCommentWriter
     /// </summary>
     public static void WriteFieldDoc(AhkWriter w, FieldMember field, AhkVersion version = AhkVersion.v20)
     {
+        // Don't add the /** */ if we wouldn't emit anything between them
+        if (
+            string.IsNullOrWhiteSpace(field.Description)
+            && !field.IsBitField
+            && !field.IsDeprecated
+            && version is AhkVersion.v21
+        )
+            return;
+
         w.Line("/**");
 
         if (!string.IsNullOrWhiteSpace(field.Description))

--- a/Generator/Emit/DocCommentWriter.cs
+++ b/Generator/Emit/DocCommentWriter.cs
@@ -1,5 +1,6 @@
 namespace AhkWin32.Generator.Emit;
 
+using AhkWin32.Generator.Metadata;
 using AhkWin32.Generator.Model;
 using AhkWin32.Generator.Model.Members;
 using AhkWin32.Generator.Model.Types;
@@ -85,7 +86,7 @@ public static class DocCommentWriter
     /// Write a field-level JSDoc comment.
     /// Port of AhkStructMember.MaybeAppendDocumentation.
     /// </summary>
-    public static void WriteFieldDoc(AhkWriter w, FieldMember field)
+    public static void WriteFieldDoc(AhkWriter w, FieldMember field, AhkVersion version = AhkVersion.v20)
     {
         w.Line("/**");
 
@@ -107,10 +108,15 @@ public static class DocCommentWriter
             w.Line(deprecatedTag);
         }
 
-        string typeName = field.EmbeddedStruct is not null
-            ? field.EmbeddedStruct.Name
-            : field.Type.DisplayName;
-        w.Line($" * @type {{{typeName}}}");
+        // No type doc for v2.1 struct fields since they carry type info in their
+        // type specifiers
+        if (version is AhkVersion.v20)
+        {
+            string typeName = field.EmbeddedStruct is not null
+                ? field.EmbeddedStruct.Name
+                : field.Type.DisplayName;
+            w.Line($" * @type {{{typeName}}}");
+        }
         w.Line(" */");
     }
 

--- a/Generator/Emit/DocCommentWriter.cs
+++ b/Generator/Emit/DocCommentWriter.cs
@@ -13,7 +13,8 @@ public static class DocCommentWriter
     /// <summary>
     /// Doc string for the variadic argument for variadic args
     /// </summary>
-    private const string VAR_ARGS_DOC = "Additional arguments as alternating DllCall type/value pairs (e.g., \"int\", 42, \"str\", \"hello\")";
+    private const string VAR_ARGS_DOC =
+        "Additional arguments as alternating DllCall type/value pairs (e.g., \"int\", 42, \"str\", \"hello\")";
 
     /// <summary>
     /// Write a type-level JSDoc comment.
@@ -50,7 +51,7 @@ public static class DocCommentWriter
 
         if (type.IsDeprecated)
         {
-            string deprecatedTag =  !string.IsNullOrWhiteSpace(type.DeprecationMessage)
+            string deprecatedTag = !string.IsNullOrWhiteSpace(type.DeprecationMessage)
                 ? $" * @deprecated {type.DeprecationMessage}"
                 : " * @deprecated";
             w.Line(deprecatedTag);
@@ -72,7 +73,7 @@ public static class DocCommentWriter
 
         if (constant.IsDeprecated)
         {
-            string deprecatedTag =  !string.IsNullOrWhiteSpace(constant.DeprecationMessage)
+            string deprecatedTag = !string.IsNullOrWhiteSpace(constant.DeprecationMessage)
                 ? $" * @deprecated {constant.DeprecationMessage}"
                 : " * @deprecated";
             w.Line(deprecatedTag);
@@ -112,9 +113,7 @@ public static class DocCommentWriter
         // type specifiers
         if (version is AhkVersion.v20)
         {
-            string typeName = field.EmbeddedStruct is not null
-                ? field.EmbeddedStruct.Name
-                : field.Type.DisplayName;
+            string typeName = field.EmbeddedStruct is not null ? field.EmbeddedStruct.Name : field.Type.DisplayName;
             w.Line($" * @type {{{typeName}}}");
         }
         w.Line(" */");
@@ -131,9 +130,7 @@ public static class DocCommentWriter
         if (!string.IsNullOrWhiteSpace(description))
             w.Line($" * {EscapeDocs(description, new string(' ', w.CurrentIndentLevel * 4))}");
 
-        string typeName = parent.EmbeddedStruct is not null
-            ? parent.EmbeddedStruct.Name
-            : parent.Type.DisplayName;
+        string typeName = parent.EmbeddedStruct is not null ? parent.EmbeddedStruct.Name : parent.Type.DisplayName;
         w.Line($" * @type {{{typeName}}}");
         w.Line(" */");
     }
@@ -212,9 +209,7 @@ public static class DocCommentWriter
         {
             if (method.OutputParameter is { } outParam)
             {
-                string? returnTypeName = outParam.IsPtr
-                    ? outParam.Pointee?.DisplayName
-                    : outParam.Type.DisplayName;
+                string? returnTypeName = outParam.IsPtr ? outParam.Pointee?.DisplayName : outParam.Type.DisplayName;
                 string returnDoc = !string.IsNullOrWhiteSpace(outParam.Description)
                     ? EscapeDocs(outParam.Description, indent) ?? ""
                     : "";
@@ -222,7 +217,9 @@ public static class DocCommentWriter
             }
             else
             {
-                w.Line($" * @returns {{{method.Parameters[0].Type.DisplayName}}} {EscapeDocs(method.ReturnValueDoc, indent)}");
+                w.Line(
+                    $" * @returns {{{method.Parameters[0].Type.DisplayName}}} {EscapeDocs(method.ReturnValueDoc, indent)}"
+                );
             }
         }
         else
@@ -254,9 +251,6 @@ public static class DocCommentWriter
     /// </summary>
     public static string? EscapeDocs(string? docString, string? indent = " ")
     {
-        return docString?
-            .Replace("/*", "//")
-            .Replace("*/", "")
-            .Replace("\n", $"\n{indent} * ");
+        return docString?.Replace("/*", "//").Replace("*/", "").Replace("\n", $"\n{indent} * ");
     }
 }

--- a/Generator/Emit/Emitters/ApiConstantsEmitter21.cs
+++ b/Generator/Emit/Emitters/ApiConstantsEmitter21.cs
@@ -63,6 +63,6 @@ public sealed class ApiConstantsEmitter21 : ITypeEmitter
         }
     }
 
-    private static bool HasHandleConstant(ApiType apiType)
-        => apiType.Constants.Any(c => c.Value is StructConstantValue { IsHandle: true });
+    private static bool HasHandleConstant(ApiType apiType) =>
+        apiType.Constants.Any(c => c.Value is StructConstantValue { IsHandle: true });
 }

--- a/Generator/Emit/Emitters/ApiConstantsEmitter21.cs
+++ b/Generator/Emit/Emitters/ApiConstantsEmitter21.cs
@@ -38,8 +38,6 @@ public sealed class ApiConstantsEmitter21(TypeRegistry registry, ILogger? logger
         // module's exported constant names are aliased. The base types Win32Handle/Guid are emitted
         // with fixed names below, so register them as anchors to keep other imports off those names.
         List<string> anchors = [.. apiType.Constants.Select(c => c.Name)];
-        if (hasHandleConstant)
-            anchors.Add("Win32Handle");
         if (apiType.NeedsGuid)
             anchors.Add("Guid");
 

--- a/Generator/Emit/Emitters/ApiConstantsEmitter21.cs
+++ b/Generator/Emit/Emitters/ApiConstantsEmitter21.cs
@@ -3,6 +3,7 @@ namespace AhkWin32.Generator.Emit.Emitters;
 using AhkWin32.Generator.Metadata;
 using AhkWin32.Generator.Model;
 using AhkWin32.Generator.Model.Types;
+using Microsoft.Extensions.Logging;
 
 /// <summary>
 /// Emits a v2.1 ApiType's constants as a separate Constants.ahk file alongside Apis.ahk.
@@ -10,8 +11,11 @@ using AhkWin32.Generator.Model.Types;
 /// imported, so constants are split out and users opt in by importing Constants.ahk
 /// explicitly.
 /// </summary>
-public sealed class ApiConstantsEmitter21 : ITypeEmitter
+public sealed class ApiConstantsEmitter21(TypeRegistry registry, ILogger? logger = null) : ITypeEmitter
 {
+    private readonly TypeRegistry _registry = registry;
+    private readonly ILogger? _logger = logger;
+
     public bool CanEmit(Win32Type type) => type is ApiType { Constants.Count: > 0 };
 
     public EmitResult Emit(Win32Type type, string outputRoot)
@@ -25,18 +29,32 @@ public sealed class ApiConstantsEmitter21 : ITypeEmitter
         return new EmitResult(w.ToString(), filePath);
     }
 
-    private static void EmitConstantsFile(AhkWriter w, ApiType apiType)
+    private void EmitConstantsFile(AhkWriter w, ApiType apiType)
     {
         string pathToBase = ImportResolver.GetPathToBase(apiType.Namespace);
+        bool hasHandleConstant = HasHandleConstant(apiType);
+
+        // Build a name resolver so imported type names that collide (case-insensitively) with this
+        // module's exported constant names are aliased. The base types Win32Handle/Guid are emitted
+        // with fixed names below, so register them as anchors to keep other imports off those names.
+        List<string> anchors = [.. apiType.Constants.Select(c => c.Name)];
+        if (hasHandleConstant)
+            anchors.Add("Win32Handle");
+        if (apiType.NeedsGuid)
+            anchors.Add("Guid");
+
+        IEnumerable<string> typeFqns = apiType.Constants.SelectMany(c => c.Imports.GetTypes()).Distinct();
+        var names = new ModuleNameResolver(anchors, typeFqns, [], _registry, _logger, $"{apiType.Namespace}.Constants");
+
         w.Require("AutoHotkey >= v2.1-alpha.24+ 64-bit");
 
-        if (HasHandleConstant(apiType))
+        if (hasHandleConstant)
             w.Import($"{pathToBase}Win32Handle.ahk", ["Win32Handle"]);
 
         if (apiType.NeedsGuid)
             w.Import($"{pathToBase}Guid.ahk", ["Guid"]);
 
-        EmitImports(w, apiType);
+        EmitImports(w, apiType, names);
 
         w.BlankLine();
         DocCommentWriter.WriteTypeDoc(w, apiType);
@@ -46,12 +64,12 @@ public sealed class ApiConstantsEmitter21 : ITypeEmitter
         foreach (var constant in apiType.Constants)
         {
             w.BlankLine();
-            ConstantEmitter.EmitConstant21(w, constant);
+            ConstantEmitter.EmitConstant21(w, constant, names);
         }
         w.RawLine(";@endregion Constants");
     }
 
-    private static void EmitImports(AhkWriter w, ApiType apiType)
+    private static void EmitImports(AhkWriter w, ApiType apiType, ModuleNameResolver names)
     {
         var seen = new HashSet<string>();
         foreach (string fqn in apiType.Constants.SelectMany(c => c.Imports.GetTypes()))
@@ -59,7 +77,7 @@ public sealed class ApiConstantsEmitter21 : ITypeEmitter
             if (!seen.Add(fqn))
                 continue;
             string path = ImportResolver.GetIncludePath(apiType.Namespace, fqn);
-            w.Import(path, [ImportResolver.GetImportName(fqn)]);
+            w.Import(path, [names.TypeImportToken(fqn)]);
         }
     }
 

--- a/Generator/Emit/Emitters/ApiConstantsEmitter21.cs
+++ b/Generator/Emit/Emitters/ApiConstantsEmitter21.cs
@@ -35,8 +35,7 @@ public sealed class ApiConstantsEmitter21(TypeRegistry registry, ILogger? logger
         bool hasHandleConstant = HasHandleConstant(apiType);
 
         // Build a name resolver so imported type names that collide (case-insensitively) with this
-        // module's exported constant names are aliased. The base types Win32Handle/Guid are emitted
-        // with fixed names below, so register them as anchors to keep other imports off those names.
+        // module's exported constant names are aliased.
         List<string> anchors = [.. apiType.Constants.Select(c => c.Name)];
         if (apiType.NeedsGuid)
             anchors.Add("Guid");
@@ -45,9 +44,6 @@ public sealed class ApiConstantsEmitter21(TypeRegistry registry, ILogger? logger
         var names = new ModuleNameResolver(anchors, typeFqns, [], _registry, _logger, $"{apiType.Namespace}.Constants");
 
         w.Require("AutoHotkey >= v2.1-alpha.24+ 64-bit");
-
-        if (hasHandleConstant)
-            w.Import($"{pathToBase}Win32Handle.ahk", ["Win32Handle"]);
 
         if (apiType.NeedsGuid)
             w.Import($"{pathToBase}Guid.ahk", ["Guid"]);

--- a/Generator/Emit/Emitters/ApiConstantsEmitter21.cs
+++ b/Generator/Emit/Emitters/ApiConstantsEmitter21.cs
@@ -1,0 +1,68 @@
+namespace AhkWin32.Generator.Emit.Emitters;
+
+using AhkWin32.Generator.Metadata;
+using AhkWin32.Generator.Model;
+using AhkWin32.Generator.Model.Types;
+
+/// <summary>
+/// Emits a v2.1 ApiType's constants as a separate Constants.ahk file alongside Apis.ahk.
+/// In v2.1, module-scope <c>export global</c> values load eagerly when the module is
+/// imported, so constants are split out and users opt in by importing Constants.ahk
+/// explicitly.
+/// </summary>
+public sealed class ApiConstantsEmitter21 : ITypeEmitter
+{
+    public bool CanEmit(Win32Type type) => type is ApiType { Constants.Count: > 0 };
+
+    public EmitResult Emit(Win32Type type, string outputRoot)
+    {
+        var apiType = (ApiType)type;
+        var w = new AhkWriter(AhkVersion.v21);
+
+        EmitConstantsFile(w, apiType);
+
+        string filePath = ImportResolver.GetFilePath(outputRoot, apiType.Namespace, "Constants");
+        return new EmitResult(w.ToString(), filePath);
+    }
+
+    private static void EmitConstantsFile(AhkWriter w, ApiType apiType)
+    {
+        string pathToBase = ImportResolver.GetPathToBase(apiType.Namespace);
+        w.Require("AutoHotkey >= v2.1-alpha.24+ 64-bit");
+
+        if (HasHandleConstant(apiType))
+            w.Import($"{pathToBase}Win32Handle.ahk", ["Win32Handle"]);
+
+        if (apiType.NeedsGuid)
+            w.Import($"{pathToBase}Guid.ahk", ["Guid"]);
+
+        EmitImports(w, apiType);
+
+        w.BlankLine();
+        DocCommentWriter.WriteTypeDoc(w, apiType);
+        w.BlankLine();
+
+        w.RawLine(";@region Constants");
+        foreach (var constant in apiType.Constants)
+        {
+            w.BlankLine();
+            ConstantEmitter.EmitConstant21(w, constant);
+        }
+        w.RawLine(";@endregion Constants");
+    }
+
+    private static void EmitImports(AhkWriter w, ApiType apiType)
+    {
+        var seen = new HashSet<string>();
+        foreach (string fqn in apiType.Constants.SelectMany(c => c.Imports.GetTypes()))
+        {
+            if (!seen.Add(fqn))
+                continue;
+            string path = ImportResolver.GetIncludePath(apiType.Namespace, fqn);
+            w.Import(path, [ImportResolver.GetImportName(fqn)]);
+        }
+    }
+
+    private static bool HasHandleConstant(ApiType apiType)
+        => apiType.Constants.Any(c => c.Value is StructConstantValue { IsHandle: true });
+}

--- a/Generator/Emit/Emitters/ApiTypeEmitter.cs
+++ b/Generator/Emit/Emitters/ApiTypeEmitter.cs
@@ -64,7 +64,7 @@ public sealed class ApiTypeEmitter : ITypeEmitter
 
     private static void EmitImports(AhkWriter w, ApiType apiType)
     {
-        foreach (string import in apiType.ReferencedTypes.Distinct())
+        foreach (string import in apiType.Imports.GetIncludeTargets())
         {
             w.Include(ImportResolver.GetIncludePath(apiType.Namespace, import));
         }

--- a/Generator/Emit/Emitters/ApiTypeEmitter21.cs
+++ b/Generator/Emit/Emitters/ApiTypeEmitter21.cs
@@ -56,11 +56,16 @@ public sealed class ApiTypeEmitter21(TypeRegistry registry) : ITypeEmitter
 
     private static void EmitImports(AhkWriter w, ApiType apiType)
     {
-        foreach (string import in apiType.ReferencedTypes.Distinct())
+        foreach (string fqn in apiType.Imports.GetTypes())
         {
-            string path = ImportResolver.GetIncludePath(apiType.Namespace, import);
-            string name = ImportResolver.GetImportName(import);
-            w.Import(path, [name]);
+            string path = ImportResolver.GetIncludePath(apiType.Namespace, fqn);
+            w.Import(path, [ImportResolver.GetImportName(fqn)]);
+        }
+
+        foreach (string apisFqn in apiType.Imports.GetFunctionNamespaces())
+        {
+            string path = ImportResolver.GetIncludePath(apiType.Namespace, apisFqn);
+            w.Import(path, apiType.Imports.GetFunctionsForNamespace(apisFqn));
         }
     }
 

--- a/Generator/Emit/Emitters/ApiTypeEmitter21.cs
+++ b/Generator/Emit/Emitters/ApiTypeEmitter21.cs
@@ -3,15 +3,17 @@ namespace AhkWin32.Generator.Emit.Emitters;
 using AhkWin32.Generator.Metadata;
 using AhkWin32.Generator.Model;
 using AhkWin32.Generator.Model.Types;
+using Microsoft.Extensions.Logging;
 
 /// <summary>
 /// Emits a v2.1 ApiType's free functions as a complete .ahk file.
 /// Constants are emitted separately by <see cref="ApiConstantsEmitter21"/> so users
 /// can opt in to loading them (v2.1 module-scope globals are not lazy).
 /// </summary>
-public sealed class ApiTypeEmitter21(TypeRegistry registry) : ITypeEmitter
+public sealed class ApiTypeEmitter21(TypeRegistry registry, ILogger? logger = null) : ITypeEmitter
 {
     private readonly TypeRegistry _registry = registry;
+    private readonly ILogger? _logger = logger;
 
     public bool CanEmit(Win32Type type) => type is ApiType { Methods.Count: > 0 };
 
@@ -29,13 +31,16 @@ public sealed class ApiTypeEmitter21(TypeRegistry registry) : ITypeEmitter
     private void EmitApiType(AhkWriter w, ApiType apiType)
     {
         // Directives
-        string pathToBase = ImportResolver.GetPathToBase(apiType.Namespace);
         w.Require("AutoHotkey >= v2.1-alpha.24+ 64-bit");
         w.BlankLine();
 
+        // Build a per-file name resolver so imported type/function names that collide
+        // (case-insensitively) with this module's exported function names are aliased.
+        ModuleNameResolver names = BuildResolver(apiType);
+
         // Referenced type imports needed by methods (and any extension imports not consumed
         // exclusively by constants).
-        EmitImports(w, apiType);
+        EmitImports(w, apiType, names);
 
         w.BlankLine();
 
@@ -45,10 +50,29 @@ public sealed class ApiTypeEmitter21(TypeRegistry registry) : ITypeEmitter
         w.BlankLine();
 
         // Functions region
-        EmitFunctions(w, apiType);
+        EmitFunctions(w, apiType, names);
     }
 
-    private static void EmitImports(AhkWriter w, ApiType apiType)
+    private ModuleNameResolver BuildResolver(ApiType apiType)
+    {
+        var constantOnlyTypes = new HashSet<string>(GetConstantOnlyTypeImports(apiType));
+        IEnumerable<string> typeFqns = apiType.Imports.GetTypes().Where(fqn => !constantOnlyTypes.Contains(fqn));
+
+        var functionImports = apiType
+            .Imports.GetFunctionNamespaces()
+            .Select(apisFqn => (apisFqn, apiType.Imports.GetFunctionsForNamespace(apisFqn)));
+
+        return new ModuleNameResolver(
+            apiType.Methods.Select(m => m.Name),
+            typeFqns,
+            functionImports,
+            _registry,
+            _logger,
+            $"{apiType.Namespace}.Apis"
+        );
+    }
+
+    private static void EmitImports(AhkWriter w, ApiType apiType, ModuleNameResolver names)
     {
         // Strip imports that are only referenced by constants (those go in Constants.ahk).
         var constantOnlyTypes = new HashSet<string>(GetConstantOnlyTypeImports(apiType));
@@ -58,13 +82,16 @@ public sealed class ApiTypeEmitter21(TypeRegistry registry) : ITypeEmitter
             if (constantOnlyTypes.Contains(fqn))
                 continue;
             string path = ImportResolver.GetIncludePath(apiType.Namespace, fqn);
-            w.Import(path, [ImportResolver.GetImportName(fqn)]);
+            w.Import(path, [names.TypeImportToken(fqn)]);
         }
 
         foreach (string apisFqn in apiType.Imports.GetFunctionNamespaces())
         {
             string path = ImportResolver.GetIncludePath(apiType.Namespace, apisFqn);
-            w.Import(path, apiType.Imports.GetFunctionsForNamespace(apisFqn));
+            var tokens = apiType
+                .Imports.GetFunctionsForNamespace(apisFqn)
+                .Select(fn => names.FunctionImportToken(apisFqn, fn));
+            w.Import(path, tokens);
         }
     }
 
@@ -79,13 +106,13 @@ public sealed class ApiTypeEmitter21(TypeRegistry registry) : ITypeEmitter
         return apiType.Constants.SelectMany(c => c.Imports.GetTypes()).Where(t => !methodTypes.Contains(t)).Distinct();
     }
 
-    private void EmitFunctions(AhkWriter w, ApiType apiType)
+    private void EmitFunctions(AhkWriter w, ApiType apiType, ModuleNameResolver names)
     {
         w.RawLine(";@region Functions");
 
         foreach (var method in apiType.Methods)
         {
-            MethodEmitter.EmitDllImportFunction(w, method, _registry);
+            MethodEmitter.EmitDllImportFunction(w, method, _registry, names);
             w.BlankLine();
         }
 

--- a/Generator/Emit/Emitters/ApiTypeEmitter21.cs
+++ b/Generator/Emit/Emitters/ApiTypeEmitter21.cs
@@ -1,8 +1,8 @@
 namespace AhkWin32.Generator.Emit.Emitters;
 
+using AhkWin32.Generator.Metadata;
 using AhkWin32.Generator.Model;
 using AhkWin32.Generator.Model.Types;
-using AhkWin32.Generator.Metadata;
 
 /// <summary>
 /// Emits a v2.1 ApiType's free functions as a complete .ahk file.
@@ -42,7 +42,7 @@ public sealed class ApiTypeEmitter21(TypeRegistry registry) : ITypeEmitter
         // Type documentation
         DocCommentWriter.WriteTypeDoc(w, apiType);
 
-         w.BlankLine();
+        w.BlankLine();
 
         // Functions region
         EmitFunctions(w, apiType);
@@ -74,13 +74,9 @@ public sealed class ApiTypeEmitter21(TypeRegistry registry) : ITypeEmitter
     /// </summary>
     private static IEnumerable<string> GetConstantOnlyTypeImports(ApiType apiType)
     {
-        var methodTypes = new HashSet<string>(
-            apiType.Methods.SelectMany(m => m.Imports.GetTypes()));
+        var methodTypes = new HashSet<string>(apiType.Methods.SelectMany(m => m.Imports.GetTypes()));
 
-        return apiType.Constants
-            .SelectMany(c => c.Imports.GetTypes())
-            .Where(t => !methodTypes.Contains(t))
-            .Distinct();
+        return apiType.Constants.SelectMany(c => c.Imports.GetTypes()).Where(t => !methodTypes.Contains(t)).Distinct();
     }
 
     private void EmitFunctions(AhkWriter w, ApiType apiType)

--- a/Generator/Emit/Emitters/ApiTypeEmitter21.cs
+++ b/Generator/Emit/Emitters/ApiTypeEmitter21.cs
@@ -5,14 +5,15 @@ using AhkWin32.Generator.Model.Types;
 using AhkWin32.Generator.Metadata;
 
 /// <summary>
-/// Emits a v2.1 ApiType as a complete .ahk file.
-/// TODO: consider moving constants to their own file since we cannot lazy-load them as fat arrow functions anymore
+/// Emits a v2.1 ApiType's free functions as a complete .ahk file.
+/// Constants are emitted separately by <see cref="ApiConstantsEmitter21"/> so users
+/// can opt in to loading them (v2.1 module-scope globals are not lazy).
 /// </summary>
 public sealed class ApiTypeEmitter21(TypeRegistry registry) : ITypeEmitter
 {
     private readonly TypeRegistry _registry = registry;
 
-    public bool CanEmit(Win32Type type) => type is ApiType;
+    public bool CanEmit(Win32Type type) => type is ApiType { Methods.Count: > 0 };
 
     public EmitResult Emit(Win32Type type, string outputRoot)
     {
@@ -32,10 +33,8 @@ public sealed class ApiTypeEmitter21(TypeRegistry registry) : ITypeEmitter
         w.Require("AutoHotkey >= v2.1-alpha.24+ 64-bit");
         w.Import($"{pathToBase}Win32Handle.ahk", ["Win32Handle"]);
 
-        if (apiType.NeedsGuid)
-            w.Import($"{pathToBase}Guid.ahk", ["Guid"]);
-
-        // Referenced type imports (from constants, methods, and extensions)
+        // Referenced type imports needed by methods (and any extension imports not consumed
+        // exclusively by constants).
         EmitImports(w, apiType);
 
         w.BlankLine();
@@ -45,19 +44,19 @@ public sealed class ApiTypeEmitter21(TypeRegistry registry) : ITypeEmitter
 
          w.BlankLine();
 
-        // Constants region
-        EmitConstants(w, apiType);
-
-        w.BlankLine();
-
         // Functions region
         EmitFunctions(w, apiType);
     }
 
     private static void EmitImports(AhkWriter w, ApiType apiType)
     {
+        // Strip imports that are only referenced by constants (those go in Constants.ahk).
+        var constantOnlyTypes = new HashSet<string>(GetConstantOnlyTypeImports(apiType));
+
         foreach (string fqn in apiType.Imports.GetTypes())
         {
+            if (constantOnlyTypes.Contains(fqn))
+                continue;
             string path = ImportResolver.GetIncludePath(apiType.Namespace, fqn);
             w.Import(path, [ImportResolver.GetImportName(fqn)]);
         }
@@ -69,18 +68,19 @@ public sealed class ApiTypeEmitter21(TypeRegistry registry) : ITypeEmitter
         }
     }
 
-    private static void EmitConstants(AhkWriter w, ApiType apiType)
+    /// <summary>
+    /// Type FQNs referenced by at least one constant but no method. These belong only in
+    /// Constants.ahk and should not appear in the functions file's import list.
+    /// </summary>
+    private static IEnumerable<string> GetConstantOnlyTypeImports(ApiType apiType)
     {
-        // Region markers are at column 0 (matching legacy format)
-        w.RawLine(";@region Constants");
+        var methodTypes = new HashSet<string>(
+            apiType.Methods.SelectMany(m => m.Imports.GetTypes()));
 
-        foreach (var constant in apiType.Constants)
-        {
-            w.BlankLine();
-            ConstantEmitter.EmitConstant21(w, constant);
-        }
-
-        w.RawLine(";@endregion Constants");
+        return apiType.Constants
+            .SelectMany(c => c.Imports.GetTypes())
+            .Where(t => !methodTypes.Contains(t))
+            .Distinct();
     }
 
     private void EmitFunctions(AhkWriter w, ApiType apiType)

--- a/Generator/Emit/Emitters/ApiTypeEmitter21.cs
+++ b/Generator/Emit/Emitters/ApiTypeEmitter21.cs
@@ -1,0 +1,93 @@
+namespace AhkWin32.Generator.Emit.Emitters;
+
+using AhkWin32.Generator.Model;
+using AhkWin32.Generator.Model.Types;
+using AhkWin32.Generator.Metadata;
+
+/// <summary>
+/// Emits a v2.1 ApiType as a complete .ahk file.
+/// TODO: consider moving constants to their own file since we cannot lazy-load them as fat arrow functions anymore
+/// </summary>
+public sealed class ApiTypeEmitter21(TypeRegistry registry) : ITypeEmitter
+{
+    private readonly TypeRegistry _registry = registry;
+
+    public bool CanEmit(Win32Type type) => type is ApiType;
+
+    public EmitResult Emit(Win32Type type, string outputRoot)
+    {
+        var apiType = (ApiType)type;
+        var w = new AhkWriter(AhkVersion.v21);
+
+        EmitApiType(w, apiType);
+
+        string filePath = ImportResolver.GetFilePath(outputRoot, apiType.Namespace, apiType.CanonicalName);
+        return new EmitResult(w.ToString(), filePath);
+    }
+
+    private void EmitApiType(AhkWriter w, ApiType apiType)
+    {
+        // Directives
+        string pathToBase = ImportResolver.GetPathToBase(apiType.Namespace);
+        w.Require("AutoHotkey >= v2.1-alpha.24+ 64-bit");
+        w.Import($"{pathToBase}Win32Handle.ahk", ["Win32Handle"]);
+
+        if (apiType.NeedsGuid)
+            w.Import($"{pathToBase}Guid.ahk", ["Guid"]);
+
+        // Referenced type imports (from constants, methods, and extensions)
+        EmitImports(w, apiType);
+
+        w.BlankLine();
+
+        // Type documentation
+        DocCommentWriter.WriteTypeDoc(w, apiType);
+
+         w.BlankLine();
+
+        // Constants region
+        EmitConstants(w, apiType);
+
+        w.BlankLine();
+
+        // Functions region
+        EmitFunctions(w, apiType);
+    }
+
+    private static void EmitImports(AhkWriter w, ApiType apiType)
+    {
+        foreach (string import in apiType.ReferencedTypes.Distinct())
+        {
+            string path = ImportResolver.GetIncludePath(apiType.Namespace, import);
+            string name = ImportResolver.GetImportName(import);
+            w.Import(path, [name]);
+        }
+    }
+
+    private static void EmitConstants(AhkWriter w, ApiType apiType)
+    {
+        // Region markers are at column 0 (matching legacy format)
+        w.RawLine(";@region Constants");
+
+        foreach (var constant in apiType.Constants)
+        {
+            w.BlankLine();
+            ConstantEmitter.EmitConstant21(w, constant);
+        }
+
+        w.RawLine(";@endregion Constants");
+    }
+
+    private void EmitFunctions(AhkWriter w, ApiType apiType)
+    {
+        w.RawLine(";@region Functions");
+
+        foreach (var method in apiType.Methods)
+        {
+            MethodEmitter.EmitDllImportFunction(w, method, _registry);
+            w.BlankLine();
+        }
+
+        w.RawLine(";@endregion Functions");
+    }
+}

--- a/Generator/Emit/Emitters/ApiTypeEmitter21.cs
+++ b/Generator/Emit/Emitters/ApiTypeEmitter21.cs
@@ -31,7 +31,7 @@ public sealed class ApiTypeEmitter21(TypeRegistry registry) : ITypeEmitter
         // Directives
         string pathToBase = ImportResolver.GetPathToBase(apiType.Namespace);
         w.Require("AutoHotkey >= v2.1-alpha.24+ 64-bit");
-        w.Import($"{pathToBase}Win32Handle.ahk", ["Win32Handle"]);
+        w.BlankLine();
 
         // Referenced type imports needed by methods (and any extension imports not consumed
         // exclusively by constants).

--- a/Generator/Emit/Emitters/ComInterfaceEmitter.cs
+++ b/Generator/Emit/Emitters/ComInterfaceEmitter.cs
@@ -56,7 +56,7 @@ public sealed class ComInterfaceEmitter(TypeRegistry registry, AhkVersion versio
             foreach (var method in comType.Methods)
             {
                 w.BlankLine();
-                MethodEmitter.EmitComMethod(w, method, _registry);
+                MethodEmitter.EmitComMethod(w, method, _registry, _version);
             }
 
             StructEmitter.EmitExtensions(w, comType);
@@ -84,20 +84,25 @@ public sealed class ComInterfaceEmitter(TypeRegistry registry, AhkVersion versio
 
     private void EmitImports(AhkWriter w, ComInterfaceType comType)
     {
-        IEnumerable<string> imports = comType.ReferencedTypes
-            .Distinct()
-            .Where(fqn => fqn != comType.FQN);
-        foreach (string fqn in imports)
+        if (_version is AhkVersion.v21)
         {
-            string path = ImportResolver.GetIncludePath(comType.Namespace, fqn);
-            if (_version is AhkVersion.v21)
+            foreach (string fqn in comType.Imports.GetTypes().Where(f => f != comType.FQN))
             {
-                string name = ImportResolver.GetImportName(fqn);
-                w.Import(path, [name]);
+                string path = ImportResolver.GetIncludePath(comType.Namespace, fqn);
+                w.Import(path, [ImportResolver.GetImportName(fqn)]);
             }
-            else
+
+            foreach (string apisFqn in comType.Imports.GetFunctionNamespaces())
             {
-                w.Include(path);
+                string path = ImportResolver.GetIncludePath(comType.Namespace, apisFqn);
+                w.Import(path, comType.Imports.GetFunctionsForNamespace(apisFqn));
+            }
+        }
+        else
+        {
+            foreach (string fqn in comType.Imports.GetIncludeTargets().Where(f => f != comType.FQN))
+            {
+                w.Include(ImportResolver.GetIncludePath(comType.Namespace, fqn));
             }
         }
     }

--- a/Generator/Emit/Emitters/ComInterfaceEmitter.cs
+++ b/Generator/Emit/Emitters/ComInterfaceEmitter.cs
@@ -6,21 +6,19 @@ using AhkWin32.Generator.Model.Members;
 using AhkWin32.Generator.Model.Types;
 
 /// <summary>
-/// Emits ComInterfaceType as a complete .ahk file.
-/// Port of legacy AhkComInterface.ToAhk().
+/// Emits ComInterfaceType as a v2.0 class. v2.1 emission is handled by
+/// <see cref="ComInterfaceEmitter21"/>.
 /// </summary>
-public sealed class ComInterfaceEmitter(TypeRegistry registry, AhkVersion version) : ITypeEmitter
+public sealed class ComInterfaceEmitter(TypeRegistry registry) : ITypeEmitter
 {
     private readonly TypeRegistry _registry = registry;
-
-    private readonly AhkVersion _version = version;
 
     public bool CanEmit(Win32Type type) => type is ComInterfaceType;
 
     public EmitResult Emit(Win32Type type, string outputRoot)
     {
         var comType = (ComInterfaceType)type;
-        var w = new AhkWriter(_version);
+        var w = new AhkWriter(AhkVersion.v20);
 
         EmitComInterface(w, comType);
 
@@ -56,7 +54,7 @@ public sealed class ComInterfaceEmitter(TypeRegistry registry, AhkVersion versio
             foreach (var method in comType.Methods)
             {
                 w.BlankLine();
-                MethodEmitter.EmitComMethod(w, method, _registry, _version);
+                MethodEmitter.EmitComMethod(w, method, _registry, AhkVersion.v20);
             }
 
             StructEmitter.EmitExtensions(w, comType);
@@ -66,44 +64,13 @@ public sealed class ComInterfaceEmitter(TypeRegistry registry, AhkVersion versio
     private void EmitHeaders(AhkWriter w, ComInterfaceType comType)
     {
         string pathToBase = ImportResolver.GetPathToBase(comType.Namespace);
-        if (_version is AhkVersion.v21)
-        {
-            w.Require("AutoHotkey v2.1-alpha+ 64-bit");
-            w.Import($"{pathToBase}Win32ComInterface.ahk", ["Win32ComInterface"]);
-            w.Import($"{pathToBase}Guid.ahk", ["Guid"]);
-        }
-        else
-        {
-            w.Require("AutoHotkey v2.0.0 64-bit");
-            w.Include($"{pathToBase}Win32ComInterface.ahk");
-            w.Include($"{pathToBase}Guid.ahk");
-        }
+        w.Require("AutoHotkey v2.0.0 64-bit");
+        w.Include($"{pathToBase}Win32ComInterface.ahk");
+        w.Include($"{pathToBase}Guid.ahk");
 
-        EmitImports(w, comType);
-    }
-
-    private void EmitImports(AhkWriter w, ComInterfaceType comType)
-    {
-        if (_version is AhkVersion.v21)
+        foreach (string fqn in comType.Imports.GetIncludeTargets().Where(f => f != comType.FQN))
         {
-            foreach (string fqn in comType.Imports.GetTypes().Where(f => f != comType.FQN))
-            {
-                string path = ImportResolver.GetIncludePath(comType.Namespace, fqn);
-                w.Import(path, [ImportResolver.GetImportName(fqn)]);
-            }
-
-            foreach (string apisFqn in comType.Imports.GetFunctionNamespaces())
-            {
-                string path = ImportResolver.GetIncludePath(comType.Namespace, apisFqn);
-                w.Import(path, comType.Imports.GetFunctionsForNamespace(apisFqn));
-            }
-        }
-        else
-        {
-            foreach (string fqn in comType.Imports.GetIncludeTargets().Where(f => f != comType.FQN))
-            {
-                w.Include(ImportResolver.GetIncludePath(comType.Namespace, fqn));
-            }
+            w.Include(ImportResolver.GetIncludePath(comType.Namespace, fqn));
         }
     }
 

--- a/Generator/Emit/Emitters/ComInterfaceEmitter.cs
+++ b/Generator/Emit/Emitters/ComInterfaceEmitter.cs
@@ -1,5 +1,6 @@
 namespace AhkWin32.Generator.Emit.Emitters;
 
+using AhkWin32.Generator.Metadata;
 using AhkWin32.Generator.Model;
 using AhkWin32.Generator.Model.Members;
 using AhkWin32.Generator.Model.Types;
@@ -8,21 +9,18 @@ using AhkWin32.Generator.Model.Types;
 /// Emits ComInterfaceType as a complete .ahk file.
 /// Port of legacy AhkComInterface.ToAhk().
 /// </summary>
-public sealed class ComInterfaceEmitter : ITypeEmitter
+public sealed class ComInterfaceEmitter(TypeRegistry registry, AhkVersion version) : ITypeEmitter
 {
-    private readonly TypeRegistry _registry;
+    private readonly TypeRegistry _registry = registry;
 
-    public ComInterfaceEmitter(TypeRegistry registry)
-    {
-        _registry = registry;
-    }
+    private readonly AhkVersion _version = version;
 
     public bool CanEmit(Win32Type type) => type is ComInterfaceType;
 
     public EmitResult Emit(Win32Type type, string outputRoot)
     {
         var comType = (ComInterfaceType)type;
-        var w = new AhkWriter();
+        var w = new AhkWriter(_version);
 
         EmitComInterface(w, comType);
 
@@ -32,14 +30,7 @@ public sealed class ComInterfaceEmitter : ITypeEmitter
 
     private void EmitComInterface(AhkWriter w, ComInterfaceType comType)
     {
-        // --- Headers ---
-        string pathToBase = ImportResolver.GetPathToBase(comType.Namespace);
-        w.Require("AutoHotkey v2.0.0 64-bit");
-        w.Include($"{pathToBase}Win32ComInterface.ahk");
-        w.Include($"{pathToBase}Guid.ahk");
-
-        // Referenced type imports (filter self-references)
-        EmitImports(w, comType);
+        EmitHeaders(w, comType);
 
         w.BlankLine();
 
@@ -72,12 +63,42 @@ public sealed class ComInterfaceEmitter : ITypeEmitter
         }
     }
 
-    private static void EmitImports(AhkWriter w, ComInterfaceType comType)
+    private void EmitHeaders(AhkWriter w, ComInterfaceType comType)
     {
-        foreach (string import in comType.ReferencedTypes.Distinct()
-            .Where(fqn => fqn != comType.FQN))
+        string pathToBase = ImportResolver.GetPathToBase(comType.Namespace);
+        if (_version is AhkVersion.v21)
         {
-            w.Include(ImportResolver.GetIncludePath(comType.Namespace, import));
+            w.Require("AutoHotkey v2.1-alpha+ 64-bit");
+            w.Import($"{pathToBase}Win32ComInterface.ahk", ["Win32ComInterface"]);
+            w.Import($"{pathToBase}Guid.ahk", ["Guid"]);
+        }
+        else
+        {
+            w.Require("AutoHotkey v2.0.0 64-bit");
+            w.Include($"{pathToBase}Win32ComInterface.ahk");
+            w.Include($"{pathToBase}Guid.ahk");
+        }
+        
+        EmitImports(w, comType);
+    }
+
+    private void EmitImports(AhkWriter w, ComInterfaceType comType)
+    {
+        IEnumerable<string> imports = comType.ReferencedTypes
+            .Distinct()
+            .Where(fqn => fqn != comType.FQN);
+        foreach (string fqn in imports)
+        {
+            string path = ImportResolver.GetIncludePath(comType.Namespace, fqn);
+            if (_version is AhkVersion.v21)
+            {
+                string name = ImportResolver.GetImportName(fqn);
+                w.Import(path, [name]);
+            }
+            else
+            {
+                w.Include(path);
+            }
         }
     }
 

--- a/Generator/Emit/Emitters/ComInterfaceEmitter.cs
+++ b/Generator/Emit/Emitters/ComInterfaceEmitter.cs
@@ -78,7 +78,7 @@ public sealed class ComInterfaceEmitter(TypeRegistry registry, AhkVersion versio
             w.Include($"{pathToBase}Win32ComInterface.ahk");
             w.Include($"{pathToBase}Guid.ahk");
         }
-        
+
         EmitImports(w, comType);
     }
 

--- a/Generator/Emit/Emitters/ComInterfaceEmitter21.cs
+++ b/Generator/Emit/Emitters/ComInterfaceEmitter21.cs
@@ -1,0 +1,283 @@
+namespace AhkWin32.Generator.Emit.Emitters;
+
+using AhkWin32.Generator.Metadata;
+using AhkWin32.Generator.Model;
+using AhkWin32.Generator.Model.Members;
+using AhkWin32.Generator.Model.Types;
+
+/// <summary>
+/// Emits a ComInterfaceType as a v2.1 native <c>struct</c>:
+/// <list type="bullet">
+///   <item><description>Outer struct holds the vtable pointer at offset 0 (inherited from
+///   <c>Win32ComInterface</c>'s <c>vtbl : IntPtr</c>), retyped per-interface via a
+///   trailing <c>DefineProp</c> call so <c>this.vtbl.MethodName</c> is typed.</description></item>
+///
+///   <item><description>Nested <c>struct Vtbl extends Base.Vtbl { fn : IntPtr ... }</c> carries
+///   the function-pointer layout via struct inheritance; no <c>VTableNames</c> array or
+///   <c>vTableOffset</c> integer is emitted.</description></item>
+///
+///   <item><description>Generated <c>Implement</c> and <c>Dispose</c> chain via <c>super</c>
+///   and wire callbacks with statically-known parameter counts. IUnknown opts out: its
+///   <c>Implement</c>/<c>Dispose</c> live in its extension YAML, where the optional-override
+///   logic for QI/AddRef/Release is hand-coded.</description></item>
+///
+///   <item><description></description></item>
+/// </list>
+/// </summary>
+public sealed class ComInterfaceEmitter21(TypeRegistry registry) : ITypeEmitter
+{
+    private readonly TypeRegistry _registry = registry;
+
+    public bool CanEmit(Win32Type type) => type is ComInterfaceType;
+
+    public EmitResult Emit(Win32Type type, string outputRoot)
+    {
+        var comType = (ComInterfaceType)type;
+        var w = new AhkWriter(AhkVersion.v21);
+
+        EmitComInterface(w, comType);
+
+        string filePath = ImportResolver.GetFilePath(outputRoot, comType.Namespace, comType.CanonicalName);
+        return new EmitResult(w.ToString(), filePath);
+    }
+
+    private void EmitComInterface(AhkWriter w, ComInterfaceType comType)
+    {
+        EmitHeaders(w, comType);
+
+        w.BlankLine();
+
+        DocCommentWriter.WriteTypeDoc(w, comType);
+
+        string baseClass = comType.BaseInterfaceName ?? "Win32ComInterface";
+        using (w.Struct(comType.Name, baseClass))
+        {
+            EmitStaticIdentifiers(w, comType);
+            EmitStaticNew(w, comType);
+
+            // Nested Vtbl struct - one IntPtr per method on THIS interface.
+            // Parent methods come via `extends Base.Vtbl`.
+            EmitVtblStruct(w, comType);
+
+            EmitNew(w, comType);
+
+            // Property accessors
+            foreach (var prop in comType.Properties)
+            {
+                w.BlankLine();
+                EmitProperty(w, prop);
+            }
+
+            // Method wrappers (ComCall by absolute vtable index)
+            foreach (var method in comType.Methods)
+            {
+                w.BlankLine();
+                MethodEmitter.EmitComMethod(w, method, _registry, AhkVersion.v21);
+            }
+
+            EmitQuery(w, comType);
+
+            // IUnknown's Implement/Dispose handle optional QI/AddRef/Release overrides and
+            // live in IUnknown.yml. Every other interface gets generated implementations.
+            if (comType.BaseInterfaceFQN is not null)
+            {
+                w.BlankLine();
+                EmitImplement(w, comType);
+
+                w.BlankLine();
+                EmitDispose(w, comType);
+            }
+
+            StructEmitter21.EmitExtensions(w, comType);
+        }
+    }
+
+    /// <summary>
+    /// Retype the inherited `vtbl` field on this prototype so `this.vtbl.MethodName`
+    ///is typed against THIS interface's Vtbl rather than Win32ComInterface's IntPtr.
+    /// </summary>
+    private static void EmitStaticNew(AhkWriter w, ComInterfaceType comType)
+    {
+        w.BlankLine();
+        using (w.StaticMethod("__New", ""))
+        {
+            w.Line("; Retype our prototype's vtable pointer to be our vtbl's type");
+            w.Line("DefineProp(this.Prototype, 'vtbl', { type: this.Vtbl.Ptr, offset: 0 })");
+            w.Line("this.DeleteProp(\"__New\")");
+        }
+    }
+
+    /// <summary>
+    /// Emit the instance constructor. This allocates the vtable and shells out to the
+    /// base constructor.
+    /// </summary>
+    /// <param name="w"></param>
+    /// <param name="comType"></param>
+    private static void EmitNew(AhkWriter w, ComInterfaceType comType)
+    {
+        w.BlankLine();
+        using (w.InstanceMethod("__New", "implObj := 0, flags := \"\""))
+        {
+            using (w.If("NumGet(this, 0, \"ptr\") == 0"))
+            {
+                w.Line($"this.vtbl := {comType.Name}.Vtbl()");
+            }
+            w.Line($"super.__New(implObj, flags)");
+        }
+    }
+
+    private static void EmitQuery(AhkWriter w, ComInterfaceType comType)
+    {
+        w.BlankLine();
+        using (w.InstanceMethod("Query", "iid"))
+        {
+            using (w.If($"{comType.Name}.IID.Equals(iid)"))
+            {
+                w.Line("return true");
+            }
+            w.Line("return super.Query(iid)");
+        }
+    }
+
+    private static void EmitHeaders(AhkWriter w, ComInterfaceType comType)
+    {
+        w.Require("AutoHotkey v2.1-alpha.30+ 64-bit");
+
+        // The COM-runtime fixtures (Win32ComInterface, Win32Struct, Guid) live at the
+        // projection root regardless of namespace; emit explicit imports rather than
+        // routing through the per-FQN ImportResolver paths.
+        string pathToBase = ImportResolver.GetPathToBase(comType.Namespace);
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        WriteImport(w, $"{pathToBase}Win32ComInterface.ahk", "Win32ComInterface", seen);
+        WriteImport(w, $"{pathToBase}Guid.ahk", "Guid", seen);
+
+        foreach (string fqn in comType.Imports.GetTypes().Where(f => f != comType.FQN))
+        {
+            string path = ImportResolver.GetIncludePath(comType.Namespace, fqn);
+            WriteImport(w, path, ImportResolver.GetImportName(fqn), seen);
+        }
+
+        foreach (string apisFqn in comType.Imports.GetFunctionNamespaces())
+        {
+            string path = ImportResolver.GetIncludePath(comType.Namespace, apisFqn);
+            w.Import(path, comType.Imports.GetFunctionsForNamespace(apisFqn));
+        }
+    }
+
+    private static void WriteImport(AhkWriter w, string path, string name, HashSet<string> seen)
+    {
+        if (!seen.Add(name))
+            return;
+        w.Import(path, [name]);
+    }
+
+    /// <summary>Emit static IID and optional CLSID fields.</summary>
+    private static void EmitStaticIdentifiers(AhkWriter w, ComInterfaceType comType)
+    {
+        if (comType.IID is { } iid)
+        {
+            w.Line("/**");
+            w.Line($" * The interface identifier for {comType.Name}");
+            w.Line(" * @type {Guid}");
+            w.Line(" */");
+            w.Line($"static IID := Guid(\"{{{iid}}}\")");
+        }
+
+        if (comType.CLSID is { } clsid)
+        {
+            w.BlankLine();
+            w.Line("/**");
+            w.Line($" * The class identifier for {comType.Name.TrimStart('I')}");
+            w.Line(" * @type {Guid}");
+            w.Line(" */");
+            w.Line($"static CLSID := Guid(\"{{{clsid}}}\")");
+        }
+    }
+
+    /// <summary>
+    /// Emit the nested <c>struct Vtbl { ... }</c>. For root interfaces (IUnknown) no base
+    /// is used; otherwise <c>extends Base.Vtbl</c> threads the parent's slots in declaration
+    /// order at the start of the vtable.
+    /// </summary>
+    private static void EmitVtblStruct(AhkWriter w, ComInterfaceType comType)
+    {
+        w.BlankLine();
+
+        string? vtblBase = comType.BaseInterfaceName is { } baseName ? $"{baseName}.Vtbl" : null;
+        int align = comType.Methods.Any() ? comType.Methods.Max(m => m.DeduplicatedName.Length) : 0;
+
+        w.Line("/**");
+        w.Line(" * The {@link https://devblogs.microsoft.com/oldnewthing/20040205-00/?p=40733 Virtual Function Table}");
+        w.Line($" * used for {comType.Name} interfaces");
+        w.Line("*/");
+
+        using (w.Struct("Vtbl", vtblBase))
+        {
+            foreach (var method in comType.Methods)
+            {
+                w.Line($"{method.DeduplicatedName.PadRight(align)} : IntPtr");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Emit a single COM property (documentation + get/set block).
+    /// </summary>
+    private static void EmitProperty(AhkWriter w, ComPropertyMember prop)
+    {
+        DocCommentWriter.WritePropertyDoc(w, prop);
+        using (w.InstanceProperty(prop.Name))
+        {
+            if (prop.Getter is not null)
+                w.Line($"get => this.{prop.Getter.DeduplicatedName}()");
+
+            if (prop.Setter is not null)
+                w.Line($"set => this.{prop.Setter.DeduplicatedName}(value)");
+        }
+    }
+
+    /// <summary>
+    /// Emit <c>Implement(implObj, flags := "")</c>: chain to super, then wire each
+    /// method on this interface via <c>CallbackCreate</c> with the COM-ABI parameter
+    /// count (declared params + 1 for the C++ this pointer).
+    /// </summary>
+    private static void EmitImplement(AhkWriter w, ComInterfaceType comType)
+    {
+        using (w.InstanceMethod("Implement", "implObj, flags := \"\""))
+        {
+            w.Line("super.Implement(implObj, flags)");
+            foreach (ComMethodMember method in comType.Methods)
+            {
+                // C++ ABI passes `this` + every declared parameter. Parameters[0] is the
+                // return-value slot in the IR, so Parameters.Count = 1 (return) + N (declared),
+                // which is exactly the cppThis + N callback args we need.
+                int paramCount = method.Parameters.Count;
+                w.Line(
+                    $"this.vtbl.{method.DeduplicatedName} := CallbackCreate("
+                        + $"GetMethod(implObj, \"{method.DeduplicatedName}\"), flags, {paramCount})"
+                );
+            }
+        }
+    }
+
+    /// <summary>
+    /// Emit <c>Dispose()</c>: chain to super, then <c>CallbackFree</c> each callback this
+    /// interface installed.
+    /// </summary>
+    private static void EmitDispose(AhkWriter w, ComInterfaceType comType)
+    {
+        using (w.InstanceMethod("Dispose", ""))
+        {
+            using (w.If("!this.owned"))
+            {
+                w.Line("throw MethodError(\"Cannot dispose of an unowned interface\", -1, this)");
+            }
+
+            w.Line("super.Dispose()");
+            foreach (var method in comType.Methods)
+            {
+                w.Line($"CallbackFree(this.vtbl.{method.DeduplicatedName})");
+            }
+        }
+    }
+}

--- a/Generator/Emit/Emitters/ComInterfaceEmitter21.cs
+++ b/Generator/Emit/Emitters/ComInterfaceEmitter21.cs
@@ -118,7 +118,9 @@ public sealed class ComInterfaceEmitter21(TypeRegistry registry) : ITypeEmitter
         w.BlankLine();
         using (w.InstanceMethod("__New", "implObj := 0, flags := \"\""))
         {
-            using (w.If("NumGet(this, 0, \"ptr\") == 0"))
+            // Read offset 0 via the intrinsic backing address: `this` marshals as the
+            // overridden `Ptr` (comPtr), which is still 0 this early in construction.
+            using (w.If("NumGet(ObjGetDataPtr(this), 0, \"ptr\") == 0"))
             {
                 w.Line($"this.vtbl := {comType.Name}.Vtbl()");
             }

--- a/Generator/Emit/Emitters/ConstantEmitter.cs
+++ b/Generator/Emit/Emitters/ConstantEmitter.cs
@@ -1,5 +1,6 @@
 namespace AhkWin32.Generator.Emit.Emitters;
 
+using AhkWin32.Generator.Metadata;
 using AhkWin32.Generator.Model;
 using AhkWin32.Generator.Model.Members;
 
@@ -68,7 +69,7 @@ public static class ConstantEmitter
                 break;
 
             case StructConstantValue { IsHandle: false } sv:
-                EmitStructConstantFunction(w, constant.Name, sv, names);
+                EmitStructConstantVariable(w, constant.Name, sv, names);
                 break;
 
             default:
@@ -90,18 +91,19 @@ public static class ConstantEmitter
     }
 
     /// <summary>
-    /// Emit a struct constant as a function that returns the struct. For v2.1
+    /// Emit a struct constant as a global (auto-execute) varable. For v2.1
     /// </summary>
-    private static void EmitStructConstantFunction(
+    private static void EmitStructConstantVariable(
         AhkWriter w,
         string name,
         StructConstantValue sv,
         ModuleNameResolver names
     )
     {
-        using (w.Function(name))
+        w.Line($"export global {name} := {names?.ForType(sv.StructFQN) ?? sv.StructName}()");
+        foreach (StructFieldInit init in sv.FieldInits ?? [])
         {
-            EmitStructConstantInitializers(w, sv, names);
+            EmitFieldInit(w, init, AhkVersion.v21, name);
         }
     }
 
@@ -120,7 +122,7 @@ public static class ConstantEmitter
 
             foreach (StructFieldInit init in sv.FieldInits ?? [])
             {
-                EmitFieldInit(w, init);
+                EmitFieldInit(w, init, AhkVersion.v20, "value");
             }
 
             w.Line("return value");
@@ -130,25 +132,52 @@ public static class ConstantEmitter
     /// <summary>
     /// Emit a single field initialization line based on its kind.
     /// </summary>
-    private static void EmitFieldInit(AhkWriter w, StructFieldInit init)
+    private static void EmitFieldInit(AhkWriter w, StructFieldInit init, AhkVersion version, string prefix)
     {
+        string fieldPath = $"{prefix}.{string.Join(".", init.FieldPath)}";
+
         switch (init.Kind)
         {
             case StructFieldInitKind.Direct:
-                w.Line($"{init.FieldPath} := {init.Value}");
+                w.Line($"{fieldPath} := {init.Value}");
                 break;
 
             case StructFieldInitKind.ArrayElement:
-                w.Line($"{init.FieldPath}[{init.ArrayIndex}] := {init.Value}");
+                w.Line($"{fieldPath}[{init.ArrayIndex}] := {init.Value}");
+                break;
+
+            case StructFieldInitKind.Guid:
+                // We can't straightforwardly assign a struct to another struct's embedded struct, we need to copy the
+                // data between pointers. In v2 we have a helper method but in v2.1 we scrapped the custom base class
+                // so we don't have that same utility. They're both RtlCopyMemory under the hood though
+                string copyCode = version switch
+                {
+                    AhkVersion.v20 => $"Guid(\"{{{init.GuidValue:D}}}\").CopyTo({fieldPath}.ptr)",
+                    // TODO this is kind of hacky - probably better to reimplement CopyTo?
+                    // Can't use a projected method because RtoCopyMemory isn't in the projection
+                    // https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-rtlcopymemory
+                    AhkVersion.v21 => $"DllCall(\"NtDll.dll\\RtlCopyMemory\",{Environment.NewLine}"
+                        + $"    IntPtr, ObjGetDataPtr({fieldPath}),{Environment.NewLine}"
+                        + $"    Guid.Ptr, Guid(\"{{{init.GuidValue:D}}}\"),{Environment.NewLine}"
+                        + "    UInt32, 16)",
+                    _ => throw new NotSupportedException("Unreachable: " + version.ToString()),
+                };
+                w.Line(copyCode);
                 break;
 
             case StructFieldInitKind.GuidPointer:
                 // Extract field name from the path for the static variable name
-                string fieldName = init.FieldPath.Contains('.')
-                    ? init.FieldPath[(init.FieldPath.LastIndexOf('.') + 1)..]
-                    : init.FieldPath;
-                w.Line($"static {fieldName}_guid := Guid(\"{{{init.GuidValue:D}}}\")");
-                w.Line($"{init.FieldPath} := {fieldName}_guid.ptr");
+                string fieldName = init.FieldPath[init.FieldPath.Count - 1];
+
+                // Pin a Guid struct to either the method (v2.0) or the module (v2.1)
+                string pinCode = version switch
+                {
+                    AhkVersion.v20 => $"static {fieldName}_guid := Guid(\"{{{init.GuidValue:D}}}\")",
+                    AhkVersion.v21 => $"{fieldName}_guid := Guid(\"{{{init.GuidValue:D}}}\")",
+                    _ => throw new NotSupportedException("Unreachable " + version.ToString()),
+                };
+                w.Line(pinCode);
+                w.Line($"{fieldPath} := {fieldName}_guid.ptr");
                 break;
 
             default:

--- a/Generator/Emit/Emitters/ConstantEmitter.cs
+++ b/Generator/Emit/Emitters/ConstantEmitter.cs
@@ -42,21 +42,70 @@ public static class ConstantEmitter
     }
 
     /// <summary>
+    /// Emit a single constant (doc comment + value) into the writer in an AHK v2.1-compatible way
+    /// </summary>
+    public static void EmitConstant21(AhkWriter w, ConstantMember constant)
+    {
+        DocCommentWriter.WriteConstantDoc(w, constant);
+
+        switch (constant.Value)
+        {
+            case PrimitiveConstantValue pv:
+                w.Variable(constant.Name, pv.FormattedValue);
+                break;
+
+            case GuidConstantValue gv:
+                w.Variable(constant.Name, gv.AsAhk);
+                break;
+
+            case StructConstantValue { IsHandle: true } sv:
+                w.Variable(constant.Name, sv.AsAhk);
+                break;
+
+            case StructConstantValue { IsHandle: false } sv:
+                EmitStructConstantFunction(w, constant.Name, sv);
+                break;
+
+            default:
+                throw new NotSupportedException(
+                    $"Unsupported constant value type: {constant.Value.GetType().Name} for '{constant.Name}'");
+        }
+    }
+
+    /// <summary>
     /// Emit a struct constant as a getter property with field initialization.
     /// </summary>
     private static void EmitStructConstantProperty(AhkWriter w, string name, StructConstantValue sv)
     {
         using (w.Property(name))
+        {
+            EmitStructConstantInitializers(w, sv);
+        }
+    }
+
+    /// <summary>
+    /// Emit a struct constant as a function that returns the struct. For v2.1
+    /// </summary>
+    private static void EmitStructConstantFunction(AhkWriter w, string name, StructConstantValue sv)
+    {
+        using (w.Function(name))
+        {
+            EmitStructConstantInitializers(w, sv);
+        }
+    }
+
+    /// <summary>
+    /// Emit struct fill code for a given struct constant
+    /// </summary>
+    private static void EmitStructConstantInitializers(AhkWriter w, StructConstantValue sv)
+    {
         using (w.GetBlock())
         {
             w.Line($"value := {sv.StructName}()");
 
-            if (sv.FieldInits != null)
+            foreach (StructFieldInit init in sv.FieldInits ?? [])
             {
-                foreach (StructFieldInit init in sv.FieldInits)
-                {
-                    EmitFieldInit(w, init);
-                }
+                EmitFieldInit(w, init);
             }
 
             w.Line("return value");

--- a/Generator/Emit/Emitters/ConstantEmitter.cs
+++ b/Generator/Emit/Emitters/ConstantEmitter.cs
@@ -65,7 +65,7 @@ public static class ConstantEmitter
             case StructConstantValue { IsHandle: true } sv:
                 // Reconstruct the handle wrapper using the resolved (possibly aliased) type name
                 // rather than the pre-baked AsAhk string, which embeds the raw StructName.
-                w.Variable(constant.Name, $"{names.ForType(sv.StructFQN)}({{Value: {sv.HandleValue}}}, false)");
+                w.Variable(constant.Name, $"{names.ForType(sv.StructFQN)}({sv.HandleValue})");
                 break;
 
             case StructConstantValue { IsHandle: false } sv:

--- a/Generator/Emit/Emitters/ConstantEmitter.cs
+++ b/Generator/Emit/Emitters/ConstantEmitter.cs
@@ -37,7 +37,8 @@ public static class ConstantEmitter
 
             default:
                 throw new NotSupportedException(
-                    $"Unsupported constant value type: {constant.Value.GetType().Name} for '{constant.Name}'");
+                    $"Unsupported constant value type: {constant.Value.GetType().Name} for '{constant.Name}'"
+                );
         }
     }
 
@@ -68,7 +69,8 @@ public static class ConstantEmitter
 
             default:
                 throw new NotSupportedException(
-                    $"Unsupported constant value type: {constant.Value.GetType().Name} for '{constant.Name}'");
+                    $"Unsupported constant value type: {constant.Value.GetType().Name} for '{constant.Name}'"
+                );
         }
     }
 
@@ -137,8 +139,7 @@ public static class ConstantEmitter
                 break;
 
             default:
-                throw new NotSupportedException(
-                    $"Unsupported struct field init kind: {init.Kind}");
+                throw new NotSupportedException($"Unsupported struct field init kind: {init.Kind}");
         }
     }
 }

--- a/Generator/Emit/Emitters/ConstantEmitter.cs
+++ b/Generator/Emit/Emitters/ConstantEmitter.cs
@@ -43,9 +43,11 @@ public static class ConstantEmitter
     }
 
     /// <summary>
-    /// Emit a single constant (doc comment + value) into the writer in an AHK v2.1-compatible way
+    /// Emit a single constant (doc comment + value) into the writer in an AHK v2.1-compatible way.
+    /// <paramref name="names"/> resolves referenced type names to their local (possibly aliased)
+    /// identifier so struct/handle constants keep working when their type was deconflicted.
     /// </summary>
-    public static void EmitConstant21(AhkWriter w, ConstantMember constant)
+    public static void EmitConstant21(AhkWriter w, ConstantMember constant, ModuleNameResolver names)
     {
         DocCommentWriter.WriteConstantDoc(w, constant);
 
@@ -60,11 +62,13 @@ public static class ConstantEmitter
                 break;
 
             case StructConstantValue { IsHandle: true } sv:
-                w.Variable(constant.Name, sv.AsAhk);
+                // Reconstruct the handle wrapper using the resolved (possibly aliased) type name
+                // rather than the pre-baked AsAhk string, which embeds the raw StructName.
+                w.Variable(constant.Name, $"{names.ForType(sv.StructFQN)}({{Value: {sv.HandleValue}}}, false)");
                 break;
 
             case StructConstantValue { IsHandle: false } sv:
-                EmitStructConstantFunction(w, constant.Name, sv);
+                EmitStructConstantFunction(w, constant.Name, sv, names);
                 break;
 
             default:
@@ -88,22 +92,31 @@ public static class ConstantEmitter
     /// <summary>
     /// Emit a struct constant as a function that returns the struct. For v2.1
     /// </summary>
-    private static void EmitStructConstantFunction(AhkWriter w, string name, StructConstantValue sv)
+    private static void EmitStructConstantFunction(
+        AhkWriter w,
+        string name,
+        StructConstantValue sv,
+        ModuleNameResolver names
+    )
     {
         using (w.Function(name))
         {
-            EmitStructConstantInitializers(w, sv);
+            EmitStructConstantInitializers(w, sv, names);
         }
     }
 
     /// <summary>
     /// Emit struct fill code for a given struct constant
     /// </summary>
-    private static void EmitStructConstantInitializers(AhkWriter w, StructConstantValue sv)
+    private static void EmitStructConstantInitializers(
+        AhkWriter w,
+        StructConstantValue sv,
+        ModuleNameResolver? names = null
+    )
     {
         using (w.GetBlock())
         {
-            w.Line($"value := {sv.StructName}()");
+            w.Line($"value := {names?.ForType(sv.StructFQN) ?? sv.StructName}()");
 
             foreach (StructFieldInit init in sv.FieldInits ?? [])
             {

--- a/Generator/Emit/Emitters/EnumEmitter.cs
+++ b/Generator/Emit/Emitters/EnumEmitter.cs
@@ -1,5 +1,6 @@
 namespace AhkWin32.Generator.Emit.Emitters;
 
+using AhkWin32.Generator.Metadata;
 using AhkWin32.Generator.Model.Types;
 
 /// <summary>
@@ -68,10 +69,11 @@ public sealed class EnumEmitter : ITypeEmitter
 
         foreach (var ext in enumType.Extensions)
         {
-            // Replace tokens (only $Class for now)
-            string code = ext.Code.Replace("$Class", enumType.Name);
+            if (!ext.CodeByVersion.TryGetValue(AhkVersion.v20, out string? rawCode))
+                continue;
 
-            // Indent extension code to current level (inside class body)
+            string code = rawCode.Replace("$Class", enumType.Name);
+
             string indentStr = w.CurrentIndent;
             string indented = indentStr + code.Replace("\n", "\n" + indentStr);
             w.RawLine(indented);

--- a/Generator/Emit/Emitters/EnumEmitter.cs
+++ b/Generator/Emit/Emitters/EnumEmitter.cs
@@ -54,8 +54,8 @@ public sealed class EnumEmitter : ITypeEmitter
 
     private static void EmitImports(AhkWriter w, EnumType enumType)
     {
-        // Enum referenced types come only from extensions
-        foreach (string import in enumType.ReferencedTypes.Distinct())
+        // Enum imports come only from extensions
+        foreach (string import in enumType.Imports.GetIncludeTargets())
         {
             w.Include(ImportResolver.GetIncludePath(enumType.Namespace, import));
         }

--- a/Generator/Emit/Emitters/EnumEmitter.cs
+++ b/Generator/Emit/Emitters/EnumEmitter.cs
@@ -63,7 +63,8 @@ public sealed class EnumEmitter : ITypeEmitter
 
     private static void EmitExtensions(AhkWriter w, EnumType enumType)
     {
-        if (enumType.Extensions.Count == 0) return;
+        if (enumType.Extensions.Count == 0)
+            return;
 
         foreach (var ext in enumType.Extensions)
         {

--- a/Generator/Emit/Emitters/EnumEmitter21.cs
+++ b/Generator/Emit/Emitters/EnumEmitter21.cs
@@ -1,0 +1,83 @@
+namespace AhkWin32.Generator.Emit.Emitters;
+
+using AhkWin32.Generator.Metadata;
+using AhkWin32.Generator.Model.Types;
+
+/// <summary>
+/// Emits an EnumType as a v2.1 native <c>struct</c>. The struct carries a
+/// <c>value</c> field plus <c>__value</c> get/set so an instance of the enum class
+/// can be used as a typed DllCall parameter; AHK coerces an incoming int via the
+/// <c>__value</c> setter. The enum's constants remain plain integer static
+/// properties (matching v2.0), so bitflag OR-ing and equality comparisons against
+/// constants keep working naturally.
+///
+/// IsFlags enums use the same shape - operator overloading isn't available on
+/// structs in v2.1, so there's no benefit to a separate code path.
+/// </summary>
+public sealed class EnumEmitter21 : ITypeEmitter
+{
+    public bool CanEmit(Win32Type type) => type is EnumType;
+
+    public EmitResult Emit(Win32Type type, string outputRoot)
+    {
+        var enumType = (EnumType)type;
+        var w = new AhkWriter(AhkVersion.v21);
+
+        EmitEnum(w, enumType);
+
+        string filePath = ImportResolver.GetFilePath(outputRoot, enumType.Namespace, enumType.CanonicalName);
+        return new EmitResult(w.ToString(), filePath);
+    }
+
+    private static void EmitEnum(AhkWriter w, EnumType enumType)
+    {
+        w.Require("AutoHotkey v2.1-alpha.26+ 64-bit");
+
+        EmitImports(w, enumType);
+
+        w.BlankLine();
+
+        DocCommentWriter.WriteTypeDoc(w, enumType);
+
+        using (w.Struct(enumType.Name))
+        {
+            w.Line($"value : {enumType.UnderlyingTypeName}");
+
+            w.BlankLine();
+            using (w.InstanceProperty("__value"))
+            {
+                w.Line("get => this.value");
+                w.Line("set => this.value := value");
+            }
+
+            w.BlankLine();
+            using (w.InstanceMethod("__New", "value := 0"))
+            {
+                w.Line("this.value := value");
+            }
+
+            foreach (var constant in enumType.Constants)
+            {
+                w.BlankLine();
+                ConstantEmitter.EmitConstant(w, constant);
+            }
+
+            StructEmitter21.EmitExtensions(w, enumType);
+        }
+    }
+
+    private static void EmitImports(AhkWriter w, EnumType enumType)
+    {
+        foreach (string fqn in enumType.Imports.GetTypes().Where(fqn => fqn != enumType.FQN))
+        {
+            string path = ImportResolver.GetIncludePath(enumType.Namespace, fqn);
+            w.Import(path, [ImportResolver.GetImportName(fqn)]);
+        }
+
+        foreach (string apisFqn in enumType.Imports.GetFunctionNamespaces())
+        {
+            string path = ImportResolver.GetIncludePath(enumType.Namespace, apisFqn);
+            w.Import(path, enumType.Imports.GetFunctionsForNamespace(apisFqn));
+        }
+    }
+}

--- a/Generator/Emit/Emitters/HandleEmitter21.cs
+++ b/Generator/Emit/Emitters/HandleEmitter21.cs
@@ -5,7 +5,6 @@ using AhkWin32.Generator.Model.Members;
 using AhkWin32.Generator.Model.Types;
 using YamlDotNet.Core.Tokens;
 
-
 /// <summary>
 /// Emits a HandleType as a v2.1 native `struct` block. Handles are emitted as a
 /// single-field struct with `__value` get/set so the instance is transparently

--- a/Generator/Emit/Emitters/HandleEmitter21.cs
+++ b/Generator/Emit/Emitters/HandleEmitter21.cs
@@ -48,8 +48,18 @@ public sealed class HandleEmitter21 : ITypeEmitter
             w.BlankLine();
             using (w.InstanceProperty("__value"))
             {
-                w.Line($"get => this.{valueField.Name}");
-                w.Line($"set => this.{valueField.Name} := value");
+                using (w.SetBlock())
+                {
+                    // TODO accept values from AlsoUsableFor attribute (need to decode too)
+                    using (w.If($"value is {handleType.Name}"))
+                    {
+                        w.Line($"this.{valueField.Name} := value.{valueField.Name}");
+                    }
+                    using (w.Else())
+                    {
+                        w.Line($"this.{valueField.Name} := value");
+                    }
+                }
             }
 
             w.BlankLine();

--- a/Generator/Emit/Emitters/HandleEmitter21.cs
+++ b/Generator/Emit/Emitters/HandleEmitter21.cs
@@ -3,7 +3,6 @@ namespace AhkWin32.Generator.Emit.Emitters;
 using AhkWin32.Generator.Metadata;
 using AhkWin32.Generator.Model.Members;
 using AhkWin32.Generator.Model.Types;
-using YamlDotNet.Core.Tokens;
 
 /// <summary>
 /// Emits a HandleType as a v2.1 native `struct` block. Handles are emitted as a
@@ -32,7 +31,7 @@ public sealed class HandleEmitter21 : ITypeEmitter
     {
         w.Require("AutoHotkey v2.1-alpha.26+ 64-bit");
 
-        EmitImports(w, handleType);
+        SingleFieldEmitter.EmitImports(w, handleType);
 
         w.BlankLine();
 
@@ -46,21 +45,7 @@ public sealed class HandleEmitter21 : ITypeEmitter
             w.Line($"{valueField.Name} : {valueField.Type.TypeSpecifier}");
 
             w.BlankLine();
-            using (w.InstanceProperty("__value"))
-            {
-                using (w.SetBlock())
-                {
-                    // TODO accept values from AlsoUsableFor attribute (need to decode too)
-                    using (w.If($"value is {handleType.Name}"))
-                    {
-                        w.Line($"this.{valueField.Name} := value.{valueField.Name}");
-                    }
-                    using (w.Else())
-                    {
-                        w.Line($"this.{valueField.Name} := value");
-                    }
-                }
-            }
+            SingleFieldEmitter.EmitValueSetter(w, handleType, valueField.Name);
 
             w.BlankLine();
             w.Line("/**");
@@ -87,21 +72,6 @@ public sealed class HandleEmitter21 : ITypeEmitter
                 w.Line($"    this.{valueField.Name} := {firstInvalid}");
                 w.Line("}");
             }
-        }
-    }
-
-    private static void EmitImports(AhkWriter w, Win32Type type)
-    {
-        foreach (string fqn in type.Imports.GetTypes().Where(fqn => fqn != type.FQN))
-        {
-            string path = ImportResolver.GetIncludePath(type.Namespace, fqn);
-            w.Import(path, [ImportResolver.GetImportName(fqn)]);
-        }
-
-        foreach (string apisFqn in type.Imports.GetFunctionNamespaces())
-        {
-            string path = ImportResolver.GetIncludePath(type.Namespace, apisFqn);
-            w.Import(path, type.Imports.GetFunctionsForNamespace(apisFqn));
         }
     }
 }

--- a/Generator/Emit/Emitters/HandleEmitter21.cs
+++ b/Generator/Emit/Emitters/HandleEmitter21.cs
@@ -1,5 +1,6 @@
 namespace AhkWin32.Generator.Emit.Emitters;
 
+using System.Runtime.InteropServices.Swift;
 using AhkWin32.Generator.Metadata;
 using AhkWin32.Generator.Model.Members;
 using AhkWin32.Generator.Model.Types;
@@ -69,14 +70,101 @@ public sealed class HandleEmitter21 : ITypeEmitter
             // Extension code blocks (e.g. helper methods from metadata/extensions/*.yml)
             StructEmitter21.EmitExtensions(w, handleType);
 
-            // Free() is emitted but NOT auto-invoked via __delete.
+            // If we have a free function, emit a Free() method, an `Owned` subclass that
+            // calls it automatically in __Delete, an `OwnedWith()` factory for handles
+            // freed by a context-specific function, and an `Adopt()` method that converts
+            // a handle to an owned handle.
             if (handleType.FreeFunc is not null)
             {
+                // "handle is still valid" guard, shared by Free() and __FreeWith(). Treats 0 as
+                // invalid in addition to the metadata-declared invalid values, making free
+                // idempotent (so a moved-from handle is a no-op).
+                string validGuard = string.Join(
+                    " && ",
+                    handleType.InvalidValues.Append(0).Distinct().Select(val => $"this.{valueField.Name} != {val}")
+                );
+
                 w.BlankLine();
-                w.Line("Free() {");
-                w.Line($"    {handleType.FreeFunc.Name}(this.{valueField.Name})");
-                w.Line($"    this.{valueField.Name} := {firstInvalid}");
-                w.Line("}");
+                using (w.InstanceMethod("Free", ""))
+                {
+                    w.Line("; Do nothing if the handle is invalid already");
+                    using (w.If(validGuard))
+                    {
+                        w.Line($"{handleType.FreeFunc.Name}(this.{valueField.Name})");
+                        w.Line($"this.{valueField.Name} := {firstInvalid}");
+                    }
+                }
+
+                w.BlankLine();
+                w.Line("/**");
+                w.Line($" * A `{handleType.Name}` which is owned by the script and which frees itself");
+                w.Line(" * in `__Delete`.");
+                w.Line(" */");
+                using (w.Struct("Owned", handleType.Name))
+                {
+                    using (w.InstanceMethod("__Delete", ""))
+                    {
+                        w.Line("this.Free()");
+                    }
+                }
+
+                // Only handles actually returned with a context-specific (divergent) RAIIFree need
+                // the OwnedWith factory; gating keeps it off the many handles that never use it.
+                if (handleType.NeedsOwnedWith)
+                {
+                    w.BlankLine();
+                    w.Line("/**");
+                    w.Line(" * Frees this handle using a caller-supplied function rather than the default.");
+                    w.Line(" * Used by `OwnedWith` for handles returned with a context-specific RAIIFree.");
+                    w.Line(" * @param {Func} freeFunc called with the raw handle value");
+                    w.Line(" */");
+                    using (w.InstanceMethod("__FreeWith", "freeFunc"))
+                    {
+                        using (w.If(validGuard))
+                        {
+                            w.Line($"freeFunc(this.{valueField.Name})");
+                            w.Line($"this.{valueField.Name} := {firstInvalid}");
+                        }
+                    }
+
+                    w.BlankLine();
+                    w.Line("/**");
+                    w.Line($" * Returns a cached `{handleType.Name}.Owned` subclass whose `Free()` calls `freeFunc`");
+                    w.Line(" * instead of the default. Used for handles returned with a context-specific");
+                    w.Line(" * RAIIFree (e.g. a HANDLE that must be closed with FindClose, not CloseHandle).");
+                    w.Line(" * @param {Func} freeFunc called with the raw handle value to free it");
+                    w.Line(" * @returns {Class} a subclass of {@link " + handleType.Name + ".Owned}");
+                    w.Line(" */");
+                    using (w.StaticMethod("OwnedWith", "freeFunc"))
+                    {
+                        w.Line("static cache := Map()");
+                        using (w.If("cache.Has(freeFunc)"))
+                        {
+                            w.Line("return cache[freeFunc]");
+                        }
+                        w.Line($"cls := Class({handleType.Name}.Owned)");
+                        w.Line("DefineProp(cls.Prototype, \"Free\", { Call: (self) => self.__FreeWith(freeFunc) })");
+                        w.Line("return cache[freeFunc] := cls");
+                    }
+                }
+
+                w.BlankLine();
+                w.Line("/**");
+                w.Line($" * Takes ownership of this {handleType.Name}, returning an owned handle that frees");
+                w.Line(" * itself when it falls out of scope. This is a *move*: the original handle is");
+                w.Line(" * invalidated so the underlying resource has exactly one owner.");
+                w.Line($" * @returns {{{handleType.Name}.Owned}}");
+                w.Line(" */");
+                using (w.InstanceMethod("Adopt", ""))
+                {
+                    using (w.If($"this is {handleType.Name}.Owned"))
+                    {
+                        w.Line($"throw TypeError(\"Cannot adopt an owned {handleType.Name}\", -1)");
+                    }
+                    w.Line($"owned := {handleType.Name}.Owned(this.{valueField.Name})");
+                    w.Line($"this.{valueField.Name} := {firstInvalid}");
+                    w.Line("return owned");
+                }
             }
         }
     }

--- a/Generator/Emit/Emitters/HandleEmitter21.cs
+++ b/Generator/Emit/Emitters/HandleEmitter21.cs
@@ -72,7 +72,7 @@ public sealed class HandleEmitter21 : ITypeEmitter
 
     private static void EmitImports(AhkWriter w, Win32Type type)
     {
-        foreach (string fqn in type.Imports.GetTypes())
+        foreach (string fqn in type.Imports.GetTypes().Where(fqn => fqn != type.FQN))
         {
             string path = ImportResolver.GetIncludePath(type.Namespace, fqn);
             w.Import(path, [ImportResolver.GetImportName(fqn)]);

--- a/Generator/Emit/Emitters/HandleEmitter21.cs
+++ b/Generator/Emit/Emitters/HandleEmitter21.cs
@@ -45,7 +45,13 @@ public sealed class HandleEmitter21 : ITypeEmitter
             w.Line($"{valueField.Name} : {valueField.Type.TypeSpecifier}");
 
             w.BlankLine();
-            SingleFieldEmitter.EmitValueSetter(w, handleType, valueField.Name);
+            SingleFieldEmitter.EmitValueSetter(
+                w,
+                handleType,
+                valueField.Name,
+                handleType.ValueGetterExpr,
+                handleType.ValueSetterCoerceExpr
+            );
 
             w.BlankLine();
             w.Line("/**");

--- a/Generator/Emit/Emitters/HandleEmitter21.cs
+++ b/Generator/Emit/Emitters/HandleEmitter21.cs
@@ -1,11 +1,18 @@
 namespace AhkWin32.Generator.Emit.Emitters;
 
+using AhkWin32.Generator.Metadata;
+using AhkWin32.Generator.Model.Members;
 using AhkWin32.Generator.Model.Types;
+using YamlDotNet.Core.Tokens;
+
 
 /// <summary>
-/// Emits v2.1 HandleType as a complete .ahk file.
-/// Port of legacy AhkHandle.ToAhk().
-/// Delegates body emission to StructEmitter shared methods.
+/// Emits a HandleType as a v2.1 native `struct` block. Handles are emitted as a
+/// single-field struct with `__value` get/set so the instance is transparently
+/// usable as the underlying integer/pointer in DllCall and assignment.
+///
+/// `Free()` is emitted from <see cref="HandleType.FreeFunc"/> metadata but is NOT
+/// wired into `__delete` - auto-cleanup is the caller's responsibility for now.
 /// </summary>
 public sealed class HandleEmitter21 : ITypeEmitter
 {
@@ -14,7 +21,7 @@ public sealed class HandleEmitter21 : ITypeEmitter
     public EmitResult Emit(Win32Type type, string outputRoot)
     {
         var handleType = (HandleType)type;
-        var w = new AhkWriter();
+        var w = new AhkWriter(AhkVersion.v21);
 
         EmitHandle(w, handleType);
 
@@ -24,27 +31,28 @@ public sealed class HandleEmitter21 : ITypeEmitter
 
     private static void EmitHandle(AhkWriter w, HandleType handleType)
     {
-        string pathToBase = ImportResolver.GetPathToBase(handleType.Namespace);
-
-        // Headers — Win32Handle.ahk comes after imports (matching legacy ordering)
-        w.Require("AutoHotkey v2.1-alpha.24+ 64-bit");
-        w.Import($"{pathToBase}Win32Struct.ahk", ["Win32Struct"]);
+        w.Require("AutoHotkey v2.1-alpha.26+ 64-bit");
 
         EmitImports(w, handleType);
-
-        w.Import($"{pathToBase}Win32Handle.ahk", ["Win32Handle"]);
 
         w.BlankLine();
 
         DocCommentWriter.WriteTypeDoc(w, handleType);
 
-        using (w.Class(handleType.Name, "Win32Handle"))
-        {
-            w.StaticField("sizeof", handleType.Size.ToString());
-            w.BlankLine();
-            w.StaticField("packingSize", handleType.PackingSize.ToString());
+        FieldMember valueField = handleType.Members.Single();
+        long firstInvalid = handleType.InvalidValues.FirstOrDefault(0);
 
-            // Invalid values
+        using (w.Struct(handleType.Name))
+        {
+            w.Line($"{valueField.Name} : {valueField.Type.TypeSpecifier}");
+
+            w.BlankLine();
+            using (w.InstanceProperty("__value"))
+            {
+                w.Line($"get => this.{valueField.Name}");
+                w.Line($"set => this.{valueField.Name} := value");
+            }
+
             w.BlankLine();
             w.Line("/**");
             w.Line(" * The list of values which indicate that the handle is invalid");
@@ -52,19 +60,22 @@ public sealed class HandleEmitter21 : ITypeEmitter
             w.Line(" */");
             w.StaticField("invalidValues", $"[{string.Join(", ", handleType.InvalidValues)}]");
 
-            // Body (member properties, extensions, __New)
-            StructEmitter.EmitBody(w, handleType, 0, [], handleType.Name);
+            w.BlankLine();
+            using (w.InstanceMethod("__New", $"{valueField.Name} := {firstInvalid}"))
+            {
+                w.Line($"this.{valueField.Name} := {valueField.Name}");
+            }
 
-            // Free destructor
-            if (handleType.FreeFunc is not null && handleType.Members.Count > 0)
+            // Extension code blocks (e.g. helper methods from metadata/extensions/*.yml)
+            StructEmitter21.EmitExtensions(w, handleType);
+
+            // Free() is emitted but NOT auto-invoked via __delete.
+            if (handleType.FreeFunc is not null)
             {
                 w.BlankLine();
-                string firstMemberName = handleType.Members[0].Name;
-                long firstInvalidValue = handleType.InvalidValues.FirstOrDefault(0);
-
-                w.Line($"Free(){{");
-                w.Line($"    {handleType.FreeFunc.Name}(this.{firstMemberName})");
-                w.Line($"    this.{firstMemberName} := {firstInvalidValue}");
+                w.Line("Free() {");
+                w.Line($"    {handleType.FreeFunc.Name}(this.{valueField.Name})");
+                w.Line($"    this.{valueField.Name} := {firstInvalid}");
                 w.Line("}");
             }
         }

--- a/Generator/Emit/Emitters/HandleEmitter21.cs
+++ b/Generator/Emit/Emitters/HandleEmitter21.cs
@@ -3,11 +3,11 @@ namespace AhkWin32.Generator.Emit.Emitters;
 using AhkWin32.Generator.Model.Types;
 
 /// <summary>
-/// Emits HandleType as a complete .ahk file.
+/// Emits v2.1 HandleType as a complete .ahk file.
 /// Port of legacy AhkHandle.ToAhk().
 /// Delegates body emission to StructEmitter shared methods.
 /// </summary>
-public sealed class HandleEmitter : ITypeEmitter
+public sealed class HandleEmitter21 : ITypeEmitter
 {
     public bool CanEmit(Win32Type type) => type is HandleType;
 
@@ -27,12 +27,12 @@ public sealed class HandleEmitter : ITypeEmitter
         string pathToBase = ImportResolver.GetPathToBase(handleType.Namespace);
 
         // Headers — Win32Handle.ahk comes after imports (matching legacy ordering)
-        w.Require("AutoHotkey v2.0.0 64-bit");
-        w.Include($"{pathToBase}Win32Struct.ahk");
+        w.Require("AutoHotkey v2.1-alpha.24+ 64-bit");
+        w.Import($"{pathToBase}Win32Struct.ahk", ["Win32Struct"]);
 
         EmitImports(w, handleType);
 
-        w.Include($"{pathToBase}Win32Handle.ahk");
+        w.Import($"{pathToBase}Win32Handle.ahk", ["Win32Handle"]);
 
         w.BlankLine();
 
@@ -63,7 +63,7 @@ public sealed class HandleEmitter : ITypeEmitter
                 long firstInvalidValue = handleType.InvalidValues.FirstOrDefault(0);
 
                 w.Line($"Free(){{");
-                w.Line($"    {handleType.FreeFunc.DeclarerName}.{handleType.FreeFunc.Name}(this.{firstMemberName})");
+                w.Line($"    {handleType.FreeFunc.Name}(this.{firstMemberName})");
                 w.Line($"    this.{firstMemberName} := {firstInvalidValue}");
                 w.Line("}");
             }
@@ -72,9 +72,16 @@ public sealed class HandleEmitter : ITypeEmitter
 
     private static void EmitImports(AhkWriter w, Win32Type type)
     {
-        foreach (string import in type.Imports.GetIncludeTargets())
+        foreach (string fqn in type.Imports.GetTypes())
         {
-            w.Include(ImportResolver.GetIncludePath(type.Namespace, import));
+            string path = ImportResolver.GetIncludePath(type.Namespace, fqn);
+            w.Import(path, [ImportResolver.GetImportName(fqn)]);
+        }
+
+        foreach (string apisFqn in type.Imports.GetFunctionNamespaces())
+        {
+            string path = ImportResolver.GetIncludePath(type.Namespace, apisFqn);
+            w.Import(path, type.Imports.GetFunctionsForNamespace(apisFqn));
         }
     }
 }

--- a/Generator/Emit/Emitters/MethodEmitter.cs
+++ b/Generator/Emit/Emitters/MethodEmitter.cs
@@ -82,7 +82,7 @@ public static class MethodEmitter
         EmitOutputParamMarshalling(w, method, names);
 
         if (method.IsVariadic)
-            EmitVariadicMarshalling(w, method);
+            EmitVariadicMarshalling(w, method, unqualifyApis, names);
 
         w.Line(BuildDllCallExpression(method, unqualifyApis, names));
 
@@ -240,16 +240,22 @@ public static class MethodEmitter
 
     /// <summary>
     /// Emit the varArgs array construction for variadic methods.
-    /// Spreads caller's type/value pairs into an array and appends the calling convention string.
+    /// Spreads caller's type/value pairs into an array and appends the return-type token
+    /// (v2.0: a quoted calling-convention + return-type string; v2.1: a class-ref token).
     /// </summary>
-    private static void EmitVariadicMarshalling(AhkWriter w, MethodMember method)
+    private static void EmitVariadicMarshalling(
+        AhkWriter w,
+        MethodMember method,
+        bool unqualifyApis,
+        ModuleNameResolver? names
+    )
     {
-        string convString = BuildCallingConventionString(method);
         string varArgName = method.VariadicParamName;
-
         w.Line($"varArgs := [{varArgName}*]");
-        if (!string.IsNullOrWhiteSpace(convString))
-            w.Line($"varArgs.Push(\"{convString}\")");
+
+        string retToken = unqualifyApis ? BuildReturnTypeToken(method, names) : QuotedConvString(method);
+        if (!string.IsNullOrWhiteSpace(retToken))
+            w.Line($"varArgs.Push({retToken})");
 
         w.BlankLine();
     }
@@ -257,7 +263,7 @@ public static class MethodEmitter
     // --- DllCall expression ---
 
     /// <summary>
-    /// Build the DllCall calling convention + return type string.
+    /// Build the v2.0 DllCall calling convention + return type string.
     /// Returns e.g. "CDecl", "CDecl int", "int", "HRESULT", or "" (empty).
     /// </summary>
     private static string BuildCallingConventionString(MethodMember method)
@@ -274,6 +280,64 @@ public static class MethodEmitter
 
         return sb.ToString().Trim();
     }
+
+    /// <summary>v2.0 return-type token: the calling-convention string, quoted, or "" when empty.</summary>
+    private static string QuotedConvString(MethodMember method)
+    {
+        string conv = BuildCallingConventionString(method);
+        return string.IsNullOrWhiteSpace(conv) ? "" : $"\"{conv}\"";
+    }
+
+    /// <summary>
+    /// Build the v2.1 DllCall/ComCall return-type token. v2.1 has no CDecl (it's obsolete) and
+    /// uses type classes directly instead of quoted type strings, so named numeric/struct classes
+    /// are emitted unquoted (alias-resolved). Exceptions:
+    /// <list type="bullet">
+    ///     <item>HRESULT renders as the quoted <c>"HRESULT"</c> string so the runtime auto-throws an
+    ///     OSError on failure codes - unless this HRESULT is not flagged to throw, in which case it is
+    ///     returned as a raw <c>Int32</c>.</item>
+    ///     <item>Handle returns render as <c>IntPtr</c> (a raw pointer); <see cref="EmitHandleReturn"/>
+    ///     boxes the value into its handle wrapper afterwards.</item>
+    /// </list>
+    /// Returns "" when the method has no return value to specify.
+    /// </summary>
+    private static string BuildReturnTypeToken(MethodMember method, ModuleNameResolver? names)
+    {
+        if (!method.HasReturnValue)
+            return "";
+
+        ResolvedType retType = method.Parameters[0].Type;
+
+        if (retType is HResultType)
+            return method.ShouldThrowOnHResult ? "\"HRESULT\"" : "Int32";
+
+        return ReturnTypeClassRef(retType, names);
+    }
+
+    /// <summary>
+    /// The v2.1 type-class reference used to convert a return value, alias-resolved for the local
+    /// module. Mirrors <see cref="ResolvedType.TypeSpecifier"/> but routes named types through the
+    /// <see cref="ModuleNameResolver"/>. Pointer-to-named-type returns use the dereferencing
+    /// <c>X.Ptr</c> form; void/opaque/primitive pointers return the raw pointer (<c>IntPtr</c>).
+    /// </summary>
+    private static string ReturnTypeClassRef(ResolvedType type, ModuleNameResolver? names) =>
+        type switch
+        {
+            NativeTypedefRef n => TypeRef(names, n.FQN, n.Name),
+            StructRef s => TypeRef(names, s.FQN, s.Name),
+            EnumRef e => TypeRef(names, e.FQN, e.Name),
+            ComRef c => TypeRef(names, c.FQN, c.Name),
+            NtStatusType => "NTSTATUS",
+            PointerType { Pointee: StructRef s } => $"{TypeRef(names, s.FQN, s.Name)}.Ptr",
+            PointerType { Pointee: HandleRef h } => $"{TypeRef(names, h.FQN, h.Name)}.Ptr",
+            PointerType { Pointee: ComRef c } => $"{TypeRef(names, c.FQN, c.Name)}.Ptr",
+            PointerType { Pointee: NativeTypedefRef n } => $"{TypeRef(names, n.FQN, n.Name)}.Ptr",
+            PointerType { Pointee: EnumRef e } => $"{TypeRef(names, e.FQN, e.Name)}.Ptr",
+            // void*, ptr-to-primitive, function ptr -> return the raw pointer
+            PointerType => "IntPtr",
+            // Primitives: Int32, IntPtr, Float32, ...
+            _ => type.TypeSpecifier,
+        };
 
     private static string BuildDllCallExpression(
         MethodMember method,
@@ -305,11 +369,12 @@ public static class MethodEmitter
         }
         else
         {
-            // Calling convention + return type (inline)
-            string convString = BuildCallingConventionString(method);
-            if (!string.IsNullOrWhiteSpace(convString))
+            // Return type token (inline). v2.1 uses unquoted type-class refs; v2.0 a quoted
+            // calling-convention + return-type string.
+            string retToken = unqualifyApis ? BuildReturnTypeToken(method, names) : QuotedConvString(method);
+            if (!string.IsNullOrWhiteSpace(retToken))
             {
-                sb.Append($", \"{convString}\"");
+                sb.Append($", {retToken}");
             }
         }
 
@@ -467,7 +532,8 @@ public static class MethodEmitter
         ParameterMember fnRetVal = method.OutputParameter ?? method.Parameters[0];
 
         // Handle return (direct HandleRef only — ptr-to-handle output params return raw values)
-        if (fnRetVal.IsHandle)
+        // In 2.1 we don't need to manually box this, we can specify the class itself as the return value
+        if (fnRetVal.IsHandle && !unqualifyApis)
         {
             EmitHandleReturn(w, fnRetVal, registry, unqualifyApis, names);
             return;
@@ -674,11 +740,12 @@ public static class MethodEmitter
             sb.Append(BuildDllCallArguments(method, unqualifyApis));
         }
 
-        // Calling convention + return type
-        string convString = BuildCallingConventionString(method);
-        if (!string.IsNullOrWhiteSpace(convString))
+        // Return type token. v2.1 uses unquoted type-class refs (ComCall defaults to HRESULT when
+        // omitted); v2.0 a quoted calling-convention + return-type string.
+        string retToken = unqualifyApis ? BuildReturnTypeToken(method, null) : QuotedConvString(method);
+        if (!string.IsNullOrWhiteSpace(retToken))
         {
-            sb.Append($", \"{convString}\"");
+            sb.Append($", {retToken}");
         }
 
         sb.Append(')');

--- a/Generator/Emit/Emitters/MethodEmitter.cs
+++ b/Generator/Emit/Emitters/MethodEmitter.cs
@@ -292,6 +292,7 @@ public static class MethodEmitter
             var param = method.Parameters[i];
 
             bool useMarshalVar = param.IsPtrToPrimitive && !param.IsReserved && param != method.OutputParameter;
+            bool isComOutput = param == method.OutputParameter && param.IsPtrToCom;
 
             string marshalAs;
             if (useMarshalVar)
@@ -301,6 +302,14 @@ public static class MethodEmitter
             else if (param.TypeDefName is "PWSTR" or "PSTR")
             {
                 marshalAs = "\"ptr\"";
+            }
+            else if (isComOutput)
+            {
+                // COM out-params need IUri** — pass a raw ptr slot, then wrap the returned
+                // pointer on the way out. A typed `IUri.Ptr` marshal passes the struct buffer
+                // directly, collapsing a level of indirection (the API writes the object
+                // pointer into the struct's vtable slot, breaking subsequent ComCalls).
+                marshalAs = "\"ptr*\"";
             }
             else
             {
@@ -391,7 +400,7 @@ public static class MethodEmitter
             return;
         }
 
-        // COM return (ptr-to-COM output param)
+        // COM return (ptr-to-COM output param): wrap the raw IUri* the API wrote
         if (fnRetVal.IsPtrToCom)
         {
             string comName = GetPointeeName(fnRetVal.Type);

--- a/Generator/Emit/Emitters/MethodEmitter.cs
+++ b/Generator/Emit/Emitters/MethodEmitter.cs
@@ -1,5 +1,6 @@
 namespace AhkWin32.Generator.Emit.Emitters;
 
+using System.CommandLine;
 using AhkWin32.Generator.Metadata;
 using AhkWin32.Generator.Model;
 using AhkWin32.Generator.Model.Members;
@@ -95,7 +96,7 @@ public static class MethodEmitter
             w.BlankLine();
         }
 
-        EmitErrorCheck(w, method, unqualifyApis, names);
+        EmitErrorCheck(w, method, registry, unqualifyApis, names);
         EmitReturnStatement(w, method, registry, unqualifyApis, names);
     }
 
@@ -373,6 +374,7 @@ public static class MethodEmitter
     private static void EmitErrorCheck(
         AhkWriter w,
         MethodMember method,
+        TypeRegistry registry,
         bool unqualifyApis = false,
         ModuleNameResolver? names = null
     )
@@ -415,7 +417,33 @@ public static class MethodEmitter
             string callee = unqualifyApis
                 ? FunctionRef(names, freeWith.ApisFQN, freeWith.Name)
                 : $"{freeWith.DeclarerName}.{freeWith.Name}";
-            w.Line($"    {callee}({param.Name})");
+
+            // Extracting the underlying primitive value guarantees that the call works even when free function
+            // takes an untyped pointer (e.g. CoTaskMemFree takes void*)
+            // TODO we could be stricter - check free function arg type, cast if possible, otherwise use the
+            // primitive escape hatch
+            string paramName = param.Name;
+            switch (param.Type)
+            {
+                case HandleRef handleRef:
+                    string handleMember =
+                        registry.Resolve<HandleType>(handleRef.FQN, Architecture.All)?.Members.Single().Name
+                        ?? throw new NullReferenceException();
+                    paramName = $"{paramName}.{handleMember}";
+                    break;
+                case PointerType pt when pt.Pointee is HandleRef handleRef:
+                    string ptHandleMember =
+                        registry.Resolve<HandleType>(handleRef.FQN, Architecture.All)?.Members.Single().Name
+                        ?? throw new NullReferenceException();
+                    paramName = $"{paramName}.{ptHandleMember}";
+                    break;
+                case NativeTypedefRef:
+                case PointerType pt when pt.Pointee is NativeTypedefRef:
+                    paramName = $"{paramName}.value";
+                    break;
+            }
+
+            w.Line($"    {callee}({paramName})");
         }
 
         w.Line($"    throw OSError({string.Join(" || ", errCodeSources)})");
@@ -621,7 +649,7 @@ public static class MethodEmitter
             EmitOutputParamMarshalling(w, method);
             w.Line(BuildComCallExpression(method, unqualifyApis));
 
-            EmitErrorCheck(w, method, unqualifyApis);
+            EmitErrorCheck(w, method, registry, unqualifyApis);
             EmitReturnStatement(w, method, registry, unqualifyApis);
         }
     }

--- a/Generator/Emit/Emitters/MethodEmitter.cs
+++ b/Generator/Emit/Emitters/MethodEmitter.cs
@@ -438,7 +438,7 @@ public static class MethodEmitter
     private static string GetParamDllCallType(ResolvedType type) => type switch
     {
         PointerType p => p.TypedDllCallType,
-        NativeTypedefType n => GetParamDllCallType(n.Underlying),
+        NativeTypedefRef n => GetParamDllCallType(n.Underlying),
         _ => type.DllCallType
     };
 

--- a/Generator/Emit/Emitters/MethodEmitter.cs
+++ b/Generator/Emit/Emitters/MethodEmitter.cs
@@ -1,5 +1,6 @@
 namespace AhkWin32.Generator.Emit.Emitters;
 
+using AhkWin32.Generator.Metadata;
 using AhkWin32.Generator.Model;
 using AhkWin32.Generator.Model.Members;
 using AhkWin32.Generator.Model.Types;
@@ -20,13 +21,14 @@ public static class MethodEmitter
         string argList = BuildArgumentList(method);
         using (w.StaticMethod(method.Name, argList))
         {
-            EmitDllImportMethodBody(w, method, registry);
-        }   
+            EmitDllImportMethodBody(w, method, registry, unqualifyApis: false);
+        }
     }
 
     /// <summary>
     /// Emit a complete DllImport function (documentation + signature + body). Used in v2.1. Identical to
-    /// methods except not static and exported by default.
+    /// methods except not static and exported by default. Calls into other Apis files are unqualified
+    /// (free functions) since v2.1 Apis modules export functions, not class methods.
     /// </summary>
     public static void EmitDllImportFunction(AhkWriter w, MethodMember method, TypeRegistry registry)
     {
@@ -35,11 +37,11 @@ public static class MethodEmitter
         string argList = BuildArgumentList(method);
         using (w.Function(method.Name, argList))
         {
-            EmitDllImportMethodBody(w, method, registry);
+            EmitDllImportMethodBody(w, method, registry, unqualifyApis: true);
         }
     }
 
-    private static void EmitDllImportMethodBody(AhkWriter w, MethodMember method, TypeRegistry registry)
+    private static void EmitDllImportMethodBody(AhkWriter w, MethodMember method, TypeRegistry registry, bool unqualifyApis)
     {
         // AutoHotkey doesn't support the thiscall calling convention
         if (method.CallingConvention == CallingConvention.ThisCall)
@@ -59,7 +61,7 @@ public static class MethodEmitter
         }
 
         if (method.IsOrdinal)
-            EmitOrdinalLoading(w, method);
+            EmitOrdinalLoading(w, method, unqualifyApis);
 
         EmitOutputParamMarshalling(w, method);
 
@@ -71,11 +73,11 @@ public static class MethodEmitter
         if (method.IsOrdinal)
         {
             w.BlankLine();
-            w.Line("Foundation.FreeLibrary(hModule)");
+            w.Line(unqualifyApis ? "FreeLibrary(hModule)" : "Foundation.FreeLibrary(hModule)");
             w.BlankLine();
         }
 
-        EmitErrorCheck(w, method);
+        EmitErrorCheck(w, method, unqualifyApis);
         EmitReturnStatement(w, method, registry);
     }
 
@@ -158,11 +160,14 @@ public static class MethodEmitter
 
     // --- Ordinal entry point loading ---
 
-    private static void EmitOrdinalLoading(AhkWriter w, MethodMember method)
+    private static void EmitOrdinalLoading(AhkWriter w, MethodMember method, bool unqualifyApis)
     {
+        string loadLib = unqualifyApis ? "LoadLibraryW" : "LibraryLoader.LoadLibraryW";
+        string getProc = unqualifyApis ? "GetProcAddress" : "LibraryLoader.GetProcAddress";
+
         w.Line("; This method's EntryPoint is an ordinal, so we need to load the dll manually");
-        w.Line($"hModule := LibraryLoader.LoadLibraryW(\"{method.DllName}\")");
-        w.Line($"procAddr := LibraryLoader.GetProcAddress(hModule, {method.EntryPoint[1..]})");
+        w.Line($"hModule := {loadLib}(\"{method.DllName}\")");
+        w.Line($"procAddr := {getProc}(hModule, {method.EntryPoint[1..]})");
         w.BlankLine();
     }
 
@@ -305,7 +310,7 @@ public static class MethodEmitter
 
     // --- Error checking ---
 
-    private static void EmitErrorCheck(AhkWriter w, MethodMember method)
+    private static void EmitErrorCheck(AhkWriter w, MethodMember method, bool unqualifyApis = false)
     {
         // NTSTATUS: special case — no SetsLastError interaction
         if (method.Parameters[0].Type is NtStatusType)
@@ -341,7 +346,8 @@ public static class MethodEmitter
         foreach (var param in freeWithParams)
         {
             FreeFuncRef freeWith = param.FreeWith!;
-            w.Line($"    {freeWith.DeclarerName}.{freeWith.Name}({param.Name})");
+            string callee = unqualifyApis ? freeWith.Name : $"{freeWith.DeclarerName}.{freeWith.Name}";
+            w.Line($"    {callee}({param.Name})");
         }
 
         w.Line($"    throw OSError({string.Join(" || ", errCodeSources)})");
@@ -462,9 +468,10 @@ public static class MethodEmitter
     /// Emit a complete COM method (documentation + signature + body).
     /// Port of legacy AhkComMethod.ToAhk().
     /// </summary>
-    public static void EmitComMethod(AhkWriter w, ComMethodMember method, TypeRegistry registry)
+    public static void EmitComMethod(AhkWriter w, ComMethodMember method, TypeRegistry registry, AhkVersion version = AhkVersion.v20)
     {
         DocCommentWriter.WriteMethodDoc(w, method);
+        bool unqualifyApis = version is AhkVersion.v21;
 
         string argList = BuildArgumentList(method);
         using (w.InstanceMethod(method.DeduplicatedName, argList))
@@ -482,7 +489,7 @@ public static class MethodEmitter
             EmitOutputParamMarshalling(w, method);
             w.Line(BuildComCallExpression(method));
 
-            EmitErrorCheck(w, method);
+            EmitErrorCheck(w, method, unqualifyApis);
             EmitReturnStatement(w, method, registry);
         }
     }

--- a/Generator/Emit/Emitters/MethodEmitter.cs
+++ b/Generator/Emit/Emitters/MethodEmitter.cs
@@ -6,8 +6,7 @@ using AhkWin32.Generator.Model.Types;
 
 /// <summary>
 /// Emits method bodies (DllCall) for DllImport methods.
-/// Static helper class used by ApiTypeEmitter (and later ComInterfaceEmitter).
-/// Port of legacy AhkMethod.ToAhk().
+/// Static helper class used by ApiTypeEmitter and ComInterfaceEmitter.
 /// </summary>
 public static class MethodEmitter
 {
@@ -21,43 +20,63 @@ public static class MethodEmitter
         string argList = BuildArgumentList(method);
         using (w.StaticMethod(method.Name, argList))
         {
-            // AutoHotkey doesn't support the thiscall calling convention
-            if (method.CallingConvention == CallingConvention.ThisCall)
-            {
-                w.Line("throw MethodError(\"Not supported: AutoHotkey does not support the thiscall calling convention\", , A_ThisFunc)");
-                return;
-            }
+            EmitDllImportMethodBody(w, method, registry);
+        }   
+    }
 
-            EmitReservedParams(w, method);
-            EmitParameterConversions(w, method, false);
-            EmitParameterMarshalling(w, method);
+    /// <summary>
+    /// Emit a complete DllImport function (documentation + signature + body). Used in v2.1. Identical to
+    /// methods except not static and exported by default.
+    /// </summary>
+    public static void EmitDllImportFunction(AhkWriter w, MethodMember method, TypeRegistry registry)
+    {
+        DocCommentWriter.WriteMethodDoc(w, method);
 
-            if (method.SetsLastError)
-            {
-                w.Line("A_LastError := 0");
-                w.BlankLine();
-            }
-
-            if (method.IsOrdinal)
-                EmitOrdinalLoading(w, method);
-
-            EmitOutputParamMarshalling(w, method);
-
-            if (method.IsVariadic)
-                EmitVariadicMarshalling(w, method);
-
-            w.Line(BuildDllCallExpression(method));
-
-            if (method.IsOrdinal)
-            {
-                w.BlankLine();
-                w.Line("Foundation.FreeLibrary(hModule)");
-                w.BlankLine();
-            }
-
-            EmitErrorCheck(w, method);
-            EmitReturnStatement(w, method, registry);
+        string argList = BuildArgumentList(method);
+        using (w.Function(method.Name, argList))
+        {
+            EmitDllImportMethodBody(w, method, registry);
         }
+    }
+
+    private static void EmitDllImportMethodBody(AhkWriter w, MethodMember method, TypeRegistry registry)
+    {
+        // AutoHotkey doesn't support the thiscall calling convention
+        if (method.CallingConvention == CallingConvention.ThisCall)
+        {
+            w.Line("throw MethodError(\"Not supported: AutoHotkey does not support the thiscall calling convention\", , A_ThisFunc)");
+            return;
+        }
+
+        EmitReservedParams(w, method);
+        EmitParameterConversions(w, method, false);
+        EmitParameterMarshalling(w, method);
+
+        if (method.SetsLastError)
+        {
+            w.Line("A_LastError := 0");
+            w.BlankLine();
+        }
+
+        if (method.IsOrdinal)
+            EmitOrdinalLoading(w, method);
+
+        EmitOutputParamMarshalling(w, method);
+
+        if (method.IsVariadic)
+            EmitVariadicMarshalling(w, method);
+
+        w.Line(BuildDllCallExpression(method));
+
+        if (method.IsOrdinal)
+        {
+            w.BlankLine();
+            w.Line("Foundation.FreeLibrary(hModule)");
+            w.BlankLine();
+        }
+
+        EmitErrorCheck(w, method);
+        EmitReturnStatement(w, method, registry);
     }
 
     // --- Argument list ---

--- a/Generator/Emit/Emitters/MethodEmitter.cs
+++ b/Generator/Emit/Emitters/MethodEmitter.cs
@@ -29,15 +29,22 @@ public static class MethodEmitter
     /// Emit a complete DllImport function (documentation + signature + body). Used in v2.1. Identical to
     /// methods except not static and exported by default. Calls into other Apis files are unqualified
     /// (free functions) since v2.1 Apis modules export functions, not class methods.
+    /// <paramref name="names"/> resolves imported type/function references to their local (possibly
+    /// aliased) identifier, deconflicting imports that collide with this module's exported functions.
     /// </summary>
-    public static void EmitDllImportFunction(AhkWriter w, MethodMember method, TypeRegistry registry)
+    public static void EmitDllImportFunction(
+        AhkWriter w,
+        MethodMember method,
+        TypeRegistry registry,
+        ModuleNameResolver names
+    )
     {
         DocCommentWriter.WriteMethodDoc(w, method);
 
         string argList = BuildArgumentList(method);
         using (w.Function(method.Name, argList))
         {
-            EmitDllImportMethodBody(w, method, registry, unqualifyApis: true);
+            EmitDllImportMethodBody(w, method, registry, unqualifyApis: true, names);
         }
     }
 
@@ -45,7 +52,8 @@ public static class MethodEmitter
         AhkWriter w,
         MethodMember method,
         TypeRegistry registry,
-        bool unqualifyApis
+        bool unqualifyApis,
+        ModuleNameResolver? names = null
     )
     {
         // AutoHotkey doesn't support the thiscall calling convention
@@ -68,24 +76,27 @@ public static class MethodEmitter
         }
 
         if (method.IsOrdinal)
-            EmitOrdinalLoading(w, method, unqualifyApis);
+            EmitOrdinalLoading(w, method, unqualifyApis, names);
 
-        EmitOutputParamMarshalling(w, method);
+        EmitOutputParamMarshalling(w, method, names);
 
         if (method.IsVariadic)
             EmitVariadicMarshalling(w, method);
 
-        w.Line(BuildDllCallExpression(method, unqualifyApis));
+        w.Line(BuildDllCallExpression(method, unqualifyApis, names));
 
         if (method.IsOrdinal)
         {
             w.BlankLine();
-            w.Line(unqualifyApis ? "FreeLibrary(hModule)" : "Foundation.FreeLibrary(hModule)");
+            string freeLib = unqualifyApis
+                ? FunctionRef(names, "Windows.Win32.Foundation.Apis", "FreeLibrary")
+                : "Foundation.FreeLibrary";
+            w.Line($"{freeLib}(hModule)");
             w.BlankLine();
         }
 
-        EmitErrorCheck(w, method, unqualifyApis);
-        EmitReturnStatement(w, method, registry, unqualifyApis);
+        EmitErrorCheck(w, method, unqualifyApis, names);
+        EmitReturnStatement(w, method, registry, unqualifyApis, names);
     }
 
     // --- Argument list ---
@@ -175,10 +186,28 @@ public static class MethodEmitter
 
     // --- Ordinal entry point loading ---
 
-    private static void EmitOrdinalLoading(AhkWriter w, MethodMember method, bool unqualifyApis)
+    /// <summary>Local identifier for an imported free function (alias-aware in v2.1, bare name otherwise).</summary>
+    private static string FunctionRef(ModuleNameResolver? names, string apisFqn, string name) =>
+        names is null ? name : names.ForFunction(apisFqn, name);
+
+    /// <summary>Local identifier for an imported named type (alias-aware in v2.1, fallback name otherwise).</summary>
+    private static string TypeRef(ModuleNameResolver? names, string fqn, string fallbackName) =>
+        names is null ? fallbackName : names.ForType(fqn);
+
+    private static void EmitOrdinalLoading(
+        AhkWriter w,
+        MethodMember method,
+        bool unqualifyApis,
+        ModuleNameResolver? names
+    )
     {
-        string loadLib = unqualifyApis ? "LoadLibraryW" : "LibraryLoader.LoadLibraryW";
-        string getProc = unqualifyApis ? "GetProcAddress" : "LibraryLoader.GetProcAddress";
+        const string libLoaderApis = "Windows.Win32.System.LibraryLoader.Apis";
+        string loadLib = unqualifyApis
+            ? FunctionRef(names, libLoaderApis, "LoadLibraryW")
+            : "LibraryLoader.LoadLibraryW";
+        string getProc = unqualifyApis
+            ? FunctionRef(names, libLoaderApis, "GetProcAddress")
+            : "LibraryLoader.GetProcAddress";
 
         w.Line("; This method's EntryPoint is an ordinal, so we need to load the dll manually");
         w.Line($"hModule := {loadLib}(\"{method.DllName}\")");
@@ -188,7 +217,7 @@ public static class MethodEmitter
 
     // --- Output parameter marshalling ---
 
-    private static void EmitOutputParamMarshalling(AhkWriter w, MethodMember method)
+    private static void EmitOutputParamMarshalling(AhkWriter w, MethodMember method, ModuleNameResolver? names = null)
     {
         if (method.OutputParameter is not { } outParam)
             return;
@@ -201,7 +230,7 @@ public static class MethodEmitter
         }
         else if (outParam.IsPtrToStruct || outParam.IsPtrToHandle)
         {
-            string pointeeName = GetPointeeName(outParam.Type);
+            string pointeeName = GetPointeeName(outParam.Type, names);
             w.Line($"{outParam.Name} := {pointeeName}()");
         }
     }
@@ -245,7 +274,11 @@ public static class MethodEmitter
         return sb.ToString().Trim();
     }
 
-    private static string BuildDllCallExpression(MethodMember method, bool unqualifyApis = false)
+    private static string BuildDllCallExpression(
+        MethodMember method,
+        bool unqualifyApis = false,
+        ModuleNameResolver? names = null
+    )
     {
         var sb = new System.Text.StringBuilder();
 
@@ -261,7 +294,7 @@ public static class MethodEmitter
         if (method.Parameters.Count > 1)
         {
             sb.Append(", ");
-            sb.Append(BuildDllCallArguments(method, unqualifyApis));
+            sb.Append(BuildDllCallArguments(method, unqualifyApis, names));
         }
 
         // Variadic: append varArgs* (convention string is already in the array)
@@ -283,7 +316,11 @@ public static class MethodEmitter
         return sb.ToString();
     }
 
-    private static string BuildDllCallArguments(MethodMember method, bool unqualifyApis = false)
+    private static string BuildDllCallArguments(
+        MethodMember method,
+        bool unqualifyApis = false,
+        ModuleNameResolver? names = null
+    )
     {
         var sb = new System.Text.StringBuilder();
 
@@ -313,7 +350,7 @@ public static class MethodEmitter
             }
             else
             {
-                marshalAs = GetParamDllCallTypeToken(param.Type, unqualifyApis);
+                marshalAs = GetParamDllCallTypeToken(param.Type, unqualifyApis, names);
             }
 
             // Value string
@@ -333,7 +370,12 @@ public static class MethodEmitter
 
     // --- Error checking ---
 
-    private static void EmitErrorCheck(AhkWriter w, MethodMember method, bool unqualifyApis = false)
+    private static void EmitErrorCheck(
+        AhkWriter w,
+        MethodMember method,
+        bool unqualifyApis = false,
+        ModuleNameResolver? names = null
+    )
     {
         // NTSTATUS: special case — no SetsLastError interaction
         if (method.Parameters[0].Type is NtStatusType)
@@ -370,7 +412,9 @@ public static class MethodEmitter
         foreach (var param in freeWithParams)
         {
             FreeFuncRef freeWith = param.FreeWith!;
-            string callee = unqualifyApis ? freeWith.Name : $"{freeWith.DeclarerName}.{freeWith.Name}";
+            string callee = unqualifyApis
+                ? FunctionRef(names, freeWith.ApisFQN, freeWith.Name)
+                : $"{freeWith.DeclarerName}.{freeWith.Name}";
             w.Line($"    {callee}({param.Name})");
         }
 
@@ -385,7 +429,8 @@ public static class MethodEmitter
         AhkWriter w,
         MethodMember method,
         TypeRegistry registry,
-        bool unqualifyApis = false
+        bool unqualifyApis = false,
+        ModuleNameResolver? names = null
     )
     {
         if (!method.HasReturnValue && method.OutputParameter == null)
@@ -396,14 +441,14 @@ public static class MethodEmitter
         // Handle return (direct HandleRef only — ptr-to-handle output params return raw values)
         if (fnRetVal.IsHandle)
         {
-            EmitHandleReturn(w, fnRetVal, registry, unqualifyApis);
+            EmitHandleReturn(w, fnRetVal, registry, unqualifyApis, names);
             return;
         }
 
         // COM return (ptr-to-COM output param): wrap the raw IUri* the API wrote
         if (fnRetVal.IsPtrToCom)
         {
-            string comName = GetPointeeName(fnRetVal.Type);
+            string comName = GetPointeeName(fnRetVal.Type, names);
             w.Line($"return {comName}({fnRetVal.Name})");
             return;
         }
@@ -416,7 +461,8 @@ public static class MethodEmitter
         AhkWriter w,
         ParameterMember fnRetVal,
         TypeRegistry registry,
-        bool unqualifyApis = false
+        bool unqualifyApis = false,
+        ModuleNameResolver? names = null
     )
     {
         // Get handle info from the type
@@ -456,7 +502,7 @@ public static class MethodEmitter
         {
             // v2.1 handle: `__New(value := default) { this.value := value }`. Pass the raw value.
             // TODO: handle ownership
-            w.Line($"resultHandle := {handleName}({fnRetVal.Name})");
+            w.Line($"resultHandle := {TypeRef(names, handleFqn, handleName)}({fnRetVal.Name})");
         }
         else
         {
@@ -468,7 +514,9 @@ public static class MethodEmitter
         // RAIIFree per-instance override (callable as .Free(); not auto-invoked in v2.1)
         if (fnRetVal.RAIIFree is { } raiiFree)
         {
-            string callee = unqualifyApis ? raiiFree.Name : $"{raiiFree.DeclarerName}.{raiiFree.Name}";
+            string callee = unqualifyApis
+                ? FunctionRef(names, raiiFree.ApisFQN, raiiFree.Name)
+                : $"{raiiFree.DeclarerName}.{raiiFree.Name}";
             w.Line($"resultHandle.DefineProp(\"Free\", {{ Call: (self) => {callee}(self.{fieldName}) }})");
         }
 
@@ -495,22 +543,26 @@ public static class MethodEmitter
     /// (<paramref name="unqualifyApis"/> = true) named types render as unquoted class
     /// references (HWND, RECT.Ptr, BOOL, ...) so DllCall uses the type class directly.
     /// </summary>
-    private static string GetParamDllCallTypeToken(ResolvedType type, bool unqualifyApis)
+    private static string GetParamDllCallTypeToken(
+        ResolvedType type,
+        bool unqualifyApis,
+        ModuleNameResolver? names = null
+    )
     {
         if (!unqualifyApis)
             return $"\"{GetParamDllCallType(type)}\"";
 
         return type switch
         {
-            HandleRef h => h.Name,
-            NativeTypedefRef n => n.Name,
-            StructRef s => s.Name,
-            EnumRef e => e.Name,
+            HandleRef h => TypeRef(names, h.FQN, h.Name),
+            NativeTypedefRef n => TypeRef(names, n.FQN, n.Name),
+            StructRef s => TypeRef(names, s.FQN, s.Name),
+            EnumRef e => TypeRef(names, e.FQN, e.Name),
             NtStatusType => "NTSTATUS",
-            PointerType { Pointee: StructRef s } => $"{s.Name}.Ptr",
-            PointerType { Pointee: HandleRef h } => $"{h.Name}.Ptr",
-            PointerType { Pointee: ComRef c } => $"{c.Name}.Ptr",
-            PointerType { Pointee: NativeTypedefRef n } => $"{n.Name}.Ptr",
+            PointerType { Pointee: StructRef s } => $"{TypeRef(names, s.FQN, s.Name)}.Ptr",
+            PointerType { Pointee: HandleRef h } => $"{TypeRef(names, h.FQN, h.Name)}.Ptr",
+            PointerType { Pointee: ComRef c } => $"{TypeRef(names, c.FQN, c.Name)}.Ptr",
+            PointerType { Pointee: NativeTypedefRef n } => $"{TypeRef(names, n.FQN, n.Name)}.Ptr",
             // Fallback: pointer-to-primitive (typed star), void*, function ptr, enum, HRESULT, etc.
             _ => $"\"{GetParamDllCallType(type)}\"",
         };
@@ -519,12 +571,12 @@ public static class MethodEmitter
     /// <summary>
     /// Get the display name of a pointer's pointee (for struct/handle/COM output params).
     /// </summary>
-    private static string GetPointeeName(ResolvedType type) =>
+    private static string GetPointeeName(ResolvedType type, ModuleNameResolver? names = null) =>
         type switch
         {
-            PointerType { Pointee: StructRef s } => s.Name,
-            PointerType { Pointee: HandleRef h } => h.Name,
-            PointerType { Pointee: ComRef c } => c.Name,
+            PointerType { Pointee: StructRef s } => TypeRef(names, s.FQN, s.Name),
+            PointerType { Pointee: HandleRef h } => TypeRef(names, h.FQN, h.Name),
+            PointerType { Pointee: ComRef c } => TypeRef(names, c.FQN, c.Name),
             PointerType { Pointee: { } p } => p.DisplayName,
             _ => type.DisplayName,
         };

--- a/Generator/Emit/Emitters/MethodEmitter.cs
+++ b/Generator/Emit/Emitters/MethodEmitter.cs
@@ -79,12 +79,12 @@ public static class MethodEmitter
         if (method.IsOrdinal)
             EmitOrdinalLoading(w, method, unqualifyApis, names);
 
-        EmitOutputParamMarshalling(w, method, names);
+        EmitOutputParamMarshalling(w, method, registry, names);
 
         if (method.IsVariadic)
-            EmitVariadicMarshalling(w, method, unqualifyApis, names);
+            EmitVariadicMarshalling(w, method, registry, unqualifyApis, names);
 
-        w.Line(BuildDllCallExpression(method, unqualifyApis, names));
+        w.Line(BuildDllCallExpression(method, registry, unqualifyApis, names));
 
         if (method.IsOrdinal)
         {
@@ -218,7 +218,12 @@ public static class MethodEmitter
 
     // --- Output parameter marshalling ---
 
-    private static void EmitOutputParamMarshalling(AhkWriter w, MethodMember method, ModuleNameResolver? names = null)
+    private static void EmitOutputParamMarshalling(
+        AhkWriter w,
+        MethodMember method,
+        TypeRegistry registry,
+        ModuleNameResolver? names = null
+    )
     {
         if (method.OutputParameter is not { } outParam)
             return;
@@ -232,7 +237,14 @@ public static class MethodEmitter
         else if (outParam.IsPtrToStruct || outParam.IsPtrToHandle)
         {
             string pointeeName = GetPointeeName(outParam.Type, names);
-            w.Line($"{outParam.Name} := {pointeeName}()");
+            // An owned [Out] handle is boxed as its `.Owned`/`.OwnedWith(...)` subclass so __Delete
+            // frees it. The API writes the handle value into this instance's storage via its `.Ptr`.
+            string ctor =
+                outParam.Type is PointerType { Pointee: HandleRef ph }
+                && OwnedHandleClass(pointeeName, outParam, ph.FQN, registry, names) is { } owned
+                    ? owned
+                    : pointeeName;
+            w.Line($"{outParam.Name} := {ctor}()");
         }
     }
 
@@ -246,6 +258,7 @@ public static class MethodEmitter
     private static void EmitVariadicMarshalling(
         AhkWriter w,
         MethodMember method,
+        TypeRegistry registry,
         bool unqualifyApis,
         ModuleNameResolver? names
     )
@@ -253,7 +266,7 @@ public static class MethodEmitter
         string varArgName = method.VariadicParamName;
         w.Line($"varArgs := [{varArgName}*]");
 
-        string retToken = unqualifyApis ? BuildReturnTypeToken(method, names) : QuotedConvString(method);
+        string retToken = unqualifyApis ? BuildReturnTypeToken(method, registry, names) : QuotedConvString(method);
         if (!string.IsNullOrWhiteSpace(retToken))
             w.Line($"varArgs.Push({retToken})");
 
@@ -301,18 +314,57 @@ public static class MethodEmitter
     /// </list>
     /// Returns "" when the method has no return value to specify.
     /// </summary>
-    private static string BuildReturnTypeToken(MethodMember method, ModuleNameResolver? names)
+    private static string BuildReturnTypeToken(MethodMember method, TypeRegistry registry, ModuleNameResolver? names)
     {
         if (!method.HasReturnValue)
             return "";
 
-        ResolvedType retType = method.Parameters[0].Type;
+        ParameterMember fnRetVal = method.Parameters[0];
+        ResolvedType retType = fnRetVal.Type;
 
         if (retType is HResultType)
             return method.ShouldThrowOnHResult ? "\"HRESULT\"" : "Int32";
 
-        return ReturnTypeClassRef(retType, names);
+        string token = ReturnTypeClassRef(retType, names);
+
+        // Ownership: a directly-returned handle that the script owns (not [DoNotRelease]) is boxed
+        // as its `.Owned` (or `.OwnedWith(...)`) subclass so __Delete frees it when it leaves scope.
+        if (retType is HandleRef hr && OwnedHandleClass(token, fnRetVal, hr.FQN, registry, names) is { } owned)
+            token = owned;
+
+        return token;
     }
+
+    /// <summary>
+    /// The class expression to box an owned returned/output handle, or <c>null</c> if it's borrowed.
+    /// Returns <c><paramref name="baseClass"/>.Owned</c> for the handle's default free function, or
+    /// <c>.OwnedWith(freeFunc)</c> when the call-site <c>RAIIFree</c> diverges from that default (e.g.
+    /// a HANDLE closed with FindClose rather than CloseHandle). Borrowed (null) when the param is
+    /// <c>[DoNotRelease]</c> or the handle type has no free function at all.
+    /// </summary>
+    private static string? OwnedHandleClass(
+        string baseClass,
+        ParameterMember param,
+        string handleFqn,
+        TypeRegistry registry,
+        ModuleNameResolver? names
+    )
+    {
+        if (!param.ScriptOwned)
+            return null;
+        if (registry.Resolve(handleFqn, Architecture.All) is not HandleType ht || ht.FreeFunc is null)
+            return null;
+        if (DivergentRAIIFree(param, ht) is { } raii)
+            return $"{baseClass}.OwnedWith({FunctionRef(names, raii.ApisFQN, raii.Name)})";
+        return $"{baseClass}.Owned";
+    }
+
+    /// <summary>
+    /// The call-site <c>RAIIFree</c> function for an owned handle param that differs from the handle
+    /// type's default free function (and so requires an <c>OwnedWith</c> factory), or <c>null</c>.
+    /// </summary>
+    private static FreeFuncRef? DivergentRAIIFree(ParameterMember param, HandleType ht) =>
+        ht.FreeFunc is not null && param.RAIIFree is { } raii && raii != ht.FreeFunc ? raii : null;
 
     /// <summary>
     /// The v2.1 type-class reference used to convert a return value, alias-resolved for the local
@@ -341,6 +393,7 @@ public static class MethodEmitter
 
     private static string BuildDllCallExpression(
         MethodMember method,
+        TypeRegistry registry,
         bool unqualifyApis = false,
         ModuleNameResolver? names = null
     )
@@ -371,7 +424,7 @@ public static class MethodEmitter
         {
             // Return type token (inline). v2.1 uses unquoted type-class refs; v2.0 a quoted
             // calling-convention + return-type string.
-            string retToken = unqualifyApis ? BuildReturnTypeToken(method, names) : QuotedConvString(method);
+            string retToken = unqualifyApis ? BuildReturnTypeToken(method, registry, names) : QuotedConvString(method);
             if (!string.IsNullOrWhiteSpace(retToken))
             {
                 sb.Append($", {retToken}");
@@ -712,8 +765,8 @@ public static class MethodEmitter
                 w.BlankLine();
             }
 
-            EmitOutputParamMarshalling(w, method);
-            w.Line(BuildComCallExpression(method, unqualifyApis));
+            EmitOutputParamMarshalling(w, method, registry);
+            w.Line(BuildComCallExpression(method, registry, unqualifyApis));
 
             EmitErrorCheck(w, method, registry, unqualifyApis);
             EmitReturnStatement(w, method, registry, unqualifyApis);
@@ -724,7 +777,11 @@ public static class MethodEmitter
     /// Build a ComCall expression: [result := ] ComCall(VTableIndex, this[, args][, "conv retType"])
     /// Port of legacy AhkComMethod.BuildDllCallCall.
     /// </summary>
-    private static string BuildComCallExpression(ComMethodMember method, bool unqualifyApis = false)
+    private static string BuildComCallExpression(
+        ComMethodMember method,
+        TypeRegistry registry,
+        bool unqualifyApis = false
+    )
     {
         var sb = new System.Text.StringBuilder();
 
@@ -742,7 +799,7 @@ public static class MethodEmitter
 
         // Return type token. v2.1 uses unquoted type-class refs (ComCall defaults to HRESULT when
         // omitted); v2.0 a quoted calling-convention + return-type string.
-        string retToken = unqualifyApis ? BuildReturnTypeToken(method, null) : QuotedConvString(method);
+        string retToken = unqualifyApis ? BuildReturnTypeToken(method, registry, null) : QuotedConvString(method);
         if (!string.IsNullOrWhiteSpace(retToken))
         {
             sb.Append($", {retToken}");

--- a/Generator/Emit/Emitters/MethodEmitter.cs
+++ b/Generator/Emit/Emitters/MethodEmitter.cs
@@ -41,12 +41,19 @@ public static class MethodEmitter
         }
     }
 
-    private static void EmitDllImportMethodBody(AhkWriter w, MethodMember method, TypeRegistry registry, bool unqualifyApis)
+    private static void EmitDllImportMethodBody(
+        AhkWriter w,
+        MethodMember method,
+        TypeRegistry registry,
+        bool unqualifyApis
+    )
     {
         // AutoHotkey doesn't support the thiscall calling convention
         if (method.CallingConvention == CallingConvention.ThisCall)
         {
-            w.Line("throw MethodError(\"Not supported: AutoHotkey does not support the thiscall calling convention\", , A_ThisFunc)");
+            w.Line(
+                "throw MethodError(\"Not supported: AutoHotkey does not support the thiscall calling convention\", , A_ThisFunc)"
+            );
             return;
         }
 
@@ -89,8 +96,8 @@ public static class MethodEmitter
     /// </summary>
     private static string BuildArgumentList(MethodMember method)
     {
-        var names = method.Parameters
-            .Skip(1) // Skip param 0 (return value)
+        var names = method
+            .Parameters.Skip(1) // Skip param 0 (return value)
             .Where(p => !p.IsReserved && p != method.OutputParameter)
             .Select(p => p.Name)
             .ToList();
@@ -106,15 +113,23 @@ public static class MethodEmitter
     private static void EmitReservedParams(AhkWriter w, MethodMember method)
     {
         var reserved = method.Parameters.Skip(1).Where(p => p.IsReserved).ToList();
-        if (reserved.Count == 0) return;
+        if (reserved.Count == 0)
+            return;
 
-        w.Line($"static {string.Join(", ", reserved.Select(p => $"{p.Name} := 0"))} ;Reserved parameters must always be NULL");
+        w.Line(
+            $"static {string.Join(", ", reserved.Select(p => $"{p.Name} := 0"))} ;Reserved parameters must always be NULL"
+        );
         w.BlankLine();
     }
 
     // --- Parameter conversions (String→StrPtr, Handle→NumGet) ---
 
-    private static void EmitParameterConversions(AhkWriter w, MethodMember method, bool isComMethod, bool unqualifyApis = false)
+    private static void EmitParameterConversions(
+        AhkWriter w,
+        MethodMember method,
+        bool isComMethod,
+        bool unqualifyApis = false
+    )
     {
         int startLen = w.Length;
 
@@ -175,7 +190,8 @@ public static class MethodEmitter
 
     private static void EmitOutputParamMarshalling(AhkWriter w, MethodMember method)
     {
-        if (method.OutputParameter is not { } outParam) return;
+        if (method.OutputParameter is not { } outParam)
+            return;
 
         if (outParam.IsSizedBuffer)
         {
@@ -223,9 +239,7 @@ public static class MethodEmitter
 
         if (method.HasReturnValue)
         {
-            sb.Append(method.ShouldThrowOnHResult
-                ? "HRESULT"
-                : method.Parameters[0].Type.DllCallType);
+            sb.Append(method.ShouldThrowOnHResult ? "HRESULT" : method.Parameters[0].Type.DllCallType);
         }
 
         return sb.ToString().Trim();
@@ -239,9 +253,7 @@ public static class MethodEmitter
             sb.Append("result := ");
 
         // Entry point
-        string entry = method.IsOrdinal
-            ? "procAddr"
-            : $"\"{method.DllName}\\{method.EntryPoint}\"";
+        string entry = method.IsOrdinal ? "procAddr" : $"\"{method.DllName}\\{method.EntryPoint}\"";
 
         sb.Append($"DllCall({entry}");
 
@@ -279,9 +291,7 @@ public static class MethodEmitter
         {
             var param = method.Parameters[i];
 
-            bool useMarshalVar = param.IsPtrToPrimitive
-                && !param.IsReserved
-                && param != method.OutputParameter;
+            bool useMarshalVar = param.IsPtrToPrimitive && !param.IsReserved && param != method.OutputParameter;
 
             string marshalAs;
             if (useMarshalVar)
@@ -298,11 +308,8 @@ public static class MethodEmitter
             }
 
             // Value string
-            bool isVarRefOutput = param == method.OutputParameter
-                && (param.IsPtrToPrimitive || param.IsPtrToCom);
-            string passAs = isVarRefOutput
-                ? $"&{param.Name} := 0"
-                : param.Name;
+            bool isVarRefOutput = param == method.OutputParameter && (param.IsPtrToPrimitive || param.IsPtrToCom);
+            string passAs = isVarRefOutput ? $"&{param.Name} := 0" : param.Name;
 
             sb.Append(marshalAs);
             sb.Append(", ");
@@ -345,7 +352,8 @@ public static class MethodEmitter
             errCodeSources.Add("A_LastError");
         }
 
-        if (conditions.Count == 0) return;
+        if (conditions.Count == 0)
+            return;
 
         w.Line($"if({string.Join(" && ", conditions)}) {{");
 
@@ -364,7 +372,12 @@ public static class MethodEmitter
 
     // --- Return statement ---
 
-    private static void EmitReturnStatement(AhkWriter w, MethodMember method, TypeRegistry registry, bool unqualifyApis = false)
+    private static void EmitReturnStatement(
+        AhkWriter w,
+        MethodMember method,
+        TypeRegistry registry,
+        bool unqualifyApis = false
+    )
     {
         if (!method.HasReturnValue && method.OutputParameter == null)
             return;
@@ -390,10 +403,16 @@ public static class MethodEmitter
         w.Line($"return {fnRetVal.Name}");
     }
 
-    private static void EmitHandleReturn(AhkWriter w, ParameterMember fnRetVal, TypeRegistry registry, bool unqualifyApis = false)
+    private static void EmitHandleReturn(
+        AhkWriter w,
+        ParameterMember fnRetVal,
+        TypeRegistry registry,
+        bool unqualifyApis = false
+    )
     {
         // Get handle info from the type
-        string handleName, handleFqn;
+        string handleName,
+            handleFqn;
         if (fnRetVal.Type is HandleRef hr)
         {
             handleName = hr.Name;
@@ -453,12 +472,13 @@ public static class MethodEmitter
     /// Get the DllCall type for a parameter, using typed pointer forms (e.g., "int*").
     /// Matches legacy GetDllCallType(useNakedPointer: false) behavior.
     /// </summary>
-    private static string GetParamDllCallType(ResolvedType type) => type switch
-    {
-        PointerType p => p.TypedDllCallType,
-        NativeTypedefRef n => GetParamDllCallType(n.Underlying),
-        _ => type.DllCallType
-    };
+    private static string GetParamDllCallType(ResolvedType type) =>
+        type switch
+        {
+            PointerType p => p.TypedDllCallType,
+            NativeTypedefRef n => GetParamDllCallType(n.Underlying),
+            _ => type.DllCallType,
+        };
 
     /// <summary>
     /// Render the DllCall type token for a parameter - the exact text to paste into
@@ -473,31 +493,32 @@ public static class MethodEmitter
 
         return type switch
         {
-            HandleRef h                                  => h.Name,
-            NativeTypedefRef n                           => n.Name,
-            StructRef s                                  => s.Name,
-            EnumRef e                                    => e.Name,
-            NtStatusType                                 => "NTSTATUS",
-            PointerType { Pointee: StructRef s }         => $"{s.Name}.Ptr",
-            PointerType { Pointee: HandleRef h }         => $"{h.Name}.Ptr",
-            PointerType { Pointee: ComRef c }            => $"{c.Name}.Ptr",
-            PointerType { Pointee: NativeTypedefRef n }  => $"{n.Name}.Ptr",
+            HandleRef h => h.Name,
+            NativeTypedefRef n => n.Name,
+            StructRef s => s.Name,
+            EnumRef e => e.Name,
+            NtStatusType => "NTSTATUS",
+            PointerType { Pointee: StructRef s } => $"{s.Name}.Ptr",
+            PointerType { Pointee: HandleRef h } => $"{h.Name}.Ptr",
+            PointerType { Pointee: ComRef c } => $"{c.Name}.Ptr",
+            PointerType { Pointee: NativeTypedefRef n } => $"{n.Name}.Ptr",
             // Fallback: pointer-to-primitive (typed star), void*, function ptr, enum, HRESULT, etc.
-            _                                            => $"\"{GetParamDllCallType(type)}\""
+            _ => $"\"{GetParamDllCallType(type)}\"",
         };
     }
 
     /// <summary>
     /// Get the display name of a pointer's pointee (for struct/handle/COM output params).
     /// </summary>
-    private static string GetPointeeName(ResolvedType type) => type switch
-    {
-        PointerType { Pointee: StructRef s } => s.Name,
-        PointerType { Pointee: HandleRef h } => h.Name,
-        PointerType { Pointee: ComRef c } => c.Name,
-        PointerType { Pointee: { } p } => p.DisplayName,
-        _ => type.DisplayName
-    };
+    private static string GetPointeeName(ResolvedType type) =>
+        type switch
+        {
+            PointerType { Pointee: StructRef s } => s.Name,
+            PointerType { Pointee: HandleRef h } => h.Name,
+            PointerType { Pointee: ComRef c } => c.Name,
+            PointerType { Pointee: { } p } => p.DisplayName,
+            _ => type.DisplayName,
+        };
 
     /// <summary>
     /// Look up a handle type's first field name from the registry.
@@ -513,7 +534,12 @@ public static class MethodEmitter
     /// Emit a complete COM method (documentation + signature + body).
     /// Port of legacy AhkComMethod.ToAhk().
     /// </summary>
-    public static void EmitComMethod(AhkWriter w, ComMethodMember method, TypeRegistry registry, AhkVersion version = AhkVersion.v20)
+    public static void EmitComMethod(
+        AhkWriter w,
+        ComMethodMember method,
+        TypeRegistry registry,
+        AhkVersion version = AhkVersion.v20
+    )
     {
         DocCommentWriter.WriteMethodDoc(w, method);
         bool unqualifyApis = version is AhkVersion.v21;

--- a/Generator/Emit/Emitters/MethodEmitter.cs
+++ b/Generator/Emit/Emitters/MethodEmitter.cs
@@ -51,7 +51,7 @@ public static class MethodEmitter
         }
 
         EmitReservedParams(w, method);
-        EmitParameterConversions(w, method, false);
+        EmitParameterConversions(w, method, false, unqualifyApis);
         EmitParameterMarshalling(w, method);
 
         if (method.SetsLastError)
@@ -68,7 +68,7 @@ public static class MethodEmitter
         if (method.IsVariadic)
             EmitVariadicMarshalling(w, method);
 
-        w.Line(BuildDllCallExpression(method));
+        w.Line(BuildDllCallExpression(method, unqualifyApis));
 
         if (method.IsOrdinal)
         {
@@ -78,7 +78,7 @@ public static class MethodEmitter
         }
 
         EmitErrorCheck(w, method, unqualifyApis);
-        EmitReturnStatement(w, method, registry);
+        EmitReturnStatement(w, method, registry, unqualifyApis);
     }
 
     // --- Argument list ---
@@ -114,12 +114,11 @@ public static class MethodEmitter
 
     // --- Parameter conversions (String→StrPtr, Handle→NumGet) ---
 
-    private static void EmitParameterConversions(AhkWriter w, MethodMember method, bool isComMethod)
+    private static void EmitParameterConversions(AhkWriter w, MethodMember method, bool isComMethod, bool unqualifyApis = false)
     {
         int startLen = w.Length;
 
-        foreach (var param in method.Parameters.Skip(1)
-            .Where(p => !p.IsReserved && p != method.OutputParameter))
+        foreach (var param in method.InputParameters)
         {
             if (isComMethod && param.TypeDefName is "BSTR")
             {
@@ -129,10 +128,12 @@ public static class MethodEmitter
             }
             else if (param.TypeDefName is "PSTR" or "PWSTR")
             {
+                // DllImport methods allow AHK strings or string pointers
                 w.Line($"{param.Name} := {param.Name} is String ? StrPtr({param.Name}) : {param.Name}");
             }
-            else if (param.IsHandle)
+            else if (param.IsHandle && !unqualifyApis)
             {
+                // v2.0: manual handle dereference.
                 w.Line($"{param.Name} := {param.Name} is Win32Handle ? NumGet({param.Name}, \"ptr\") : {param.Name}");
             }
         }
@@ -147,8 +148,7 @@ public static class MethodEmitter
     {
         int startLen = w.Length;
 
-        foreach (var param in method.Parameters.Skip(1)
-            .Where(p => !p.IsReserved && p != method.OutputParameter && p.IsPtrToPrimitive))
+        foreach (var param in method.InputParameters.Where(p => p.IsPtrToPrimitive))
         {
             string typedDllCallType = ((PointerType)param.Type).TypedDllCallType;
             w.Line($"{param.Name}Marshal := {param.Name} is VarRef ? \"{typedDllCallType}\" : \"ptr\"");
@@ -231,7 +231,7 @@ public static class MethodEmitter
         return sb.ToString().Trim();
     }
 
-    private static string BuildDllCallExpression(MethodMember method)
+    private static string BuildDllCallExpression(MethodMember method, bool unqualifyApis = false)
     {
         var sb = new System.Text.StringBuilder();
 
@@ -249,7 +249,7 @@ public static class MethodEmitter
         if (method.Parameters.Count > 1)
         {
             sb.Append(", ");
-            sb.Append(BuildDllCallArguments(method));
+            sb.Append(BuildDllCallArguments(method, unqualifyApis));
         }
 
         // Variadic: append varArgs* (convention string is already in the array)
@@ -271,7 +271,7 @@ public static class MethodEmitter
         return sb.ToString();
     }
 
-    private static string BuildDllCallArguments(MethodMember method)
+    private static string BuildDllCallArguments(MethodMember method, bool unqualifyApis = false)
     {
         var sb = new System.Text.StringBuilder();
 
@@ -279,16 +279,23 @@ public static class MethodEmitter
         {
             var param = method.Parameters[i];
 
-            // Type string
-            bool isString = param.TypeDefName is "PWSTR" or "PSTR";
-            string dllCallType = isString ? "ptr" : GetParamDllCallType(param.Type);
-
             bool useMarshalVar = param.IsPtrToPrimitive
                 && !param.IsReserved
                 && param != method.OutputParameter;
-            string marshalAs = useMarshalVar
-                ? $"{param.Name}Marshal"
-                : $"\"{dllCallType}\"";
+
+            string marshalAs;
+            if (useMarshalVar)
+            {
+                marshalAs = $"{param.Name}Marshal";
+            }
+            else if (param.TypeDefName is "PWSTR" or "PSTR")
+            {
+                marshalAs = "\"ptr\"";
+            }
+            else
+            {
+                marshalAs = GetParamDllCallTypeToken(param.Type, unqualifyApis);
+            }
 
             // Value string
             bool isVarRefOutput = param == method.OutputParameter
@@ -357,7 +364,7 @@ public static class MethodEmitter
 
     // --- Return statement ---
 
-    private static void EmitReturnStatement(AhkWriter w, MethodMember method, TypeRegistry registry)
+    private static void EmitReturnStatement(AhkWriter w, MethodMember method, TypeRegistry registry, bool unqualifyApis = false)
     {
         if (!method.HasReturnValue && method.OutputParameter == null)
             return;
@@ -367,7 +374,7 @@ public static class MethodEmitter
         // Handle return (direct HandleRef only — ptr-to-handle output params return raw values)
         if (fnRetVal.IsHandle)
         {
-            EmitHandleReturn(w, fnRetVal, registry);
+            EmitHandleReturn(w, fnRetVal, registry, unqualifyApis);
             return;
         }
 
@@ -383,7 +390,7 @@ public static class MethodEmitter
         w.Line($"return {fnRetVal.Name}");
     }
 
-    private static void EmitHandleReturn(AhkWriter w, ParameterMember fnRetVal, TypeRegistry registry)
+    private static void EmitHandleReturn(AhkWriter w, ParameterMember fnRetVal, TypeRegistry registry, bool unqualifyApis = false)
     {
         // Get handle info from the type
         string handleName, handleFqn;
@@ -417,13 +424,24 @@ public static class MethodEmitter
         }
 
         // Construct handle wrapper
-        string scriptOwned = fnRetVal.ScriptOwned ? "True" : "False";
-        w.Line($"resultHandle := {handleName}({{{fieldName}: {fnRetVal.Name}}}, {scriptOwned})");
+        if (unqualifyApis)
+        {
+            // v2.1 handle: `__New(value := default) { this.value := value }`. Pass the raw value.
+            // TODO: handle ownership
+            w.Line($"resultHandle := {handleName}({fnRetVal.Name})");
+        }
+        else
+        {
+            // v2.0 Win32Handle base: takes {field: value} object + owned flag.
+            string scriptOwned = fnRetVal.ScriptOwned ? "True" : "False";
+            w.Line($"resultHandle := {handleName}({{{fieldName}: {fnRetVal.Name}}}, {scriptOwned})");
+        }
 
-        // RAIIFree destructor
+        // RAIIFree per-instance override (callable as .Free(); not auto-invoked in v2.1)
         if (fnRetVal.RAIIFree is { } raiiFree)
         {
-            w.Line($"resultHandle.DefineProp(\"Free\", {{ Call: (self) => {raiiFree.DeclarerName}.{raiiFree.Name}(self.{fieldName}) }})");
+            string callee = unqualifyApis ? raiiFree.Name : $"{raiiFree.DeclarerName}.{raiiFree.Name}";
+            w.Line($"resultHandle.DefineProp(\"Free\", {{ Call: (self) => {callee}(self.{fieldName}) }})");
         }
 
         w.Line("return resultHandle");
@@ -441,6 +459,32 @@ public static class MethodEmitter
         NativeTypedefRef n => GetParamDllCallType(n.Underlying),
         _ => type.DllCallType
     };
+
+    /// <summary>
+    /// Render the DllCall type token for a parameter â€” the exact text to paste into
+    /// the DllCall arg list. For v2.0 this is a quoted type string. For v2.1
+    /// (<paramref name="unqualifyApis"/> = true) named types render as unquoted class
+    /// references (HWND, RECT.Ptr, BOOL, â€¦) so DllCall uses the type class directly.
+    /// </summary>
+    private static string GetParamDllCallTypeToken(ResolvedType type, bool unqualifyApis)
+    {
+        if (!unqualifyApis)
+            return $"\"{GetParamDllCallType(type)}\"";
+
+        return type switch
+        {
+            HandleRef h                                  => h.Name,
+            NativeTypedefRef n                           => n.Name,
+            StructRef s                                  => s.Name,
+            NtStatusType                                 => "NTSTATUS",
+            PointerType { Pointee: StructRef s }         => $"{s.Name}.Ptr",
+            PointerType { Pointee: HandleRef h }         => $"{h.Name}.Ptr",
+            PointerType { Pointee: ComRef c }            => $"{c.Name}.Ptr",
+            PointerType { Pointee: NativeTypedefRef n }  => $"{n.Name}.Ptr",
+            // Fallback: pointer-to-primitive (typed star), void*, function ptr, enum, HRESULT, etc.
+            _                                            => $"\"{GetParamDllCallType(type)}\""
+        };
+    }
 
     /// <summary>
     /// Get the display name of a pointer's pointee (for struct/handle/COM output params).
@@ -477,7 +521,7 @@ public static class MethodEmitter
         using (w.InstanceMethod(method.DeduplicatedName, argList))
         {
             EmitReservedParams(w, method);
-            EmitParameterConversions(w, method, true);
+            EmitParameterConversions(w, method, isComMethod: true, unqualifyApis);
             EmitParameterMarshalling(w, method);
 
             if (method.SetsLastError)
@@ -487,10 +531,10 @@ public static class MethodEmitter
             }
 
             EmitOutputParamMarshalling(w, method);
-            w.Line(BuildComCallExpression(method));
+            w.Line(BuildComCallExpression(method, unqualifyApis));
 
             EmitErrorCheck(w, method, unqualifyApis);
-            EmitReturnStatement(w, method, registry);
+            EmitReturnStatement(w, method, registry, unqualifyApis);
         }
     }
 
@@ -498,7 +542,7 @@ public static class MethodEmitter
     /// Build a ComCall expression: [result := ] ComCall(VTableIndex, this[, args][, "conv retType"])
     /// Port of legacy AhkComMethod.BuildDllCallCall.
     /// </summary>
-    private static string BuildComCallExpression(ComMethodMember method)
+    private static string BuildComCallExpression(ComMethodMember method, bool unqualifyApis = false)
     {
         var sb = new System.Text.StringBuilder();
 
@@ -511,7 +555,7 @@ public static class MethodEmitter
         if (method.Parameters.Count > 1)
         {
             sb.Append(", ");
-            sb.Append(BuildDllCallArguments(method));
+            sb.Append(BuildDllCallArguments(method, unqualifyApis));
         }
 
         // Calling convention + return type

--- a/Generator/Emit/Emitters/MethodEmitter.cs
+++ b/Generator/Emit/Emitters/MethodEmitter.cs
@@ -461,10 +461,10 @@ public static class MethodEmitter
     };
 
     /// <summary>
-    /// Render the DllCall type token for a parameter â€” the exact text to paste into
+    /// Render the DllCall type token for a parameter - the exact text to paste into
     /// the DllCall arg list. For v2.0 this is a quoted type string. For v2.1
     /// (<paramref name="unqualifyApis"/> = true) named types render as unquoted class
-    /// references (HWND, RECT.Ptr, BOOL, â€¦) so DllCall uses the type class directly.
+    /// references (HWND, RECT.Ptr, BOOL, ...) so DllCall uses the type class directly.
     /// </summary>
     private static string GetParamDllCallTypeToken(ResolvedType type, bool unqualifyApis)
     {
@@ -476,6 +476,7 @@ public static class MethodEmitter
             HandleRef h                                  => h.Name,
             NativeTypedefRef n                           => n.Name,
             StructRef s                                  => s.Name,
+            EnumRef e                                    => e.Name,
             NtStatusType                                 => "NTSTATUS",
             PointerType { Pointee: StructRef s }         => $"{s.Name}.Ptr",
             PointerType { Pointee: HandleRef h }         => $"{h.Name}.Ptr",

--- a/Generator/Emit/Emitters/NativeTypedefEmitter21.cs
+++ b/Generator/Emit/Emitters/NativeTypedefEmitter21.cs
@@ -1,0 +1,83 @@
+namespace AhkWin32.Generator.Emit.Emitters;
+
+using AhkWin32.Generator.Metadata;
+using AhkWin32.Generator.Model.Types;
+
+/// <summary>
+/// Emits a NativeTypedefType as a v2.1 native `struct` block. Typedefs are emitted
+/// as a single-field struct with `__value` get/set so the instance is transparently
+/// usable as the underlying value in DllCall and assignment.
+///
+/// Mirrors the docs example:
+/// <code>
+/// struct BOOL {
+///     value : Int32
+///     __value {
+///         get => this.value
+///         set => this.value := value
+///     }
+/// }
+/// </code>
+/// </summary>
+public sealed class NativeTypedefEmitter21 : ITypeEmitter
+{
+    public bool CanEmit(Win32Type type) => type is NativeTypedefType;
+
+    public EmitResult Emit(Win32Type type, string outputRoot)
+    {
+        var typedef = (NativeTypedefType)type;
+        var w = new AhkWriter(AhkVersion.v21);
+
+        EmitTypedef(w, typedef);
+
+        string filePath = ImportResolver.GetFilePath(outputRoot, typedef.Namespace, typedef.CanonicalName);
+        return new EmitResult(w.ToString(), filePath);
+    }
+
+    private static void EmitTypedef(AhkWriter w, NativeTypedefType typedef)
+    {
+        w.Require("AutoHotkey v2.1-alpha.26+ 64-bit");
+
+        EmitImports(w, typedef);
+
+        w.BlankLine();
+
+        DocCommentWriter.WriteTypeDoc(w, typedef);
+
+        using (w.Struct(typedef.Name))
+        {
+            w.Line($"value : {typedef.Underlying.TypeSpecifier}");
+
+            w.BlankLine();
+            using (w.InstanceProperty("__value"))
+            {
+                w.Line("get => this.value");
+                w.Line("set => this.value := value");
+            }
+
+            w.BlankLine();
+            using (w.InstanceMethod("__New", "value := 0"))
+            {
+                w.Line("this.value := value");
+            }
+
+            // Extension code blocks (e.g. NTSTATUS helper methods)
+            StructEmitter21.EmitExtensions(w, typedef);
+        }
+    }
+
+    private static void EmitImports(AhkWriter w, NativeTypedefType type)
+    {
+        foreach (string fqn in type.Imports.GetTypes().Where(fqn => fqn != type.FQN))
+        {
+            string path = ImportResolver.GetIncludePath(type.Namespace, fqn);
+            w.Import(path, [ImportResolver.GetImportName(fqn)]);
+        }
+
+        foreach (string apisFqn in type.Imports.GetFunctionNamespaces())
+        {
+            string path = ImportResolver.GetIncludePath(type.Namespace, apisFqn);
+            w.Import(path, type.Imports.GetFunctionsForNamespace(apisFqn));
+        }
+    }
+}

--- a/Generator/Emit/Emitters/NativeTypedefEmitter21.cs
+++ b/Generator/Emit/Emitters/NativeTypedefEmitter21.cs
@@ -51,8 +51,17 @@ public sealed class NativeTypedefEmitter21 : ITypeEmitter
             w.BlankLine();
             using (w.InstanceProperty("__value"))
             {
-                w.Line("get => this.value");
-                w.Line("set => this.value := value");
+                using (w.SetBlock())
+                {
+                    using (w.If($"value is {typedef.Name}"))
+                    {
+                        w.Line($"this.value := value.value");
+                    }
+                    using (w.Else())
+                    {
+                        w.Line($"this.value := value");
+                    }
+                }
             }
 
             w.BlankLine();

--- a/Generator/Emit/Emitters/NativeTypedefEmitter21.cs
+++ b/Generator/Emit/Emitters/NativeTypedefEmitter21.cs
@@ -5,16 +5,23 @@ using AhkWin32.Generator.Model.Types;
 
 /// <summary>
 /// Emits a NativeTypedefType as a v2.1 native `struct` block. Typedefs are emitted
-/// as a single-field struct with `__value` get/set so the instance is transparently
-/// usable as the underlying value in DllCall and assignment.
+/// as a single-field struct with a `__value` setter that unwraps a typed instance or
+/// stores the raw value, so the instance is transparently assignable. By default no
+/// getter is emitted (the wrapped instance keeps its identity); a `value-accessor`
+/// override may restore a getter and/or customize the setter's raw-value coercion.
 ///
-/// Mirrors the docs example:
+/// Example output (BOOL, with a value-accessor override):
 /// <code>
 /// struct BOOL {
 ///     value : Int32
 ///     __value {
-///         get => this.value
-///         set => this.value := value
+///         get => !!this.value
+///         set {
+///             if (value is BOOL)
+///                 this.value := value.value
+///             else
+///                 this.value := !!value
+///         }
 ///     }
 /// }
 /// </code>
@@ -49,7 +56,13 @@ public sealed class NativeTypedefEmitter21 : ITypeEmitter
             w.Line($"value : {typedef.Underlying.TypeSpecifier}");
 
             w.BlankLine();
-            SingleFieldEmitter.EmitValueSetter(w, typedef, "value");
+            SingleFieldEmitter.EmitValueSetter(
+                w,
+                typedef,
+                "value",
+                typedef.ValueGetterExpr,
+                typedef.ValueSetterCoerceExpr
+            );
 
             w.BlankLine();
             using (w.InstanceMethod("__New", "value := 0"))

--- a/Generator/Emit/Emitters/NativeTypedefEmitter21.cs
+++ b/Generator/Emit/Emitters/NativeTypedefEmitter21.cs
@@ -38,7 +38,7 @@ public sealed class NativeTypedefEmitter21 : ITypeEmitter
     {
         w.Require("AutoHotkey v2.1-alpha.26+ 64-bit");
 
-        EmitImports(w, typedef);
+        SingleFieldEmitter.EmitImports(w, typedef);
 
         w.BlankLine();
 
@@ -49,20 +49,7 @@ public sealed class NativeTypedefEmitter21 : ITypeEmitter
             w.Line($"value : {typedef.Underlying.TypeSpecifier}");
 
             w.BlankLine();
-            using (w.InstanceProperty("__value"))
-            {
-                using (w.SetBlock())
-                {
-                    using (w.If($"value is {typedef.Name}"))
-                    {
-                        w.Line($"this.value := value.value");
-                    }
-                    using (w.Else())
-                    {
-                        w.Line($"this.value := value");
-                    }
-                }
-            }
+            SingleFieldEmitter.EmitValueSetter(w, typedef, "value");
 
             w.BlankLine();
             using (w.InstanceMethod("__New", "value := 0"))
@@ -72,21 +59,6 @@ public sealed class NativeTypedefEmitter21 : ITypeEmitter
 
             // Extension code blocks (e.g. NTSTATUS helper methods)
             StructEmitter21.EmitExtensions(w, typedef);
-        }
-    }
-
-    private static void EmitImports(AhkWriter w, NativeTypedefType type)
-    {
-        foreach (string fqn in type.Imports.GetTypes().Where(fqn => fqn != type.FQN))
-        {
-            string path = ImportResolver.GetIncludePath(type.Namespace, fqn);
-            w.Import(path, [ImportResolver.GetImportName(fqn)]);
-        }
-
-        foreach (string apisFqn in type.Imports.GetFunctionNamespaces())
-        {
-            string path = ImportResolver.GetIncludePath(type.Namespace, apisFqn);
-            w.Import(path, type.Imports.GetFunctionsForNamespace(apisFqn));
         }
     }
 }

--- a/Generator/Emit/Emitters/SingleFieldEmitter.cs
+++ b/Generator/Emit/Emitters/SingleFieldEmitter.cs
@@ -45,29 +45,49 @@ internal static class SingleFieldEmitter
     /// raw value. Source and target are assumed to share the backing field name, which
     /// holds because convertibility only links types of the same kind (handle->handle,
     /// typedef->typedef).
+    ///
+    /// A <c>value-accessor</c> override may supply <paramref name="getterExpr"/> (restores a
+    /// <c>__value</c> getter; <c>$field</c> -> <c>this.&lt;field&gt;</c>) and/or
+    /// <paramref name="coerceExpr"/> (transforms the raw-value else branch; <c>$value</c> ->
+    /// the setter's <c>value</c>). The instance-unwrap branch is unaffected.
     /// </summary>
-    public static void EmitValueSetter(AhkWriter w, Win32Type type, string field)
+    public static void EmitValueSetter(
+        AhkWriter w,
+        Win32Type type,
+        string field,
+        string? getterExpr = null,
+        string? coerceExpr = null
+    )
     {
         using (w.InstanceProperty("__value"))
-        using (w.SetBlock())
         {
-            string typeCheck = $"value is {type.Name}";
-            if (type.ConvertibleFrom is { Count: > 0 })
+            if (getterExpr is not null)
             {
-                IEnumerable<string> sources = type
-                    .ConvertibleFrom.Append(type)
-                    .Select(t => t.Name)
-                    .OrderBy(n => n, StringComparer.OrdinalIgnoreCase); // Stable order for source control
-                typeCheck = string.Join(" || ", sources.Select(n => $"(value is {n})"));
+                w.Line($"get => {getterExpr.Replace("$field", $"this.{field}")}");
             }
 
-            using (w.If(typeCheck))
+            using (w.SetBlock())
             {
-                w.Line($"this.{field} := value.{field}");
-            }
-            using (w.Else())
-            {
-                w.Line($"this.{field} := value");
+                string typeCheck = $"value is {type.Name}";
+                if (type.ConvertibleFrom is { Count: > 0 })
+                {
+                    IEnumerable<string> sources = type
+                        .ConvertibleFrom.Append(type)
+                        .Select(t => t.Name)
+                        .OrderBy(n => n, StringComparer.OrdinalIgnoreCase); // Stable order for source control
+                    typeCheck = string.Join(" || ", sources.Select(n => $"(value is {n})"));
+                }
+
+                string stored = coerceExpr is null ? "value" : coerceExpr.Replace("$value", "value");
+
+                using (w.If(typeCheck))
+                {
+                    w.Line($"this.{field} := value.{field}");
+                }
+                using (w.Else())
+                {
+                    w.Line($"this.{field} := {stored}");
+                }
             }
         }
     }

--- a/Generator/Emit/Emitters/SingleFieldEmitter.cs
+++ b/Generator/Emit/Emitters/SingleFieldEmitter.cs
@@ -1,0 +1,74 @@
+namespace AhkWin32.Generator.Emit.Emitters;
+
+using AhkWin32.Generator.Model.Types;
+
+/// <summary>
+/// Shared emission helpers for single-field "value" types — handles and native
+/// typedefs — both of which render as a one-field v2.1 <c>struct</c> with a
+/// transparent <c>__value</c> setter. Keeps the two emitters from duplicating the
+/// import and conversion logic.
+/// </summary>
+internal static class SingleFieldEmitter
+{
+    /// <summary>
+    /// Emit #Import lines for the type's referenced types/functions, plus the
+    /// implicitly-convertible source types referenced by the <c>__value</c> setter.
+    /// Convertible imports come from <see cref="Win32Type.ConvertibleFrom"/> rather
+    /// than the <see cref="Win32Type.Imports"/> collection, so a type only imports a
+    /// convertible source when it actually emits a check against it.
+    /// </summary>
+    public static void EmitImports(AhkWriter w, Win32Type type)
+    {
+        IEnumerable<string> typeFqns = type
+            .Imports.GetTypes()
+            .Concat((type.ConvertibleFrom ?? []).Select(t => t.FQN))
+            .Where(fqn => fqn != type.FQN)
+            .Distinct();
+
+        foreach (string fqn in typeFqns)
+        {
+            string path = ImportResolver.GetIncludePath(type.Namespace, fqn);
+            w.Import(path, [ImportResolver.GetImportName(fqn)]);
+        }
+
+        foreach (string apisFqn in type.Imports.GetFunctionNamespaces())
+        {
+            string path = ImportResolver.GetIncludePath(type.Namespace, apisFqn);
+            w.Import(path, type.Imports.GetFunctionsForNamespace(apisFqn));
+        }
+    }
+
+    /// <summary>
+    /// Emit the <c>__value</c> property whose setter unwraps the backing field of the
+    /// type itself or any implicitly-convertible source (from <c>[AlsoUsableFor]</c>,
+    /// inverted into <see cref="Win32Type.ConvertibleFrom"/>), and otherwise stores the
+    /// raw value. Source and target are assumed to share the backing field name, which
+    /// holds because convertibility only links types of the same kind (handle->handle,
+    /// typedef->typedef).
+    /// </summary>
+    public static void EmitValueSetter(AhkWriter w, Win32Type type, string field)
+    {
+        using (w.InstanceProperty("__value"))
+        using (w.SetBlock())
+        {
+            string typeCheck = $"value is {type.Name}";
+            if (type.ConvertibleFrom is { Count: > 0 })
+            {
+                IEnumerable<string> sources = type
+                    .ConvertibleFrom.Append(type)
+                    .Select(t => t.Name)
+                    .OrderBy(n => n, StringComparer.OrdinalIgnoreCase); // Stable order for source control
+                typeCheck = string.Join(" || ", sources.Select(n => $"(value is {n})"));
+            }
+
+            using (w.If(typeCheck))
+            {
+                w.Line($"this.{field} := value.{field}");
+            }
+            using (w.Else())
+            {
+                w.Line($"this.{field} := value");
+            }
+        }
+    }
+}

--- a/Generator/Emit/Emitters/StructEmitter.cs
+++ b/Generator/Emit/Emitters/StructEmitter.cs
@@ -150,7 +150,7 @@ public sealed class StructEmitter : ITypeEmitter
             case EnumRef enumRef:
                 EmitNumericMember(w, field, offset, enumRef.UnderlyingType.DllCallType);
                 break;
-            case NativeTypedefType nativeTypedef:
+            case NativeTypedefRef nativeTypedef:
                 EmitNumericMember(w, field, offset, nativeTypedef.Underlying.DllCallType);
                 break;
             default:
@@ -232,7 +232,7 @@ public sealed class StructEmitter : ITypeEmitter
                     ? $"{parentClassName}.{structRef.Name}"
                     : structRef.Name;
                 break;
-            case NativeTypedefType nativeTypedef:
+            case NativeTypedefRef nativeTypedef:
                 ahkElementType = "Primitive";
                 dllCallType = nativeTypedef.Underlying.DllCallType;
                 break;

--- a/Generator/Emit/Emitters/StructEmitter.cs
+++ b/Generator/Emit/Emitters/StructEmitter.cs
@@ -1,5 +1,6 @@
 namespace AhkWin32.Generator.Emit.Emitters;
 
+using AhkWin32.Generator.Metadata;
 using AhkWin32.Generator.Model;
 using AhkWin32.Generator.Model.Members;
 using AhkWin32.Generator.Model.Types;
@@ -300,9 +301,11 @@ public sealed class StructEmitter : ITypeEmitter
 
         foreach (var ext in type.Extensions)
         {
-            // Replace tokens
-            string code = ext
-                .Code.Replace("$Class", type.Name)
+            if (!ext.CodeByVersion.TryGetValue(AhkVersion.v20, out string? rawCode))
+                continue;
+
+            string code = rawCode
+                .Replace("$Class", type.Name)
                 .Replace("$Namespace", type.Namespace)
                 .Replace("$Arch", type.Arch.ToString());
             if (type is ComInterfaceType iface)

--- a/Generator/Emit/Emitters/StructEmitter.cs
+++ b/Generator/Emit/Emitters/StructEmitter.cs
@@ -57,12 +57,17 @@ public sealed class StructEmitter : ITypeEmitter
     /// Emit the body of a struct: nested class definitions, member properties, extensions, __New.
     /// Shared by StructEmitter and HandleEmitter.
     /// </summary>
-    internal static void EmitBody(AhkWriter w, StructType structType, int embeddingOffset,
-        List<EmittedField> emittedMembers, string parentClassName)
+    internal static void EmitBody(
+        AhkWriter w,
+        StructType structType,
+        int embeddingOffset,
+        List<EmittedField> emittedMembers,
+        string parentClassName
+    )
     {
         // 1. Nested class definitions (non-anonymous, non-Reserved named nested types)
-        var nestedClassDefs = structType.Members
-            .Where(m => m.IsNested && !m.IsAnonymous && m.Name is not "Reserved")
+        var nestedClassDefs = structType
+            .Members.Where(m => m.IsNested && !m.IsAnonymous && m.Name is not "Reserved")
             .Where(m => m.EmbeddedStruct is not null)
             .Select(m => m.EmbeddedStruct!)
             .DistinctBy(s => s.Name);
@@ -90,10 +95,10 @@ public sealed class StructEmitter : ITypeEmitter
             {
                 if (field.EmbeddedStruct is null)
                     throw new InvalidOperationException(
-                        $"{structType.Name}.{field.Name} is anonymous but has no EmbeddedStruct");
+                        $"{structType.Name}.{field.Name} is anonymous but has no EmbeddedStruct"
+                    );
 
-                EmitBody(w, field.EmbeddedStruct, field.Offset + embeddingOffset,
-                    emittedMembers, parentClassName);
+                EmitBody(w, field.EmbeddedStruct, field.Offset + embeddingOffset, emittedMembers, parentClassName);
                 continue;
             }
 
@@ -103,8 +108,7 @@ public sealed class StructEmitter : ITypeEmitter
 
             // Name deconfliction
             int suffix = 0;
-            while (emittedMembers.Any(e =>
-                e.Name.Equals(field.Name, StringComparison.OrdinalIgnoreCase)))
+            while (emittedMembers.Any(e => e.Name.Equals(field.Name, StringComparison.OrdinalIgnoreCase)))
             {
                 field.Name += ++suffix;
             }
@@ -133,8 +137,12 @@ public sealed class StructEmitter : ITypeEmitter
         switch (field.Type)
         {
             case StructRef when field.EmbeddedStruct is not null:
-                EmitEmbeddedTypeMember(w, field, offset,
-                    field.IsNested ? $"{parentClassName}.{field.EmbeddedStruct.Name}" : field.EmbeddedStruct.Name);
+                EmitEmbeddedTypeMember(
+                    w,
+                    field,
+                    offset,
+                    field.IsNested ? $"{parentClassName}.{field.EmbeddedStruct.Name}" : field.EmbeddedStruct.Name
+                );
                 break;
             case HandleRef handleRef:
                 // Handle-typed fields use lazy-init pattern (handles are struct types in metadata).
@@ -193,13 +201,14 @@ public sealed class StructEmitter : ITypeEmitter
             using (w.InstanceProperty(bf.Name))
             {
                 w.Line($"get => (this.{field.Name} >> {bf.Offset}) & 0x{mask:X}");
-                w.Line($"set => this.{field.Name} := ((value & 0x{mask:X}) << {bf.Offset}) | (this.{field.Name} & ~(0x{mask:X} << {bf.Offset}))");
+                w.Line(
+                    $"set => this.{field.Name} := ((value & 0x{mask:X}) << {bf.Offset}) | (this.{field.Name} & ~(0x{mask:X} << {bf.Offset}))"
+                );
             }
         }
     }
 
-    private static void EmitEmbeddedTypeMember(AhkWriter w, FieldMember field, int offset,
-        string qualifiedName)
+    private static void EmitEmbeddedTypeMember(AhkWriter w, FieldMember field, int offset, string qualifiedName)
     {
         DocCommentWriter.WriteFieldDoc(w, field);
 
@@ -214,8 +223,7 @@ public sealed class StructEmitter : ITypeEmitter
         }
     }
 
-    private static void EmitArrayMember(AhkWriter w, FieldMember field, int offset,
-        string parentClassName)
+    private static void EmitArrayMember(AhkWriter w, FieldMember field, int offset, string parentClassName)
     {
         var arrayType = (ArrayType)field.Type;
         ResolvedType elementType = arrayType.ElementType;
@@ -228,9 +236,7 @@ public sealed class StructEmitter : ITypeEmitter
         {
             case StructRef structRef:
                 dllCallType = "";
-                ahkElementType = field.IsNested
-                    ? $"{parentClassName}.{structRef.Name}"
-                    : structRef.Name;
+                ahkElementType = field.IsNested ? $"{parentClassName}.{structRef.Name}" : structRef.Name;
                 break;
             case NativeTypedefRef nativeTypedef:
                 ahkElementType = "Primitive";
@@ -254,7 +260,9 @@ public sealed class StructEmitter : ITypeEmitter
             using (w.GetBlock())
             {
                 w.Line($"if(!this.HasProp(\"__{field.Name}ProxyArray\"))");
-                w.Line($"    this.__{field.Name}ProxyArray := Win32FixedArray(this.ptr + {offset}, {arrayType.Length}, {ahkElementType}, \"{dllCallType}\")");
+                w.Line(
+                    $"    this.__{field.Name}ProxyArray := Win32FixedArray(this.ptr + {offset}, {arrayType.Length}, {ahkElementType}, \"{dllCallType}\")"
+                );
                 w.Line($"return this.__{field.Name}ProxyArray");
             }
         }
@@ -277,8 +285,7 @@ public sealed class StructEmitter : ITypeEmitter
     internal void EmitImports(AhkWriter w, Win32Type type)
     {
         // Restrict to targets available in the registry to filter out nested types
-        IEnumerable<string> imports = type.Imports.GetIncludeTargets()
-            .Where(_registry.Contains);
+        IEnumerable<string> imports = type.Imports.GetIncludeTargets().Where(_registry.Contains);
 
         foreach (string import in imports)
         {
@@ -288,12 +295,14 @@ public sealed class StructEmitter : ITypeEmitter
 
     internal static void EmitExtensions(AhkWriter w, Win32Type type)
     {
-        if (type.Extensions.Count == 0) return;
+        if (type.Extensions.Count == 0)
+            return;
 
         foreach (var ext in type.Extensions)
         {
             // Replace tokens
-            string code = ext.Code.Replace("$Class", type.Name)
+            string code = ext
+                .Code.Replace("$Class", type.Name)
                 .Replace("$Namespace", type.Namespace)
                 .Replace("$Arch", type.Arch.ToString());
             if (type is ComInterfaceType iface)
@@ -323,8 +332,10 @@ public sealed class StructEmitter : ITypeEmitter
             else
             {
                 // Non-bitfield fields are duplicates if same offset + same name
-                if (field.Offset == existing.Offset &&
-                    field.Name.Equals(existing.Name, StringComparison.OrdinalIgnoreCase))
+                if (
+                    field.Offset == existing.Offset
+                    && field.Name.Equals(existing.Name, StringComparison.OrdinalIgnoreCase)
+                )
                     return true;
             }
         }
@@ -334,6 +345,5 @@ public sealed class StructEmitter : ITypeEmitter
     /// <summary>
     /// Tracks emitted fields for duplicate detection and name deconfliction.
     /// </summary>
-    internal record EmittedField(
-        string Name, int Offset, IReadOnlyList<BitfieldMember> Bitfields, bool IsBitField);
+    internal record EmittedField(string Name, int Offset, IReadOnlyList<BitfieldMember> Bitfields, bool IsBitField);
 }

--- a/Generator/Emit/Emitters/StructEmitter.cs
+++ b/Generator/Emit/Emitters/StructEmitter.cs
@@ -145,6 +145,10 @@ public sealed class StructEmitter : ITypeEmitter
                     field.IsNested ? $"{parentClassName}.{field.EmbeddedStruct.Name}" : field.EmbeddedStruct.Name
                 );
                 break;
+            case StructRef { FQN: "System.Guid" }:
+                // System.Guid has no embedded StructType; it maps to the Guid.ahk fixture.
+                EmitEmbeddedTypeMember(w, field, offset, "Guid");
+                break;
             case HandleRef handleRef:
                 // Handle-typed fields use lazy-init pattern (handles are struct types in metadata).
                 // Handles are always top-level types, so no parent qualification needed.
@@ -285,8 +289,12 @@ public sealed class StructEmitter : ITypeEmitter
 
     internal void EmitImports(AhkWriter w, Win32Type type)
     {
-        // Restrict to targets available in the registry to filter out nested types
-        IEnumerable<string> imports = type.Imports.GetIncludeTargets().Where(_registry.Contains);
+        // Restrict to targets available in the registry to filter out nested types.
+        // System.Guid isn't in the registry (it's the Guid.ahk fixture at the projection
+        // root) but resolves to a valid include path — let it through.
+        IEnumerable<string> imports = type
+            .Imports.GetIncludeTargets()
+            .Where(fqn => fqn == "System.Guid" || _registry.Contains(fqn));
 
         foreach (string import in imports)
         {

--- a/Generator/Emit/Emitters/StructEmitter21.cs
+++ b/Generator/Emit/Emitters/StructEmitter21.cs
@@ -297,8 +297,11 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
 
         foreach (var ext in type.Extensions)
         {
-            string code = ext
-                .Code.Replace("$Class", type.Name)
+            if (!ext.CodeByVersion.TryGetValue(AhkVersion.v21, out string? rawCode))
+                continue;
+
+            string code = rawCode
+                .Replace("$Class", type.Name)
                 .Replace("$Namespace", type.Namespace)
                 .Replace("$Arch", type.Arch.ToString());
             if (type is ComInterfaceType iface)

--- a/Generator/Emit/Emitters/StructEmitter21.cs
+++ b/Generator/Emit/Emitters/StructEmitter21.cs
@@ -145,7 +145,7 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
             case EnumRef enumRef:
                 EmitNumericMember(w, field, offset, enumRef.UnderlyingType.DllCallType);
                 break;
-            case NativeTypedefType nativeTypedef:
+            case NativeTypedefRef nativeTypedef:
                 EmitNumericMember(w, field, offset, nativeTypedef.Underlying.DllCallType);
                 break;
             default:
@@ -227,7 +227,7 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
                     ? $"{parentClassName}.{structRef.Name}"
                     : structRef.Name;
                 break;
-            case NativeTypedefType nativeTypedef:
+            case NativeTypedefRef nativeTypedef:
                 ahkElementType = "Primitive";
                 dllCallType = nativeTypedef.Underlying.DllCallType;
                 break;

--- a/Generator/Emit/Emitters/StructEmitter21.cs
+++ b/Generator/Emit/Emitters/StructEmitter21.cs
@@ -272,7 +272,8 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
     internal void EmitImports(AhkWriter w, Win32Type type)
     {
         // Restrict to types available in the registry to filter out nested types
-        foreach (string fqn in type.Imports.GetTypes().Where(_registry.Contains))
+        foreach (string fqn in type.Imports.GetTypes()
+            .Where(fqn => _registry.Contains(fqn) && fqn != type.FQN))
         {
             string path = ImportResolver.GetIncludePath(type.Namespace, fqn);
             w.Import(path, [ImportResolver.GetImportName(fqn)]);

--- a/Generator/Emit/Emitters/StructEmitter21.cs
+++ b/Generator/Emit/Emitters/StructEmitter21.cs
@@ -302,9 +302,10 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
         return field.Type switch
         {
             // String fields - IR collapses fixed-size character arrays into StringType.
-            // ANSI uses the CHAR NativeTypedef from Foundation; Unicode strings come from
-            // CLR char[] which has no metadata typedef, so render as raw UInt16 elements.
-            StringType s => $"{(s.Encoding == StringEncoding.Ansi ? "CHAR" : "UInt16")}[{s.Length}]",
+            // ANSI uses the CHAR NativeTypedef from Foundation; Unicode uses the synthetic
+            // WCHAR typedef (CLR char[] has no metadata typedef). Both carry .Array string
+            // magic via their extensions, restoring v2.0's string-assignment ergonomics.
+            StringType s => $"{(s.Encoding == StringEncoding.Ansi ? "CHAR" : "WCHAR")}[{s.Length}]",
 
             // Array of nested-defined struct: qualify the element name
             ArrayType { ElementType: StructRef es } a when field.IsNested => $"{parentClassName}.{es.Name}[{a.Length}]",
@@ -361,10 +362,14 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
     {
         foreach (FieldMember field in structType.Members)
         {
-            // Only ANSI StringType needs an import (the CHAR NativeTypedef from Foundation).
-            // Unicode StringType renders as raw UInt16[N] which needs no import.
-            if (field.Type is StringType { Encoding: StringEncoding.Ansi })
-                extras.Add("Windows.Win32.Foundation.CHAR");
+            // ANSI StringType imports the CHAR NativeTypedef; Unicode imports the synthetic
+            // WCHAR typedef. Both render as fixed arrays of the imported element type.
+            if (field.Type is StringType s)
+                extras.Add(
+                    s.Encoding == StringEncoding.Ansi
+                        ? "Windows.Win32.Foundation.CHAR"
+                        : "Windows.Win32.Foundation.WCHAR"
+                );
 
             if (field.EmbeddedStruct is not null)
                 CollectExtraImports(field.EmbeddedStruct, extras);

--- a/Generator/Emit/Emitters/StructEmitter21.cs
+++ b/Generator/Emit/Emitters/StructEmitter21.cs
@@ -189,6 +189,14 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
                 name = field.Name + ++suffix;
             field.Name = name;
 
+            // Cyclic pointer-to-struct field: emit a backing IntPtr (for layout) plus a dynamic
+            // accessor that resolves the pointee only at call time, breaking the import cycle.
+            if (field.EmitAsLazyPointer)
+            {
+                EmitLazyPointer(w, field, name, deferred, ref cursor, emitted, absOffset);
+                continue;
+            }
+
             string typeExpr = GetTypeExpression(field, parentClassName);
 
             // Forward fields (offset >= cursor) become typed properties in the body;
@@ -221,6 +229,69 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
             if (field.IsBitField)
                 EmitBitfieldAccessors(w, field);
         }
+    }
+
+    /// <summary>
+    /// Emit a cyclic pointer-to-struct field as a backing <c>IntPtr</c> (which drives layout)
+    /// plus a dynamic accessor that boxes/unboxes the pointee only at call time. This breaks the
+    /// load-time import cycle that a plain <c>Pointee.Ptr</c> typed property would create.
+    /// <para>
+    /// No script-side reference to an assigned boxed struct is retained: a v2.1 struct can only
+    /// hold typed (memory-backed) properties, so there is nowhere to stash an object reference.
+    /// As with raw pointers in v2.0, the caller must keep the pointee alive while it is referenced
+    /// — reading a pointer filled in by external code (the common interop case) is unaffected.
+    /// </para>
+    /// </summary>
+    private static void EmitLazyPointer(
+        AhkWriter w,
+        FieldMember field,
+        string name,
+        List<DeferredProp> deferred,
+        ref int cursor,
+        HashSet<string> emitted,
+        int absOffset
+    )
+    {
+        if (field.Type is not PointerType { Pointee: StructRef pointee })
+            throw new InvalidOperationException(
+                $"Field '{name}' is marked EmitAsLazyPointer but is not a pointer-to-struct ({field.Type.DisplayName})"
+            );
+
+        // Deconflict the synthetic backing property name against everything emitted so far.
+        string backing = Deconflict($"__{name}_ptr", emitted);
+        emitted.Add(backing);
+
+        // Backing storage: forward fields become a typed property in the body (auto-layout drives
+        // the offset); overlap fields become a deferred DefineProp at the explicit offset.
+        if (absOffset >= cursor)
+        {
+            w.Line($"{backing} : IntPtr");
+            cursor = absOffset + field.Size;
+        }
+        else
+        {
+            deferred.Add(new DeferredProp(backing, "IntPtr", absOffset));
+        }
+
+        // Dynamic accessor (occupies no layout). Doc goes on the public property.
+        DocCommentWriter.WriteFieldDoc(w, field, AhkVersion.v21);
+        using (w.InstanceProperty(name))
+        {
+            w.Line($"get => (addr := this.{backing}) ? {pointee.Name}.At(addr) : unset");
+            w.Line($"set => this.{backing} := (IsSet(value) && value) ? value.Ptr : 0");
+        }
+
+        emitted.Add(name);
+        w.BlankLine();
+    }
+
+    private static string Deconflict(string desired, HashSet<string> emitted)
+    {
+        string name = desired;
+        int suffix = 0;
+        while (emitted.Contains(name))
+            name = desired + ++suffix;
+        return name;
     }
 
     /// <summary>

--- a/Generator/Emit/Emitters/StructEmitter21.cs
+++ b/Generator/Emit/Emitters/StructEmitter21.cs
@@ -61,12 +61,11 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
         // when auto-execute runs.
         var deferred = new List<DeferredProp>();
 
-        // 1. Nested non-anonymous struct definitions (referenced by member fields below)
-        var nestedClassDefs = structType
-            .Members.Where(m => m.IsNested && !m.IsAnonymous && m.Name is not "Reserved")
-            .Where(m => m.EmbeddedStruct is not null)
-            .Select(m => m.EmbeddedStruct!)
-            .DistinctBy(s => s.Name);
+        // 1. Nested non-anonymous struct definitions (referenced by member fields below).
+        // Walk through anonymous-union/struct members too — when those get flattened in
+        // step 2, any non-anonymous nested structs they contained still need their class
+        // definitions hoisted into this enclosing class.
+        var nestedClassDefs = CollectNestedClassDefs(structType).DistinctBy(s => s.Name);
 
         foreach (StructType nested in nestedClassDefs)
         {
@@ -76,6 +75,9 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
                 EmitBody(w, nested, $"{parentClassName}.{nested.Name}");
             }
         }
+
+        if (nestedClassDefs.Any())
+            w.BlankLine();
 
         // 2. Field properties - track the natural-layout cursor to detect overlaps.
         int cursor = 0;
@@ -98,7 +100,6 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
         // 4. Deferred DefineProp calls inside static __New (self-deleting)
         if (deferred.Count > 0)
         {
-            w.BlankLine();
             using (w.StaticMethod("__New", ""))
             {
                 foreach (DeferredProp d in deferred)
@@ -111,6 +112,31 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
 
         // Struct-size init is handled by the typed-property initializer (`:= this.Size`)
         // emitted at the size field above; no separate __New() needed.
+    }
+
+    /// <summary>
+    /// Collect non-anonymous nested struct definitions reachable from a struct's members,
+    /// descending through anonymous nested structs/unions. Mirrors the field-flattening
+    /// done by <see cref="EmitFields"/> so that nested classes referenced after flattening
+    /// still get their definitions emitted in the enclosing class.
+    /// </summary>
+    private static IEnumerable<StructType> CollectNestedClassDefs(StructType structType)
+    {
+        foreach (FieldMember m in structType.Members)
+        {
+            if (m.EmbeddedStruct is null || m.Name == "Reserved")
+                continue;
+
+            if (m.IsNested && m.IsAnonymous)
+            {
+                foreach (StructType s in CollectNestedClassDefs(m.EmbeddedStruct))
+                    yield return s;
+            }
+            else if (m.IsNested)
+            {
+                yield return m.EmbeddedStruct;
+            }
+        }
     }
 
     /// <summary>

--- a/Generator/Emit/Emitters/StructEmitter21.cs
+++ b/Generator/Emit/Emitters/StructEmitter21.cs
@@ -61,12 +61,11 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
     /// Emit the body of a struct: nested struct definitions, typed property fields,
     /// bit accessors, struct-size init, and extension blocks.
     /// </summary>
-    internal void EmitBody(AhkWriter w, StructType structType, string parentClassName,
-        List<DeferredProp> deferred)
+    internal void EmitBody(AhkWriter w, StructType structType, string parentClassName, List<DeferredProp> deferred)
     {
         // 1. Nested non-anonymous struct definitions (referenced by member fields below)
-        var nestedClassDefs = structType.Members
-            .Where(m => m.IsNested && !m.IsAnonymous && m.Name is not "Reserved")
+        var nestedClassDefs = structType
+            .Members.Where(m => m.IsNested && !m.IsAnonymous && m.Name is not "Reserved")
             .Where(m => m.EmbeddedStruct is not null)
             .Select(m => m.EmbeddedStruct!)
             .DistinctBy(s => s.Name);
@@ -84,7 +83,16 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
         int cursor = 0;
         var emitted = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        EmitFields(w, structType, structType.Members, parentClassName, deferred, ref cursor, emitted, embeddingOffset: 0);
+        EmitFields(
+            w,
+            structType,
+            structType.Members,
+            parentClassName,
+            deferred,
+            ref cursor,
+            emitted,
+            embeddingOffset: 0
+        );
 
         // 3. Extensions
         EmitExtensions(w, structType);
@@ -97,9 +105,16 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
     /// Walk the field list emitting typed properties; recurse into anonymous nested
     /// structs/unions to flatten them into the parent's namespace.
     /// </summary>
-    private void EmitFields(AhkWriter w, StructType owner, IReadOnlyList<FieldMember> fields,
-        string parentClassName, List<DeferredProp> deferred,
-        ref int cursor, HashSet<string> emitted, int embeddingOffset)
+    private void EmitFields(
+        AhkWriter w,
+        StructType owner,
+        IReadOnlyList<FieldMember> fields,
+        string parentClassName,
+        List<DeferredProp> deferred,
+        ref int cursor,
+        HashSet<string> emitted,
+        int embeddingOffset
+    )
     {
         foreach (FieldMember field in fields)
         {
@@ -110,10 +125,19 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
             {
                 if (field.EmbeddedStruct is null)
                     throw new InvalidOperationException(
-                        $"{owner.Name}.{field.Name} is anonymous but has no EmbeddedStruct");
+                        $"{owner.Name}.{field.Name} is anonymous but has no EmbeddedStruct"
+                    );
 
-                EmitFields(w, owner, field.EmbeddedStruct.Members, parentClassName, deferred,
-                    ref cursor, emitted, absOffset);
+                EmitFields(
+                    w,
+                    owner,
+                    field.EmbeddedStruct.Members,
+                    parentClassName,
+                    deferred,
+                    ref cursor,
+                    emitted,
+                    absOffset
+                );
                 continue;
             }
 
@@ -174,8 +198,7 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
             StringType s => $"{(s.Encoding == StringEncoding.Ansi ? "CHAR" : "UInt16")}[{s.Length}]",
 
             // Array of nested-defined struct: qualify the element name
-            ArrayType { ElementType: StructRef es } a when field.IsNested
-                => $"{parentClassName}.{es.Name}[{a.Length}]",
+            ArrayType { ElementType: StructRef es } a when field.IsNested => $"{parentClassName}.{es.Name}[{a.Length}]",
 
             // Bitfields - backing field uses a primitive type derived from its size
             _ when field.IsBitField => BitfieldBackingTypeSpecifier(field.Size),
@@ -184,18 +207,19 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
             StructRef sr when field.IsNested => $"{parentClassName}.{sr.Name}",
 
             // Anything else: TypeSpecifier already produces the right token
-            _ => field.Type.TypeSpecifier
+            _ => field.Type.TypeSpecifier,
         };
     }
 
-    private static string BitfieldBackingTypeSpecifier(int sizeBytes) => sizeBytes switch
-    {
-        1 => "Int8",
-        2 => "Int16",
-        4 => "Int32",
-        8 => "Int64",
-        _ => throw new InvalidOperationException($"Unsupported bitfield backing size: {sizeBytes} bytes")
-    };
+    private static string BitfieldBackingTypeSpecifier(int sizeBytes) =>
+        sizeBytes switch
+        {
+            1 => "Int8",
+            2 => "Int16",
+            4 => "Int32",
+            8 => "Int64",
+            _ => throw new InvalidOperationException($"Unsupported bitfield backing size: {sizeBytes} bytes"),
+        };
 
     private static void EmitBitfieldAccessors(AhkWriter w, FieldMember field)
     {
@@ -212,7 +236,9 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
             using (w.InstanceProperty(bf.Name))
             {
                 w.Line($"get => (this.{field.Name} >> {bf.Offset}) & 0x{mask:X}");
-                w.Line($"set => this.{field.Name} := ((value & 0x{mask:X}) << {bf.Offset}) | (this.{field.Name} & ~(0x{mask:X} << {bf.Offset}))");
+                w.Line(
+                    $"set => this.{field.Name} := ((value & 0x{mask:X}) << {bf.Offset}) | (this.{field.Name} & ~(0x{mask:X} << {bf.Offset}))"
+                );
             }
         }
     }
@@ -241,17 +267,18 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
         var seen = new HashSet<string>();
 
         // Restrict to types available in the registry to filter out nested types
-        foreach (string fqn in type.Imports.GetTypes()
-            .Where(fqn => _registry.Contains(fqn) && fqn != type.FQN))
+        foreach (string fqn in type.Imports.GetTypes().Where(fqn => _registry.Contains(fqn) && fqn != type.FQN))
         {
-            if (!seen.Add(fqn)) continue;
+            if (!seen.Add(fqn))
+                continue;
             string path = ImportResolver.GetIncludePath(type.Namespace, fqn);
             w.Import(path, [ImportResolver.GetImportName(fqn)]);
         }
 
         foreach (string fqn in extraImports)
         {
-            if (fqn == type.FQN || !_registry.Contains(fqn) || !seen.Add(fqn)) continue;
+            if (fqn == type.FQN || !_registry.Contains(fqn) || !seen.Add(fqn))
+                continue;
             string path = ImportResolver.GetIncludePath(type.Namespace, fqn);
             w.Import(path, [ImportResolver.GetImportName(fqn)]);
         }
@@ -265,11 +292,13 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
 
     internal static void EmitExtensions(AhkWriter w, Win32Type type)
     {
-        if (type.Extensions.Count == 0) return;
+        if (type.Extensions.Count == 0)
+            return;
 
         foreach (var ext in type.Extensions)
         {
-            string code = ext.Code.Replace("$Class", type.Name)
+            string code = ext
+                .Code.Replace("$Class", type.Name)
                 .Replace("$Namespace", type.Namespace)
                 .Replace("$Arch", type.Arch.ToString());
             if (type is ComInterfaceType iface)

--- a/Generator/Emit/Emitters/StructEmitter21.cs
+++ b/Generator/Emit/Emitters/StructEmitter21.cs
@@ -413,6 +413,7 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
         if (type.Extensions.Count == 0)
             return;
 
+        w.BlankLine();
         foreach (var ext in type.Extensions)
         {
             if (!ext.CodeByVersion.TryGetValue(AhkVersion.v21, out string? rawCode))

--- a/Generator/Emit/Emitters/StructEmitter21.cs
+++ b/Generator/Emit/Emitters/StructEmitter21.cs
@@ -40,20 +40,11 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
 
         DocCommentWriter.WriteTypeDoc(w, structType);
 
-        var deferred = new List<DeferredProp>();
         using (w.Struct(structType.Name))
         {
             w.Line($"#StructPack {structType.PackingSize}");
             w.BlankLine();
-            EmitBody(w, structType, structType.Name, deferred);
-        }
-
-        w.BlankLine();
-
-        // DefineProp calls for fields whose offsets diverge from natural layout
-        foreach (DeferredProp d in deferred)
-        {
-            w.Line($"DefineProp({d.QualifiedClass}.Prototype, '{d.Name}', {{type: {d.TypeExpr}, offset: {d.Offset}}})");
+            EmitBody(w, structType, structType.Name);
         }
     }
 
@@ -61,8 +52,15 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
     /// Emit the body of a struct: nested struct definitions, typed property fields,
     /// bit accessors, struct-size init, and extension blocks.
     /// </summary>
-    internal void EmitBody(AhkWriter w, StructType structType, string parentClassName, List<DeferredProp> deferred)
+    internal void EmitBody(AhkWriter w, StructType structType, string parentClassName)
     {
+        // Deferred DefineProp calls are scoped to *this* struct's class body and emitted
+        // inside a `static __New()` at the bottom — running them in the auto-execute
+        // thread (the v2.0 approach) causes "Cannot define typed property" errors for
+        // nested structs under v2.1-alpha, since the parent class isn't fully constructed
+        // when auto-execute runs.
+        var deferred = new List<DeferredProp>();
+
         // 1. Nested non-anonymous struct definitions (referenced by member fields below)
         var nestedClassDefs = structType
             .Members.Where(m => m.IsNested && !m.IsAnonymous && m.Name is not "Reserved")
@@ -75,7 +73,7 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
             w.BlankLine();
             using (w.Struct(nested.Name))
             {
-                EmitBody(w, nested, $"{parentClassName}.{nested.Name}", deferred);
+                EmitBody(w, nested, $"{parentClassName}.{nested.Name}");
             }
         }
 
@@ -96,6 +94,20 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
 
         // 3. Extensions
         EmitExtensions(w, structType);
+
+        // 4. Deferred DefineProp calls inside static __New (self-deleting)
+        if (deferred.Count > 0)
+        {
+            w.BlankLine();
+            using (w.StaticMethod("__New", ""))
+            {
+                foreach (DeferredProp d in deferred)
+                {
+                    w.Line($"DefineProp(this.Prototype, '{d.Name}', {{ type: {d.TypeExpr}, offset: {d.Offset} }})");
+                }
+                w.Line("this.DeleteProp(\"__New\")");
+            }
+        }
 
         // Struct-size init is handled by the typed-property initializer (`:= this.Size`)
         // emitted at the size field above; no separate __New() needed.
@@ -174,7 +186,7 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
             }
             else
             {
-                deferred.Add(new DeferredProp(parentClassName, name, typeExpr, absOffset));
+                deferred.Add(new DeferredProp(name, typeExpr, absOffset));
             }
 
             emitted.Add(name);
@@ -322,7 +334,7 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
 
     /// <summary>
     /// A typed-property field whose metadata offset doesn't match natural layout
-    /// and must be emitted as a DefineProp call after the struct body.
+    /// and must be emitted as a DefineProp call in the owning class's static __New.
     /// </summary>
-    internal record DeferredProp(string QualifiedClass, string Name, string TypeExpr, int Offset);
+    internal record DeferredProp(string Name, string TypeExpr, int Offset);
 }

--- a/Generator/Emit/Emitters/StructEmitter21.cs
+++ b/Generator/Emit/Emitters/StructEmitter21.cs
@@ -9,14 +9,9 @@ using AhkWin32.Generator.Model.Types;
 /// Port of legacy AhkStruct.ToAhk() and AhkStructMember.ToAhk().
 /// Body emission methods are internal static so HandleEmitter can reuse them.
 /// </summary>
-public sealed class StructEmitter : ITypeEmitter
+public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
 {
-    private readonly TypeRegistry _registry;
-
-    public StructEmitter(TypeRegistry registry)
-    {
-        _registry = registry;
-    }
+    private readonly TypeRegistry _registry = registry;
 
     public bool CanEmit(Win32Type type) => type is StructType and not HandleType;
 
@@ -34,8 +29,8 @@ public sealed class StructEmitter : ITypeEmitter
     private void EmitStruct(AhkWriter w, StructType structType)
     {
         string pathToBase = ImportResolver.GetPathToBase(structType.Namespace);
-        w.Require("AutoHotkey v2.0.0 64-bit");
-        w.Include($"{pathToBase}Win32Struct.ahk");
+        w.Require("AutoHotkey v2.1-alpha.24+ 64-bit");
+        w.Import($"{pathToBase}Win32Struct.ahk", ["Win32Struct"]);
 
         EmitImports(w, structType);
 
@@ -276,13 +271,17 @@ public sealed class StructEmitter : ITypeEmitter
 
     internal void EmitImports(AhkWriter w, Win32Type type)
     {
-        // Restrict to targets available in the registry to filter out nested types
-        IEnumerable<string> imports = type.Imports.GetIncludeTargets()
-            .Where(_registry.Contains);
-
-        foreach (string import in imports)
+        // Restrict to types available in the registry to filter out nested types
+        foreach (string fqn in type.Imports.GetTypes().Where(_registry.Contains))
         {
-            w.Include(ImportResolver.GetIncludePath(type.Namespace, import));
+            string path = ImportResolver.GetIncludePath(type.Namespace, fqn);
+            w.Import(path, [ImportResolver.GetImportName(fqn)]);
+        }
+
+        foreach (string apisFqn in type.Imports.GetFunctionNamespaces())
+        {
+            string path = ImportResolver.GetIncludePath(type.Namespace, apisFqn);
+            w.Import(path, type.Imports.GetFunctionsForNamespace(apisFqn));
         }
     }
 

--- a/Generator/Emit/Emitters/StructEmitter21.cs
+++ b/Generator/Emit/Emitters/StructEmitter21.cs
@@ -1,13 +1,15 @@
 namespace AhkWin32.Generator.Emit.Emitters;
 
+using AhkWin32.Generator.Metadata;
 using AhkWin32.Generator.Model;
 using AhkWin32.Generator.Model.Members;
 using AhkWin32.Generator.Model.Types;
 
 /// <summary>
-/// Emits StructType as a complete .ahk file.
-/// Port of legacy AhkStruct.ToAhk() and AhkStructMember.ToAhk().
-/// Body emission methods are internal static so HandleEmitter can reuse them.
+/// Emits a StructType as a v2.1 native `struct` block. Fields are typed properties
+/// (`name : TypeSpecifier`) when their metadata offset matches natural layout; fields
+/// whose offsets diverge (anonymous-union overlaps, padding gaps) are emitted as
+/// DefineProp calls on the prototype with explicit `offset:`.
 /// </summary>
 public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
 {
@@ -18,7 +20,7 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
     public EmitResult Emit(Win32Type type, string outputRoot)
     {
         var structType = (StructType)type;
-        var w = new AhkWriter();
+        var w = new AhkWriter(AhkVersion.v21);
 
         EmitStruct(w, structType);
 
@@ -28,9 +30,7 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
 
     private void EmitStruct(AhkWriter w, StructType structType)
     {
-        string pathToBase = ImportResolver.GetPathToBase(structType.Namespace);
-        w.Require("AutoHotkey v2.1-alpha.24+ 64-bit");
-        w.Import($"{pathToBase}Win32Struct.ahk", ["Win32Struct"]);
+        w.Require("AutoHotkey v2.1-alpha.26+ 64-bit");
 
         EmitImports(w, structType);
 
@@ -38,24 +38,31 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
 
         DocCommentWriter.WriteTypeDoc(w, structType);
 
-        using (w.Class(structType.Name, "Win32Struct"))
+        var deferred = new List<DeferredProp>();
+        using (w.Struct(structType.Name))
         {
-            w.StaticField("sizeof", structType.Size.ToString());
+            w.Line($"#StructPack {structType.PackingSize}");
             w.BlankLine();
-            w.StaticField("packingSize", structType.PackingSize.ToString());
+            EmitBody(w, structType, structType.Name, deferred);
+        }
 
-            EmitBody(w, structType, 0, [], structType.Name);
+        w.BlankLine();
+
+        // DefineProp calls for fields whose offsets diverge from natural layout
+        foreach (DeferredProp d in deferred)
+        {
+            w.Line($"DefineProp({d.QualifiedClass}.Prototype, '{d.Name}', {{type: {d.TypeExpr}, offset: {d.Offset}}})");
         }
     }
 
     /// <summary>
-    /// Emit the body of a struct: nested class definitions, member properties, extensions, __New.
-    /// Shared by StructEmitter and HandleEmitter.
+    /// Emit the body of a struct: nested struct definitions, typed property fields,
+    /// bit accessors, struct-size init, and extension blocks.
     /// </summary>
-    internal static void EmitBody(AhkWriter w, StructType structType, int embeddingOffset,
-        List<EmittedField> emittedMembers, string parentClassName)
+    internal void EmitBody(AhkWriter w, StructType structType, string parentClassName,
+        List<DeferredProp> deferred)
     {
-        // 1. Nested class definitions (non-anonymous, non-Reserved named nested types)
+        // 1. Nested non-anonymous struct definitions (referenced by member fields below)
         var nestedClassDefs = structType.Members
             .Where(m => m.IsNested && !m.IsAnonymous && m.Name is not "Reserved")
             .Where(m => m.EmbeddedStruct is not null)
@@ -65,111 +72,129 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
         foreach (StructType nested in nestedClassDefs)
         {
             w.BlankLine();
-            using (w.Class(nested.Name, "Win32Struct"))
+            using (w.Struct(nested.Name))
             {
-                w.StaticField("sizeof", nested.Size.ToString());
-                w.StaticField("packingSize", nested.PackingSize.ToString());
-
-                EmitBody(w, nested, 0, [], $"{parentClassName}.{nested.Name}");
+                EmitBody(w, nested, $"{parentClassName}.{nested.Name}", deferred);
             }
         }
 
-        // 2. Members
-        foreach (FieldMember field in structType.Members)
-        {
-            if (field.IsReserved || field.IsAlignment)
-                continue;
+        // 2. Field properties - track the natural-layout cursor to detect overlaps.
+        int cursor = 0;
+        var emitted = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            // Flatten anonymous unions
-            if (field.IsNested && field.IsAnonymous)
-            {
-                if (field.EmbeddedStruct is null)
-                    throw new InvalidOperationException(
-                        $"{structType.Name}.{field.Name} is anonymous but has no EmbeddedStruct");
-
-                EmitBody(w, field.EmbeddedStruct, field.Offset + embeddingOffset,
-                    emittedMembers, parentClassName);
-                continue;
-            }
-
-            // Skip duplicates
-            if (IsDuplicate(field, emittedMembers))
-                continue;
-
-            // Name deconfliction
-            int suffix = 0;
-            while (emittedMembers.Any(e =>
-                e.Name.Equals(field.Name, StringComparison.OrdinalIgnoreCase)))
-            {
-                field.Name += ++suffix;
-            }
-
-            w.BlankLine();
-            EmitMember(w, field, field.Offset + embeddingOffset, parentClassName);
-            emittedMembers.Add(new EmittedField(field.Name, field.Offset, field.Bitfields, field.IsBitField));
-        }
+        EmitFields(w, structType, structType.Members, parentClassName, deferred, ref cursor, emitted, embeddingOffset: 0);
 
         // 3. Extensions
         EmitExtensions(w, structType);
 
-        // 4. __New for StructSizeField
-        if (structType.StructSizeFieldName is not null)
-        {
-            w.BlankLine();
-            w.Line($"__New(ptrOrObj := 0, parent := \"\"){{");
-            w.Line($"    super.__New(ptrOrObj, parent)");
-            w.Line($"    this.{structType.StructSizeFieldName} := {structType.Size}");
-            w.Line("}");
-        }
+        // Struct-size init is handled by the typed-property initializer (`:= this.Size`)
+        // emitted at the size field above; no separate __New() needed.
     }
 
-    private static void EmitMember(AhkWriter w, FieldMember field, int offset, string parentClassName)
+    /// <summary>
+    /// Walk the field list emitting typed properties; recurse into anonymous nested
+    /// structs/unions to flatten them into the parent's namespace.
+    /// </summary>
+    private void EmitFields(AhkWriter w, StructType owner, IReadOnlyList<FieldMember> fields,
+        string parentClassName, List<DeferredProp> deferred,
+        ref int cursor, HashSet<string> emitted, int embeddingOffset)
     {
-        switch (field.Type)
+        foreach (FieldMember field in fields)
         {
-            case StructRef when field.EmbeddedStruct is not null:
-                EmitEmbeddedTypeMember(w, field, offset,
-                    field.IsNested ? $"{parentClassName}.{field.EmbeddedStruct.Name}" : field.EmbeddedStruct.Name);
-                break;
-            case HandleRef handleRef:
-                // Handle-typed fields use lazy-init pattern (handles are struct types in metadata).
-                // Handles are always top-level types, so no parent qualification needed.
-                EmitEmbeddedTypeMember(w, field, offset, handleRef.Name);
-                break;
-            case ArrayType:
-                EmitArrayMember(w, field, offset, parentClassName);
-                break;
-            case StringType:
-                EmitStringMember(w, field, offset);
-                break;
-            case EnumRef enumRef:
-                EmitNumericMember(w, field, offset, enumRef.UnderlyingType.DllCallType);
-                break;
-            case NativeTypedefRef nativeTypedef:
-                EmitNumericMember(w, field, offset, nativeTypedef.Underlying.DllCallType);
-                break;
-            default:
-                // PrimitiveType, PointerType, ComRef, HResultType, NtStatusType, FunctionPointerType
-                EmitNumericMember(w, field, offset, field.Type.DllCallType);
-                break;
+            int absOffset = field.Offset + embeddingOffset;
+
+            // Anonymous nested struct/union - flatten into parent
+            if (field.IsNested && field.IsAnonymous)
+            {
+                if (field.EmbeddedStruct is null)
+                    throw new InvalidOperationException(
+                        $"{owner.Name}.{field.Name} is anonymous but has no EmbeddedStruct");
+
+                EmitFields(w, owner, field.EmbeddedStruct.Members, parentClassName, deferred,
+                    ref cursor, emitted, absOffset);
+                continue;
+            }
+
+            // Reserved / alignment fields participate in declaration-order layout under
+            // v2.1 and so MUST be emitted; auto-layout + #StructPack handles their offsets.
+
+            // Name deconfliction against already-emitted fields
+            string name = field.Name;
+            int suffix = 0;
+            while (emitted.Contains(name))
+                name = field.Name + ++suffix;
+            field.Name = name;
+
+            string typeExpr = GetTypeExpression(field, parentClassName);
+
+            // Forward fields (offset >= cursor) become typed properties in the body;
+            // overlap fields (offset < cursor) become DefineProp calls on the prototype.
+            // Auto-layout + #StructPack handles natural alignment padding, so a gap
+            // between cursor and absOffset is fine.
+            if (absOffset >= cursor)
+            {
+                DocCommentWriter.WriteFieldDoc(w, field, AhkVersion.v21);
+                if (owner.StructSizeFieldName == name)
+                {
+                    w.Line($"{name} : {typeExpr} := this.Size");
+                }
+                else
+                {
+                    w.Line($"{name} : {typeExpr}");
+                }
+
+                cursor = absOffset + field.Size;
+                w.BlankLine();
+            }
+            else
+            {
+                deferred.Add(new DeferredProp(parentClassName, name, typeExpr, absOffset));
+            }
+
+            emitted.Add(name);
+
+            // Bitfield accessors are dynamic properties regardless of how the backing was emitted
+            if (field.IsBitField)
+                EmitBitfieldAccessors(w, field);
         }
     }
 
-    private static void EmitNumericMember(AhkWriter w, FieldMember field, int offset, string dllCallType)
+    /// <summary>
+    /// Build the AHK type expression for a field's typed-property declaration.
+    /// </summary>
+    private string GetTypeExpression(FieldMember field, string parentClassName)
     {
-        DocCommentWriter.WriteFieldDoc(w, field);
-
-        using (w.InstanceProperty(field.Name))
+        return field.Type switch
         {
-            w.Line($"get => NumGet(this, {offset}, \"{dllCallType}\")");
-            w.Line($"set => NumPut(\"{dllCallType}\", value, this, {offset})");
-        }
+            // String fields (CHAR[N]/WCHAR[N]) - IR collapses these to StringType,
+            // re-expand to typedef-element arrays so the named CHAR/WCHAR survives.
+            StringType s => $"{(s.Encoding == StringEncoding.Ansi ? "CHAR" : "WCHAR")}[{s.Length}]",
 
-        if (field.IsBitField)
-            EmitBitfieldMembers(w, field);
+            // Array of nested-defined struct: qualify the element name
+            ArrayType { ElementType: StructRef es } a when field.IsNested
+                => $"{parentClassName}.{es.Name}[{a.Length}]",
+
+            // Bitfields - backing field uses a primitive type derived from its size
+            _ when field.IsBitField => BitfieldBackingTypeSpecifier(field.Size),
+
+            // Nested struct ref defined inline in the parent: qualify the name
+            StructRef sr when field.IsNested => $"{parentClassName}.{sr.Name}",
+
+            // Anything else: TypeSpecifier already produces the right token
+            _ => field.Type.TypeSpecifier
+        };
     }
 
-    private static void EmitBitfieldMembers(AhkWriter w, FieldMember field)
+    private static string BitfieldBackingTypeSpecifier(int sizeBytes) => sizeBytes switch
+    {
+        1 => "Int8",
+        2 => "Int16",
+        4 => "Int32",
+        8 => "Int64",
+        _ => throw new InvalidOperationException($"Unsupported bitfield backing size: {sizeBytes} bytes")
+    };
+
+    private static void EmitBitfieldAccessors(AhkWriter w, FieldMember field)
     {
         foreach (BitfieldMember bf in field.Bitfields)
         {
@@ -177,10 +202,6 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
                 continue;
 
             w.BlankLine();
-
-            // Look up description from field's embedded docs if available
-            // Bitfield members don't have individual descriptions in FieldMember,
-            // so we pass null for description
             DocCommentWriter.WriteBitfieldDoc(w, field, bf, null);
 
             long mask = (1L << (int)bf.Length) - 1;
@@ -190,82 +211,6 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
                 w.Line($"get => (this.{field.Name} >> {bf.Offset}) & 0x{mask:X}");
                 w.Line($"set => this.{field.Name} := ((value & 0x{mask:X}) << {bf.Offset}) | (this.{field.Name} & ~(0x{mask:X} << {bf.Offset}))");
             }
-        }
-    }
-
-    private static void EmitEmbeddedTypeMember(AhkWriter w, FieldMember field, int offset,
-        string qualifiedName)
-    {
-        DocCommentWriter.WriteFieldDoc(w, field);
-
-        using (w.InstanceProperty(field.Name))
-        {
-            using (w.GetBlock())
-            {
-                w.Line($"if(!this.HasProp(\"__{field.Name}\"))");
-                w.Line($"    this.__{field.Name} := {qualifiedName}({offset}, this)");
-                w.Line($"return this.__{field.Name}");
-            }
-        }
-    }
-
-    private static void EmitArrayMember(AhkWriter w, FieldMember field, int offset,
-        string parentClassName)
-    {
-        var arrayType = (ArrayType)field.Type;
-        ResolvedType elementType = arrayType.ElementType;
-
-        // Determine AHK element type and DllCall type for Win32FixedArray
-        string ahkElementType;
-        string dllCallType;
-
-        switch (elementType)
-        {
-            case StructRef structRef:
-                dllCallType = "";
-                ahkElementType = field.IsNested
-                    ? $"{parentClassName}.{structRef.Name}"
-                    : structRef.Name;
-                break;
-            case NativeTypedefRef nativeTypedef:
-                ahkElementType = "Primitive";
-                dllCallType = nativeTypedef.Underlying.DllCallType;
-                break;
-            case EnumRef enumRef:
-                ahkElementType = "Primitive";
-                dllCallType = enumRef.UnderlyingType.DllCallType;
-                break;
-            default:
-                // PrimitiveType, PointerType, ComRef, HandleRef, HResultType, NtStatusType, FunctionPointerType
-                ahkElementType = "Primitive";
-                dllCallType = elementType.DllCallType;
-                break;
-        }
-
-        DocCommentWriter.WriteFieldDoc(w, field);
-
-        using (w.InstanceProperty(field.Name))
-        {
-            using (w.GetBlock())
-            {
-                w.Line($"if(!this.HasProp(\"__{field.Name}ProxyArray\"))");
-                w.Line($"    this.__{field.Name}ProxyArray := Win32FixedArray(this.ptr + {offset}, {arrayType.Length}, {ahkElementType}, \"{dllCallType}\")");
-                w.Line($"return this.__{field.Name}ProxyArray");
-            }
-        }
-    }
-
-    private static void EmitStringMember(AhkWriter w, FieldMember field, int offset)
-    {
-        var stringType = (StringType)field.Type;
-        string encoding = stringType.Encoding == StringEncoding.Ansi ? "UTF-8" : "UTF-16";
-
-        DocCommentWriter.WriteFieldDoc(w, field);
-
-        using (w.InstanceProperty(field.Name))
-        {
-            w.Line($"get => StrGet(this.ptr + {offset}, {stringType.Length - 1}, \"{encoding}\")");
-            w.Line($"set => StrPut(value, this.ptr + {offset}, {stringType.Length - 1}, \"{encoding}\")");
         }
     }
 
@@ -292,7 +237,6 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
 
         foreach (var ext in type.Extensions)
         {
-            // Replace tokens
             string code = ext.Code.Replace("$Class", type.Name)
                 .Replace("$Namespace", type.Namespace)
                 .Replace("$Arch", type.Arch.ToString());
@@ -308,32 +252,9 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
         }
     }
 
-    // --- Duplicate detection ---
-
-    private static bool IsDuplicate(FieldMember field, List<EmittedField> emitted)
-    {
-        foreach (var existing in emitted)
-        {
-            if (field.IsBitField && existing.IsBitField)
-            {
-                // Bitfield fields are duplicates if they back the same bitfield list
-                if (field.Bitfields.SequenceEqual(existing.Bitfields))
-                    return true;
-            }
-            else
-            {
-                // Non-bitfield fields are duplicates if same offset + same name
-                if (field.Offset == existing.Offset &&
-                    field.Name.Equals(existing.Name, StringComparison.OrdinalIgnoreCase))
-                    return true;
-            }
-        }
-        return false;
-    }
-
     /// <summary>
-    /// Tracks emitted fields for duplicate detection and name deconfliction.
+    /// A typed-property field whose metadata offset doesn't match natural layout
+    /// and must be emitted as a DefineProp call after the struct body.
     /// </summary>
-    internal record EmittedField(
-        string Name, int Offset, IReadOnlyList<BitfieldMember> Bitfields, bool IsBitField);
+    internal record DeferredProp(string QualifiedClass, string Name, string TypeExpr, int Offset);
 }

--- a/Generator/Emit/Emitters/StructEmitter21.cs
+++ b/Generator/Emit/Emitters/StructEmitter21.cs
@@ -32,7 +32,9 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
     {
         w.Require("AutoHotkey v2.1-alpha.26+ 64-bit");
 
-        EmitImports(w, structType);
+        var extraImports = new HashSet<string>();
+        CollectExtraImports(structType, extraImports);
+        EmitImports(w, structType, extraImports);
 
         w.BlankLine();
 
@@ -166,9 +168,10 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
     {
         return field.Type switch
         {
-            // String fields (CHAR[N]/WCHAR[N]) - IR collapses these to StringType,
-            // re-expand to typedef-element arrays so the named CHAR/WCHAR survives.
-            StringType s => $"{(s.Encoding == StringEncoding.Ansi ? "CHAR" : "WCHAR")}[{s.Length}]",
+            // String fields - IR collapses fixed-size character arrays into StringType.
+            // ANSI uses the CHAR NativeTypedef from Foundation; Unicode strings come from
+            // CLR char[] which has no metadata typedef, so render as raw UInt16 elements.
+            StringType s => $"{(s.Encoding == StringEncoding.Ansi ? "CHAR" : "UInt16")}[{s.Length}]",
 
             // Array of nested-defined struct: qualify the element name
             ArrayType { ElementType: StructRef es } a when field.IsNested
@@ -214,12 +217,41 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
         }
     }
 
-    internal void EmitImports(AhkWriter w, Win32Type type)
+    /// <summary>
+    /// Collect extra import FQNs needed by typed-property type expressions but
+    /// not present in <see cref="Win32Type.Imports"/> â€” currently just CHAR/WCHAR
+    /// for <see cref="StringType"/> fields, which the IR collapses away from arrays.
+    /// </summary>
+    private static void CollectExtraImports(StructType structType, HashSet<string> extras)
     {
+        foreach (FieldMember field in structType.Members)
+        {
+            // Only ANSI StringType needs an import (the CHAR NativeTypedef from Foundation).
+            // Unicode StringType renders as raw UInt16[N] which needs no import.
+            if (field.Type is StringType { Encoding: StringEncoding.Ansi })
+                extras.Add("Windows.Win32.Foundation.CHAR");
+
+            if (field.EmbeddedStruct is not null)
+                CollectExtraImports(field.EmbeddedStruct, extras);
+        }
+    }
+
+    internal void EmitImports(AhkWriter w, Win32Type type, HashSet<string> extraImports)
+    {
+        var seen = new HashSet<string>();
+
         // Restrict to types available in the registry to filter out nested types
         foreach (string fqn in type.Imports.GetTypes()
             .Where(fqn => _registry.Contains(fqn) && fqn != type.FQN))
         {
+            if (!seen.Add(fqn)) continue;
+            string path = ImportResolver.GetIncludePath(type.Namespace, fqn);
+            w.Import(path, [ImportResolver.GetImportName(fqn)]);
+        }
+
+        foreach (string fqn in extraImports)
+        {
+            if (fqn == type.FQN || !_registry.Contains(fqn) || !seen.Add(fqn)) continue;
             string path = ImportResolver.GetIncludePath(type.Namespace, fqn);
             w.Import(path, [ImportResolver.GetImportName(fqn)]);
         }

--- a/Generator/Emit/Emitters/StructEmitter21.cs
+++ b/Generator/Emit/Emitters/StructEmitter21.cs
@@ -266,8 +266,10 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
     {
         var seen = new HashSet<string>();
 
-        // Restrict to types available in the registry to filter out nested types
-        foreach (string fqn in type.Imports.GetTypes().Where(fqn => _registry.Contains(fqn) && fqn != type.FQN))
+        // Restrict to types available in the registry to filter out nested types.
+        // System.Guid isn't in the registry (it's a pseudo-type at the projection root)
+        // but ImportResolver resolves it to Guid.ahk — let it through.
+        foreach (string fqn in type.Imports.GetTypes().Where(fqn => IsImportable(fqn) && fqn != type.FQN))
         {
             if (!seen.Add(fqn))
                 continue;
@@ -277,7 +279,7 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
 
         foreach (string fqn in extraImports)
         {
-            if (fqn == type.FQN || !_registry.Contains(fqn) || !seen.Add(fqn))
+            if (fqn == type.FQN || !IsImportable(fqn) || !seen.Add(fqn))
                 continue;
             string path = ImportResolver.GetIncludePath(type.Namespace, fqn);
             w.Import(path, [ImportResolver.GetImportName(fqn)]);
@@ -289,6 +291,8 @@ public sealed class StructEmitter21(TypeRegistry registry) : ITypeEmitter
             w.Import(path, type.Imports.GetFunctionsForNamespace(apisFqn));
         }
     }
+
+    private bool IsImportable(string fqn) => fqn == "System.Guid" || _registry.Contains(fqn);
 
     internal static void EmitExtensions(AhkWriter w, Win32Type type)
     {

--- a/Generator/Emit/ImportResolver.cs
+++ b/Generator/Emit/ImportResolver.cs
@@ -12,9 +12,7 @@ public static class ImportResolver
     /// </summary>
     public static string GetPathToBase(string ns)
     {
-        return ns.Split('.')
-            .Select(_ => $"..{Path.DirectorySeparatorChar}")
-            .Aggregate((agg, cur) => agg + cur);
+        return ns.Split('.').Select(_ => $"..{Path.DirectorySeparatorChar}").Aggregate((agg, cur) => agg + cur);
     }
 
     /// <summary>

--- a/Generator/Emit/ImportResolver.cs
+++ b/Generator/Emit/ImportResolver.cs
@@ -33,6 +33,12 @@ public static class ImportResolver
         return $"{relativePath}{importName}.ahk";
     }
 
+    public static string GetImportName(string importFqn)
+    {
+        int lastDot = importFqn.LastIndexOf('.');
+        return importFqn[(lastDot + 1)..];
+    }
+
     /// <summary>
     /// Calculate the relative directory path between two namespace directories.
     /// Port of AhkType.RelativePathBetweenNamespaces.

--- a/Generator/Emit/ModuleNameResolver.cs
+++ b/Generator/Emit/ModuleNameResolver.cs
@@ -1,0 +1,124 @@
+namespace AhkWin32.Generator.Emit;
+
+using AhkWin32.Generator.Model;
+using AhkWin32.Generator.Model.Types;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Resolves the local identifier to use for each imported type/function within a single
+/// v2.1 module file, deconflicting names that collide with the module's own exported
+/// declarations (or with each other).
+///
+/// This resolver keeps the module's own exports (the public API) unchanged and aliases the
+/// *imported* name instead, emitting <c>{ Name as Alias }</c>. Aliases are formed by
+/// suffixing the type kind (<c>INITCOMMONCONTROLSEX_struct</c>, <c>SOCKET_handle</c>),
+/// falling back to a numeric suffix if that still collides.
+/// </summary>
+public sealed class ModuleNameResolver
+{
+    private readonly Dictionary<string, string> _typeLocal = new(StringComparer.Ordinal);
+    private readonly Dictionary<(string ApisFqn, string Name), string> _functionLocal = [];
+
+    /// <summary>
+    /// Build a resolver for one module file.
+    /// </summary>
+    /// <param name="anchorNames">
+    /// The module's own exported declarations (function or constant names). These always keep
+    /// their names; imports are aliased away from them.
+    /// </param>
+    /// <param name="typeFqns">FQNs of the types this file imports.</param>
+    /// <param name="functionImports">Per-Apis-FQN free functions this file imports.</param>
+    /// <param name="registry">Used to look up each imported type's kind for the alias suffix.</param>
+    /// <param name="logger">Optional - logs a line per generated alias (the detection signal).</param>
+    /// <param name="context">Human-readable file/namespace label for log messages.</param>
+    public ModuleNameResolver(
+        IEnumerable<string> anchorNames,
+        IEnumerable<string> typeFqns,
+        IEnumerable<(string ApisFqn, IEnumerable<string> Names)> functionImports,
+        TypeRegistry registry,
+        ILogger? logger = null,
+        string context = ""
+    )
+    {
+        // Names that are already taken in the module scope; never aliased. Case-insensitive.
+        var occupied = new HashSet<string>(anchorNames, StringComparer.OrdinalIgnoreCase);
+
+        // Deterministic order so output is stable across runs.
+        foreach (string fqn in typeFqns.OrderBy(f => f, StringComparer.Ordinal))
+        {
+            string simple = ImportResolver.GetImportName(fqn);
+            string suffix = KindSuffix(registry.Resolve(fqn, Architecture.All));
+            _typeLocal[fqn] = Claim(simple, suffix, occupied, logger, context);
+        }
+
+        foreach (var (apisFqn, names) in functionImports.OrderBy(f => f.ApisFqn, StringComparer.Ordinal))
+        {
+            foreach (string name in names.OrderBy(n => n, StringComparer.Ordinal))
+            {
+                _functionLocal[(apisFqn, name)] = Claim(name, "fn", occupied, logger, context);
+            }
+        }
+    }
+
+    /// <summary>Local identifier to use for an imported type, by FQN.</summary>
+    public string ForType(string fqn) =>
+        _typeLocal.TryGetValue(fqn, out string? local) ? local : ImportResolver.GetImportName(fqn);
+
+    /// <summary>Local identifier to use for an imported free function.</summary>
+    public string ForFunction(string apisFqn, string name) =>
+        _functionLocal.TryGetValue((apisFqn, name), out string? local) ? local : name;
+
+    /// <summary>
+    /// The member token to place inside an <c>#Import "path" { ... }</c> for a type: either
+    /// <c>Name</c> or <c>Name as Alias</c> when the import was deconflicted.
+    /// </summary>
+    public string TypeImportToken(string fqn)
+    {
+        string simple = ImportResolver.GetImportName(fqn);
+        string local = ForType(fqn);
+        return local == simple ? simple : $"{simple} as {local}";
+    }
+
+    /// <summary>The member token for a free-function import: <c>name</c> or <c>name as alias</c>.</summary>
+    public string FunctionImportToken(string apisFqn, string name)
+    {
+        string local = ForFunction(apisFqn, name);
+        return local == name ? name : $"{name} as {local}";
+    }
+
+    private static string Claim(
+        string name,
+        string kindSuffix,
+        HashSet<string> occupied,
+        ILogger? logger,
+        string context
+    )
+    {
+        if (occupied.Add(name))
+            return name;
+
+        string candidate = $"{name}_{kindSuffix}";
+        if (!occupied.Add(candidate))
+        {
+            int n = 2;
+            while (!occupied.Add($"{candidate}_{n}"))
+                n++;
+            candidate = $"{candidate}_{n}";
+        }
+
+        logger?.LogDebug("Deconflicted import '{Original}' -> '{Alias}' in {Context}", name, candidate, context);
+        return candidate;
+    }
+
+    private static string KindSuffix(Win32Type? type) =>
+        type switch
+        {
+            HandleType => "handle",
+            StructType => "struct",
+            EnumType => "enum",
+            NativeTypedefType => "typedef",
+            ComInterfaceType => "com",
+            DelegateType => "delegate",
+            _ => "type",
+        };
+}

--- a/Generator/Emit/TypeEmissionPipeline.cs
+++ b/Generator/Emit/TypeEmissionPipeline.cs
@@ -17,13 +17,17 @@ public sealed class TypeEmissionPipeline
     private readonly ITypeEmitter[] _emitters;
     private readonly ParallelOptions _parallelOptions;
 
-    public TypeEmissionPipeline(IEnumerable<ITypeEmitter> emitters, ILogger<TypeEmissionPipeline> logger, int maxParallelism = 0)
+    public TypeEmissionPipeline(
+        IEnumerable<ITypeEmitter> emitters,
+        ILogger<TypeEmissionPipeline> logger,
+        int maxParallelism = 0
+    )
     {
         _emitters = [.. emitters];
         _logger = logger;
         _parallelOptions = new ParallelOptions
         {
-            MaxDegreeOfParallelism = maxParallelism > 0 ? maxParallelism : Environment.ProcessorCount
+            MaxDegreeOfParallelism = maxParallelism > 0 ? maxParallelism : Environment.ProcessorCount,
         };
     }
 
@@ -32,11 +36,15 @@ public sealed class TypeEmissionPipeline
     /// optionally filtered by namespace prefixes.
     /// </summary>
     public (int Emitted, int Skipped, int Errors) EmitAll(
-        TypeRegistry registry, string outputDir, string[]? namespaceFilter = null)
+        TypeRegistry registry,
+        string outputDir,
+        string[]? namespaceFilter = null
+    )
     {
         _logger.LogInformation("Beginning type emission...");
 
-        int skipped = 0, errors = 0;
+        int skipped = 0,
+            errors = 0;
         Stopwatch watch = Stopwatch.StartNew();
 
         Win32Type[] filteredTypes = [.. registry.GetAll().Where(type => ShouldEmit(type, namespaceFilter))];
@@ -51,50 +59,78 @@ public sealed class TypeEmissionPipeline
         // Phase 1: Emit to memory (CPU-bound)
         ConcurrentBag<EmitResult> results = [];
 
-        Parallel.ForEach(filteredTypes, (type) =>
-        {
-            ITypeEmitter[] matching = [.. _emitters.Where(e => e.CanEmit(type))];
-            if (matching.Length == 0)
+        Parallel.ForEach(
+            filteredTypes,
+            (type) =>
             {
-                Interlocked.Increment(ref skipped);
-                return;
-            }
+                ITypeEmitter[] matching = [.. _emitters.Where(e => e.CanEmit(type))];
+                if (matching.Length == 0)
+                {
+                    Interlocked.Increment(ref skipped);
+                    return;
+                }
 
-            foreach (var emitter in matching)
-            {
-                try
+                foreach (var emitter in matching)
                 {
-                    _logger.LogTrace("Emitting {Namespace}.{Name} via {Emitter}", type.Namespace, type.Name, emitter.GetType().Name);
-                    results.Add(emitter.Emit(type, outputDir));
-                }
-                catch (Exception ex)
-                {
-                    Interlocked.Increment(ref errors);
-                    _logger.LogError(ex, "Failed to emit {TypeName} via {Emitter}", type.FQN, emitter.GetType().Name);
+                    try
+                    {
+                        _logger.LogTrace(
+                            "Emitting {Namespace}.{Name} via {Emitter}",
+                            type.Namespace,
+                            type.Name,
+                            emitter.GetType().Name
+                        );
+                        results.Add(emitter.Emit(type, outputDir));
+                    }
+                    catch (Exception ex)
+                    {
+                        Interlocked.Increment(ref errors);
+                        _logger.LogError(
+                            ex,
+                            "Failed to emit {TypeName} via {Emitter}",
+                            type.FQN,
+                            emitter.GetType().Name
+                        );
+                    }
                 }
             }
-        });
+        );
 
         watch.Stop();
-        _logger.LogInformation("Emitted {Count} types to memory in {Elapsed:F1}s, writing files...", 
-            results.Count, watch.Elapsed.TotalSeconds);
+        _logger.LogInformation(
+            "Emitted {Count} types to memory in {Elapsed:F1}s, writing files...",
+            results.Count,
+            watch.Elapsed.TotalSeconds
+        );
 
         // Phase 2: Write files (I/O-bound, async to avoid blocking thread pool threads)
         watch.Restart();
         int written = 0;
 
-        Parallel.ForEachAsync(results, _parallelOptions, async (result, cancellationToken) =>
-        {
-            await File.WriteAllTextAsync(result.FilePath, result.Content, cancellationToken);
+        Parallel
+            .ForEachAsync(
+                results,
+                _parallelOptions,
+                async (result, cancellationToken) =>
+                {
+                    await File.WriteAllTextAsync(result.FilePath, result.Content, cancellationToken);
 
-            int count = Interlocked.Increment(ref written);
-            if (count % 5000 == 0)
-                _logger.LogInformation("  Wrote {Count} files...", count);
-        }).GetAwaiter().GetResult();
+                    int count = Interlocked.Increment(ref written);
+                    if (count % 5000 == 0)
+                        _logger.LogInformation("  Wrote {Count} files...", count);
+                }
+            )
+            .GetAwaiter()
+            .GetResult();
 
         watch.Stop();
-        _logger.LogInformation("Emission complete: {Emitted} emitted, {Skipped} skipped, {Errors} errors in {Elapsed:F1}s",
-            results.Count, skipped, errors, watch.Elapsed.TotalSeconds);
+        _logger.LogInformation(
+            "Emission complete: {Emitted} emitted, {Skipped} skipped, {Errors} errors in {Elapsed:F1}s",
+            results.Count,
+            skipped,
+            errors,
+            watch.Elapsed.TotalSeconds
+        );
 
         return (results.Count, skipped, errors);
     }
@@ -106,11 +142,9 @@ public sealed class TypeEmissionPipeline
     {
         if (namespaceFilter != null && namespaceFilter.Length > 0)
         {
-            return namespaceFilter.Any(prefix =>
-                type.Namespace.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
+            return namespaceFilter.Any(prefix => type.Namespace.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
         }
 
         return true;
     }
-
 }

--- a/Generator/Emit/TypeEmissionPipeline.cs
+++ b/Generator/Emit/TypeEmissionPipeline.cs
@@ -53,22 +53,25 @@ public sealed class TypeEmissionPipeline
 
         Parallel.ForEach(filteredTypes, (type) =>
         {
-            ITypeEmitter? emitter = FindEmitter(type);
-            if (emitter is null)
+            ITypeEmitter[] matching = [.. _emitters.Where(e => e.CanEmit(type))];
+            if (matching.Length == 0)
             {
                 Interlocked.Increment(ref skipped);
                 return;
             }
 
-            try
+            foreach (var emitter in matching)
             {
-                _logger.LogTrace("Emitting {Namespace}.{Name}", type.Namespace, type.Name);
-                results.Add(emitter.Emit(type, outputDir));
-            }
-            catch (Exception ex)
-            {
-                Interlocked.Increment(ref errors);
-                _logger.LogError(ex, "Failed to emit {TypeName}", type.FQN);
+                try
+                {
+                    _logger.LogTrace("Emitting {Namespace}.{Name} via {Emitter}", type.Namespace, type.Name, emitter.GetType().Name);
+                    results.Add(emitter.Emit(type, outputDir));
+                }
+                catch (Exception ex)
+                {
+                    Interlocked.Increment(ref errors);
+                    _logger.LogError(ex, "Failed to emit {TypeName} via {Emitter}", type.FQN, emitter.GetType().Name);
+                }
             }
         });
 
@@ -110,13 +113,4 @@ public sealed class TypeEmissionPipeline
         return true;
     }
 
-    private ITypeEmitter? FindEmitter(Win32Type type)
-    {
-        foreach (var e in _emitters)
-        {
-            if (e.CanEmit(type))
-                return e;
-        }
-        return null;
-    }
 }

--- a/Generator/Infrastructure/FileLoggerProvider.cs
+++ b/Generator/Infrastructure/FileLoggerProvider.cs
@@ -29,9 +29,16 @@ internal sealed class FileLoggerProvider : ILoggerProvider
     {
         public bool IsEnabled(LogLevel logLevel) => logLevel >= minLevel;
 
-        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
 
-        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter
+        )
         {
             if (!IsEnabled(logLevel))
                 return;
@@ -45,7 +52,7 @@ internal sealed class FileLoggerProvider : ILoggerProvider
                 LogLevel.Warning => "warn",
                 LogLevel.Error => "fail",
                 LogLevel.Critical => "crit",
-                _ => "????"
+                _ => "????",
             };
 
             lock (@lock)

--- a/Generator/Metadata/AhkVersion.cs
+++ b/Generator/Metadata/AhkVersion.cs
@@ -1,0 +1,23 @@
+namespace AhkWin32.Generator.Metadata;
+
+/// <summary>
+/// An AutoHotkey major version, either 2.0 or 2.1
+/// </summary>
+public enum AhkVersion
+{
+    v20,
+    v21
+}
+
+public static class AhkVersionExtensions
+{
+    /// <summary>
+    /// Can't actually override ToString - https://stackoverflow.com/a/479453
+    /// </summary>
+    public static string ToFriendlyString(this AhkVersion version) => version switch
+    {
+        AhkVersion.v20 => "2.0",
+        AhkVersion.v21 => "2.1-alpha",
+        _ => version.ToString()
+    };
+}

--- a/Generator/Metadata/AhkVersion.cs
+++ b/Generator/Metadata/AhkVersion.cs
@@ -6,7 +6,7 @@ namespace AhkWin32.Generator.Metadata;
 public enum AhkVersion
 {
     v20,
-    v21
+    v21,
 }
 
 public static class AhkVersionExtensions
@@ -14,10 +14,11 @@ public static class AhkVersionExtensions
     /// <summary>
     /// Can't actually override ToString - https://stackoverflow.com/a/479453
     /// </summary>
-    public static string ToFriendlyString(this AhkVersion version) => version switch
-    {
-        AhkVersion.v20 => "2.0",
-        AhkVersion.v21 => "2.1-alpha",
-        _ => version.ToString()
-    };
+    public static string ToFriendlyString(this AhkVersion version) =>
+        version switch
+        {
+            AhkVersion.v20 => "2.0",
+            AhkVersion.v21 => "2.1-alpha",
+            _ => version.ToString(),
+        };
 }

--- a/Generator/Metadata/AttributeReader.cs
+++ b/Generator/Metadata/AttributeReader.cs
@@ -48,6 +48,19 @@ public sealed record ParameterAttrs(
     string? FreeWithFuncName
 );
 
+/// <param name="PreserveSig">Whether [PreserveSig] attribute is present.</param>
+/// <param name="PreserveSigValue">The boolean value of [PreserveSig], or true if present with no args.
+/// Null if attribute is not present.</param>
+public sealed record MethodAttrs(
+    bool PreserveSig,
+    bool? PreserveSigValue,
+    bool CanReturnErrorsAsSuccess,
+    bool CanReturnMultipleSuccessValues,
+    string? DeprecationMessage,
+    string? SupportedOSPlatform,
+    Architecture Architecture
+);
+
 /// <summary>
 /// Cached attribute decoding utilities. Decodes attributes in a single pass
 /// and returns result records for reuse.
@@ -373,6 +386,71 @@ public static class AttributeReader
         }
 
         return new ParameterAttrs(flags, sizedBufferBytesParamIndex, ignoreIfReturnValues, raiiFreeFunc, freeWithFunc);
+    }
+
+    /// <summary>
+    /// Decode method-level custom attributes in a single pass.
+    /// </summary>
+    public static MethodAttrs DecodeMethodAttributes(MetadataReader reader, MethodDefinition methodDef)
+    {
+        bool preserveSig = false;
+        bool? preserveSigValue = null;
+        bool canReturnErrorsAsSuccess = false;
+        bool canReturnMultipleSuccessValues = false;
+        string? deprecationMessage = null;
+        string? supportedOSPlatform = null;
+        Architecture supportedArchitecture = Architecture.All;
+
+        foreach (CustomAttributeHandle attrHandle in methodDef.GetCustomAttributes())
+        {
+            CustomAttribute attr = reader.GetCustomAttribute(attrHandle);
+            (_, string attrName) = GetAttributeTypeName(reader, attr);
+            CustomAttributeValue<string> decoded = attr.DecodeValue(s_caProvider);
+
+            switch (attrName)
+            {
+                case "PreserveSigAttribute":
+                    preserveSig = true;
+                    preserveSigValue =
+                        decoded.FixedArguments.Length <= 0 || (decoded.FixedArguments[0].Value as bool? ?? true);
+                    break;
+
+                case "CanReturnErrorsAsSuccessAttribute":
+                    canReturnErrorsAsSuccess = true;
+                    break;
+
+                case "CanReturnMultipleSuccessValuesAttribute":
+                    canReturnMultipleSuccessValues = true;
+                    break;
+
+                case "ObsoleteAttribute":
+                    deprecationMessage =
+                        decoded.FixedArguments.Length > 0 ? decoded.FixedArguments[0].Value as string : null;
+                    break;
+
+                case "SupportedOSPlatformAttribute":
+                    supportedOSPlatform = (string?)decoded.FixedArguments[0].Value;
+                    break;
+
+                case "SupportedArchitectureAttribute":
+                    supportedArchitecture = (Architecture)
+                        (uint)(
+                            decoded.FixedArguments[0].Value
+                            ?? throw new InvalidOperationException("Null SupportedArchitectureAttribute value")
+                        );
+                    break;
+            }
+        }
+
+        return new MethodAttrs(
+            preserveSig,
+            preserveSigValue,
+            canReturnErrorsAsSuccess,
+            canReturnMultipleSuccessValues,
+            deprecationMessage,
+            supportedOSPlatform,
+            supportedArchitecture
+        );
     }
 
     /// <summary>

--- a/Generator/Metadata/AttributeReader.cs
+++ b/Generator/Metadata/AttributeReader.cs
@@ -23,6 +23,7 @@ public sealed record TypeAttrs(
     string? DeprecationMessage,
     string? StructSizeFieldName,
     string? SupportedOSPlatform,
+    IReadOnlyList<string> AlsoUsableFor,
     MemberFlags Flags
 );
 
@@ -92,6 +93,7 @@ public static class AttributeReader
         string? supportedOSPlatform = null;
         bool hasHandleAttr = false;
         bool hasNativeTypedefAttr = false;
+        List<string> alsoUsableFor = [];
 
         List<CAInfo> allAttrs = [];
 
@@ -145,12 +147,20 @@ public static class AttributeReader
                     supportedOSPlatform = (string?)decoded.FixedArguments[0].Value;
                     break;
 
-                case "RAIIFreeAttribute":
                 case "AlsoUsableForAttribute":
+                    var target = (string?)decoded.FixedArguments[0].Value;
+                    if (target is not null)
+                        alsoUsableFor.Add(target);
+
+                    hasHandleAttr = true;
+                    break;
+
+                case "RAIIFreeAttribute":
                 case "InvalidHandleValueAttribute":
                     hasHandleAttr = true;
                     break;
 
+                case "MetadataTypedefAttribute":
                 case "NativeTypedefAttribute":
                     hasNativeTypedefAttr = true;
                     break;
@@ -192,6 +202,7 @@ public static class AttributeReader
             deprecationMessage,
             structSizeFieldName,
             supportedOSPlatform,
+            alsoUsableFor,
             flags
         );
     }

--- a/Generator/Metadata/AttributeReader.cs
+++ b/Generator/Metadata/AttributeReader.cs
@@ -17,6 +17,7 @@ public sealed record TypeAttrs(
     IReadOnlyList<CAInfo> All,
     Architecture? SupportedArchitecture,
     bool IsHandle,
+    bool IsNativeTypedef,
     bool IsFlags,
     bool IsDeprecated,
     string? DeprecationMessage,
@@ -71,6 +72,7 @@ public static class AttributeReader
         string? structSizeFieldName = null;
         string? supportedOSPlatform = null;
         bool hasHandleAttr = false;
+        bool hasNativeTypedefAttr = false;
 
         List<CAInfo> allAttrs = [];
 
@@ -127,6 +129,10 @@ public static class AttributeReader
                 case "InvalidHandleValueAttribute":
                     hasHandleAttr = true;
                     break;
+
+                case "NativeTypedefAttribute":
+                    hasNativeTypedefAttr = true;
+                    break;
             }
         }
 
@@ -138,6 +144,7 @@ public static class AttributeReader
             flags |= MemberFlags.Anonymous;
 
         bool isHandle = fieldCount == 1 && hasHandleAttr;
+        bool isNativeTypedef = fieldCount == 1 && hasNativeTypedefAttr && !hasHandleAttr;
 
         if (logger != null)
         {
@@ -150,7 +157,7 @@ public static class AttributeReader
         }
 
         return new TypeAttrs(
-            allAttrs, supportedArch, isHandle, isFlags, isDeprecated,
+            allAttrs, supportedArch, isHandle, isNativeTypedef, isFlags, isDeprecated,
             deprecationMessage, structSizeFieldName, supportedOSPlatform, flags);
     }
 

--- a/Generator/Metadata/AttributeReader.cs
+++ b/Generator/Metadata/AttributeReader.cs
@@ -23,7 +23,8 @@ public sealed record TypeAttrs(
     string? DeprecationMessage,
     string? StructSizeFieldName,
     string? SupportedOSPlatform,
-    MemberFlags Flags);
+    MemberFlags Flags
+);
 
 /// <summary>
 /// Decoded attributes for a FieldDefinition. Computed once and reused.
@@ -33,7 +34,8 @@ public sealed record FieldAttrs(
     MemberFlags Flags,
     bool IsDeprecated,
     string? DeprecationMessage,
-    IReadOnlyList<BitfieldMember>? Bitfields);
+    IReadOnlyList<BitfieldMember>? Bitfields
+);
 
 /// <summary>
 /// Decoded attributes for a Parameter. Computed once and reused.
@@ -43,7 +45,8 @@ public sealed record ParameterAttrs(
     int SizedBufferBytesParamIndex,
     IReadOnlyList<string>? IgnoreIfReturnValues,
     string? RAIIFreeFuncName,
-    string? FreeWithFuncName);
+    string? FreeWithFuncName
+);
 
 /// <summary>
 /// Cached attribute decoding utilities. Decodes attributes in a single pass
@@ -61,8 +64,11 @@ public static class AttributeReader
     /// <param name="fieldCount">Number of fields (used for handle detection)</param>
     /// <param name="logger">Logger for trace-level output</param>
     public static TypeAttrs DecodeTypeAttributes(
-        MetadataReader reader, TypeDefinition typeDef, int fieldCount,
-        ILogger? logger = null)
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        int fieldCount,
+        ILogger? logger = null
+    )
     {
         MemberFlags flags = MemberFlags.None;
         Architecture? supportedArch = null;
@@ -90,9 +96,8 @@ public static class AttributeReader
                 case "ObsoleteAttribute":
                     flags |= MemberFlags.Deprecated;
                     isDeprecated = true;
-                    deprecationMessage = decoded.FixedArguments.Length > 0
-                        ? decoded.FixedArguments[0].Value as string
-                        : null;
+                    deprecationMessage =
+                        decoded.FixedArguments.Length > 0 ? decoded.FixedArguments[0].Value as string : null;
                     break;
 
                 case "ReservedAttribute":
@@ -112,8 +117,11 @@ public static class AttributeReader
                     break;
 
                 case "SupportedArchitectureAttribute":
-                    supportedArch = (Architecture)(uint)(decoded.FixedArguments[0].Value
-                        ?? throw new InvalidOperationException("Null SupportedArchitectureAttribute value"));
+                    supportedArch = (Architecture)
+                        (uint)(
+                            decoded.FixedArguments[0].Value
+                            ?? throw new InvalidOperationException("Null SupportedArchitectureAttribute value")
+                        );
                     break;
 
                 case "StructSizeFieldAttribute":
@@ -152,13 +160,27 @@ public static class AttributeReader
             logger.LogTrace("Decoded {Count} attributes for type {FQN}", allAttrs.Count, fqn);
             if (supportedArch.HasValue)
                 logger.LogTrace("Type {FQN}: SupportedArchitecture={Arch}", fqn, supportedArch.Value);
-            logger.LogTrace("Type {FQN}: IsHandle={IsHandle}, IsFlags={IsFlags}, IsDeprecated={IsDeprecated}",
-                fqn, isHandle, isFlags, isDeprecated);
+            logger.LogTrace(
+                "Type {FQN}: IsHandle={IsHandle}, IsFlags={IsFlags}, IsDeprecated={IsDeprecated}",
+                fqn,
+                isHandle,
+                isFlags,
+                isDeprecated
+            );
         }
 
         return new TypeAttrs(
-            allAttrs, supportedArch, isHandle, isNativeTypedef, isFlags, isDeprecated,
-            deprecationMessage, structSizeFieldName, supportedOSPlatform, flags);
+            allAttrs,
+            supportedArch,
+            isHandle,
+            isNativeTypedef,
+            isFlags,
+            isDeprecated,
+            deprecationMessage,
+            structSizeFieldName,
+            supportedOSPlatform,
+            flags
+        );
     }
 
     /// <summary>
@@ -186,9 +208,8 @@ public static class AttributeReader
                 case "ObsoleteAttribute":
                     flags |= MemberFlags.Deprecated;
                     isDeprecated = true;
-                    deprecationMessage = decoded.FixedArguments.Length > 0
-                        ? decoded.FixedArguments[0].Value as string
-                        : null;
+                    deprecationMessage =
+                        decoded.FixedArguments.Length > 0 ? decoded.FixedArguments[0].Value as string : null;
                     break;
 
                 case "ReservedAttribute":
@@ -198,15 +219,17 @@ public static class AttributeReader
                 case "NativeBitfieldAttribute":
                     flags |= MemberFlags.NativeBitField;
                     bitfields ??= [];
-                    string memberName = (string?)decoded.FixedArguments[0].Value
+                    string memberName =
+                        (string?)decoded.FixedArguments[0].Value
                         ?? throw new InvalidOperationException("Null NativeBitfieldAttribute name");
-                    long bitOffset = (long?)decoded.FixedArguments[1].Value
+                    long bitOffset =
+                        (long?)decoded.FixedArguments[1].Value
                         ?? throw new InvalidOperationException("Null NativeBitfieldAttribute offset");
-                    long length = (long?)decoded.FixedArguments[2].Value
+                    long length =
+                        (long?)decoded.FixedArguments[2].Value
                         ?? throw new InvalidOperationException("Null NativeBitfieldAttribute length");
                     bitfields.Add(new BitfieldMember(memberName, bitOffset, length));
                     break;
-                    
             }
         }
 
@@ -220,8 +243,12 @@ public static class AttributeReader
     {
         return attrs
             .Where(a => a.Name == "InvalidHandleValueAttribute")
-            .Select(a => (long)(a.Attr.FixedArguments[0].Value
-                ?? throw new InvalidOperationException("Null InvalidHandleValueAttribute value")))
+            .Select(a =>
+                (long)(
+                    a.Attr.FixedArguments[0].Value
+                    ?? throw new InvalidOperationException("Null InvalidHandleValueAttribute value")
+                )
+            )
             .ToList();
     }
 
@@ -289,8 +316,9 @@ public static class AttributeReader
                     foreach (var arg in decoded.NamedArguments)
                     {
                         if (arg.Name == "BytesParamIndex")
-                            sizedBufferBytesParamIndex = (short)(arg.Value
-                                ?? throw new InvalidOperationException("Null BytesParamIndex"));
+                            sizedBufferBytesParamIndex = (short)(
+                                arg.Value ?? throw new InvalidOperationException("Null BytesParamIndex")
+                            );
                     }
                     break;
                 }
@@ -311,8 +339,10 @@ public static class AttributeReader
                 {
                     flags |= ParameterFlags.HasIgnoreIfReturn;
                     CustomAttributeValue<string> decoded = attr.DecodeValue(s_caProvider);
-                    string val = (string)(decoded.FixedArguments[0].Value
-                        ?? throw new InvalidOperationException("Null IgnoreIfReturnAttribute value"));
+                    string val = (string)(
+                        decoded.FixedArguments[0].Value
+                        ?? throw new InvalidOperationException("Null IgnoreIfReturnAttribute value")
+                    );
                     ignoreIfReturnValues ??= [];
                     ignoreIfReturnValues.Add(val);
                     break;
@@ -322,8 +352,10 @@ public static class AttributeReader
                 {
                     flags |= ParameterFlags.HasRAIIFree;
                     CustomAttributeValue<string> decoded = attr.DecodeValue(s_caProvider);
-                    raiiFreeFunc = (string)(decoded.FixedArguments[0].Value
-                        ?? throw new InvalidOperationException("Null RAIIFreeAttribute value"));
+                    raiiFreeFunc = (string)(
+                        decoded.FixedArguments[0].Value
+                        ?? throw new InvalidOperationException("Null RAIIFreeAttribute value")
+                    );
                     break;
                 }
 
@@ -331,15 +363,16 @@ public static class AttributeReader
                 {
                     flags |= ParameterFlags.HasFreeWith;
                     CustomAttributeValue<string> decoded = attr.DecodeValue(s_caProvider);
-                    freeWithFunc = (string)(decoded.FixedArguments[0].Value
-                        ?? throw new InvalidOperationException("Null FreeWithAttribute value"));
+                    freeWithFunc = (string)(
+                        decoded.FixedArguments[0].Value
+                        ?? throw new InvalidOperationException("Null FreeWithAttribute value")
+                    );
                     break;
                 }
             }
         }
 
-        return new ParameterAttrs(flags, sizedBufferBytesParamIndex,
-            ignoreIfReturnValues, raiiFreeFunc, freeWithFunc);
+        return new ParameterAttrs(flags, sizedBufferBytesParamIndex, ignoreIfReturnValues, raiiFreeFunc, freeWithFunc);
     }
 
     /// <summary>
@@ -368,8 +401,7 @@ public static class AttributeReader
         CustomAttributeValue<string> decoded = attr.DecodeValue(s_caProvider);
 
         if (decoded.FixedArguments.Length != 11)
-            throw new ArgumentException(
-                $"GuidAttribute has {decoded.FixedArguments.Length} arguments, expected 11");
+            throw new ArgumentException($"GuidAttribute has {decoded.FixedArguments.Length} arguments, expected 11");
 
         return new Guid(
             (int)(uint)decoded.FixedArguments[0].Value!,
@@ -413,7 +445,10 @@ public static class AttributeReader
     /// Find a single attribute by name in a collection.
     /// </summary>
     public static CustomAttribute? FindAttribute(
-        MetadataReader reader, CustomAttributeHandleCollection handles, string targetName)
+        MetadataReader reader,
+        CustomAttributeHandleCollection handles,
+        string targetName
+    )
     {
         foreach (CustomAttributeHandle attrHandle in handles)
         {
@@ -429,7 +464,9 @@ public static class AttributeReader
     /// Get all attribute names from a collection.
     /// </summary>
     public static IEnumerable<string> GetAllAttributeNames(
-        MetadataReader reader, CustomAttributeHandleCollection handles)
+        MetadataReader reader,
+        CustomAttributeHandleCollection handles
+    )
     {
         foreach (CustomAttributeHandle attrHandle in handles)
         {
@@ -442,8 +479,7 @@ public static class AttributeReader
     /// <summary>
     /// Resolve the (Namespace, Name) of a custom attribute's declaring type.
     /// </summary>
-    public static (string Namespace, string Name) GetAttributeTypeName(
-        MetadataReader reader, CustomAttribute attr)
+    public static (string Namespace, string Name) GetAttributeTypeName(MetadataReader reader, CustomAttribute attr)
     {
         switch (attr.Constructor.Kind)
         {
@@ -473,7 +509,6 @@ public static class AttributeReader
             }
         }
 
-        throw new NotSupportedException(
-            $"Unsupported attribute constructor kind: {attr.Constructor.Kind}");
+        throw new NotSupportedException($"Unsupported attribute constructor kind: {attr.Constructor.Kind}");
     }
 }

--- a/Generator/Metadata/CaTypeProvider.cs
+++ b/Generator/Metadata/CaTypeProvider.cs
@@ -8,7 +8,9 @@ using System.Reflection.Metadata;
 internal sealed class CaTypeProvider : ICustomAttributeTypeProvider<string>
 {
     public string GetPrimitiveType(PrimitiveTypeCode typeCode) => typeCode.ToString();
+
     public string GetSystemType() => "System.Type";
+
     public string GetTypeFromSerializedName(string name) => name ?? "Unknown";
 
     public string GetTypeFromDefinition(MetadataReader r, TypeDefinitionHandle h, byte raw)
@@ -29,13 +31,13 @@ internal sealed class CaTypeProvider : ICustomAttributeTypeProvider<string>
 
     public string GetSZArrayType(string elementType) => $"{elementType}[]";
 
-    public string GetTypeFromSpecification(MetadataReader r, object? ctx, TypeSpecificationHandle h, byte raw)
-        => "TypeSpec";
+    public string GetTypeFromSpecification(MetadataReader r, object? ctx, TypeSpecificationHandle h, byte raw) =>
+        "TypeSpec";
 
     public bool IsSystemType(string type) => type == "System.Type";
 
-    PrimitiveTypeCode ICustomAttributeTypeProvider<string>.GetUnderlyingEnumType(string type)
-        => PrimitiveTypeCode.UInt32;
+    PrimitiveTypeCode ICustomAttributeTypeProvider<string>.GetUnderlyingEnumType(string type) =>
+        PrimitiveTypeCode.UInt32;
 
     public string GetUnderlyingEnumType(string type) => type;
 }

--- a/Generator/Metadata/ComInterfaceExtractor.cs
+++ b/Generator/Metadata/ComInterfaceExtractor.cs
@@ -83,8 +83,8 @@ public sealed class ComInterfaceExtractor
         TypeIdentity identity = new(fqn, attrs.SupportedArchitecture ?? Architecture.All);
         string displayName = typeName;
 
-        // Collect referenced types
-        List<string> referencedTypes = CollectReferencedTypes(methods, baseFQN);
+        // Collect imports
+        ImportCollection imports = CollectImports(methods, baseFQN);
 
         ComInterfaceType result = new()
         {
@@ -106,7 +106,7 @@ public sealed class ComInterfaceExtractor
             HelpLink = apiDetails?.HelpLink,
             DeprecationMessage = attrs.DeprecationMessage,
             SupportedOSPlatform = attrs.SupportedOSPlatform,
-            ReferencedTypes = referencedTypes
+            Imports = imports
         };
 
         _logger.LogDebug(
@@ -316,7 +316,7 @@ public sealed class ComInterfaceExtractor
             DeprecationMessage = baseMember.DeprecationMessage,
             ReturnValueDoc = baseMember.ReturnValueDoc,
             SupportedOSPlatform = baseMember.SupportedOSPlatform,
-            ReferencedTypes = baseMember.ReferencedTypes,
+            Imports = baseMember.Imports,
             // ComMethodMember-specific properties
             VTableIndex = vTableIndex,
             HasStringParam = hasStringParam,
@@ -389,25 +389,25 @@ public sealed class ComInterfaceExtractor
     }
 
     /// <summary>
-    /// Collect referenced types for a COM interface.
+    /// Collect imports for a COM interface.
     /// </summary>
-    private static List<string> CollectReferencedTypes(
+    private static ImportCollection CollectImports(
         List<ComMethodMember> methods, string? baseInterfaceFQN)
     {
-        List<string> refs = [];
+        var imports = new ImportCollection();
 
         // Base interface
         if (baseInterfaceFQN != null)
-            refs.Add(baseInterfaceFQN);
+            imports.AddType(baseInterfaceFQN);
 
         // BSTR import
         if (methods.Any(m => m.HasStringParam))
-            refs.Add("Windows.Win32.Foundation.BSTR");
+            imports.AddType("Windows.Win32.Foundation.BSTR");
 
-        // Per-method referenced types
+        // Per-method imports
         foreach (ComMethodMember method in methods)
         {
-            refs.AddRange(method.ReferencedTypes);
+            imports.MergeFrom(method.Imports);
 
             // COM output parameter types (computed separately from base method extraction)
             if (method.OutputParameter is { } outParam)
@@ -420,10 +420,10 @@ public sealed class ComInterfaceExtractor
                     _ => null
                 };
                 if (outFqn != null)
-                    refs.Add(outFqn);
+                    imports.AddType(outFqn);
             }
         }
 
-        return refs.Distinct().ToList();
+        return imports;
     }
 }

--- a/Generator/Metadata/ComInterfaceExtractor.cs
+++ b/Generator/Metadata/ComInterfaceExtractor.cs
@@ -40,7 +40,8 @@ public sealed class ComInterfaceExtractor
         TypeDefinition typeDef,
         string assemblyName,
         string version,
-        TypeAttrs attrs
+        TypeAttrs attrs,
+        out int methodArchSkips
     )
     {
         string typeName = reader.GetString(typeDef.Name);
@@ -49,11 +50,22 @@ public sealed class ComInterfaceExtractor
 
         try
         {
-            return ExtractComInterfaceCore(reader, typeDef, typeName, typeNamespace, fqn, assemblyName, version, attrs);
+            return ExtractComInterfaceCore(
+                reader,
+                typeDef,
+                typeName,
+                typeNamespace,
+                fqn,
+                assemblyName,
+                version,
+                attrs,
+                out methodArchSkips
+            );
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to extract COM interface {FQN}", fqn);
+            methodArchSkips = 0;
             return null;
         }
     }
@@ -66,7 +78,8 @@ public sealed class ComInterfaceExtractor
         string fqn,
         string assemblyName,
         string version,
-        TypeAttrs attrs
+        TypeAttrs attrs,
+        out int methodArchSkips
     )
     {
         // Extract IID
@@ -85,7 +98,14 @@ public sealed class ComInterfaceExtractor
         ApiDetails? apiDetails = _docs.GetApiDetails(reader, typeDef);
 
         // Extract methods
-        List<ComMethodMember> methods = ExtractComMethods(reader, typeDef, typeNamespace, vTableOffset, apiDetails);
+        List<ComMethodMember> methods = ExtractComMethods(
+            reader,
+            typeDef,
+            typeNamespace,
+            vTableOffset,
+            apiDetails,
+            out methodArchSkips
+        );
 
         // Group properties from special-name get_/put_ methods
         List<ComPropertyMember> properties = GroupProperties(methods, apiDetails);
@@ -261,11 +281,13 @@ public sealed class ComInterfaceExtractor
         TypeDefinition typeDef,
         string typeNamespace,
         int vTableOffset,
-        ApiDetails? apiDetails
+        ApiDetails? apiDetails,
+        out int archSkips
     )
     {
         List<ComMethodMember> methods = [];
         int methodIndex = 0;
+        archSkips = 0;
 
         foreach (MethodDefinitionHandle hMethod in typeDef.GetMethods())
         {
@@ -281,11 +303,14 @@ public sealed class ComInterfaceExtractor
                     methodName,
                     typeNamespace,
                     vTableIndex,
-                    methods
+                    methods,
+                    out bool methodArchSkipped
                 );
 
                 if (comMethod != null)
                     methods.Add(comMethod);
+                else if (methodArchSkipped)
+                    archSkips++;
             }
             catch (Exception ex)
             {
@@ -307,11 +332,14 @@ public sealed class ComInterfaceExtractor
         string methodName,
         string typeNamespace,
         int vTableIndex,
-        List<ComMethodMember> previousMethods
+        List<ComMethodMember> previousMethods,
+        out bool archSkipped
     )
     {
         // Use MethodExtractor for base method data
-        MethodMember? baseMember = _methodExtractor.ExtractMethod(reader, methodDef, typeNamespace);
+        MethodExtractionResult baseResult = _methodExtractor.ExtractMethod(reader, methodDef, typeNamespace);
+        archSkipped = baseResult.SkipReason == MethodSkipReason.ArchFiltered;
+        MethodMember? baseMember = baseResult.Method;
 
         if (baseMember == null)
             return null;

--- a/Generator/Metadata/ComInterfaceExtractor.cs
+++ b/Generator/Metadata/ComInterfaceExtractor.cs
@@ -280,8 +280,7 @@ public sealed class ComInterfaceExtractor
         // Check for string (BSTR) parameters
         bool hasStringParam = baseMember.Parameters
             .Skip(1) // skip return type
-            .Any(p => p.Type is NativeTypedefType { Name: "BSTR" }
-                    || p.Type is PointerType { Pointee: NativeTypedefType { Name: "BSTR" } });
+            .Any(p => p.TypeDefName is "BSTR");
 
         // Check for special name (get_/put_ for property backing)
         bool isSpecialName = methodDef.Attributes.HasFlag(MethodAttributes.SpecialName);
@@ -398,16 +397,16 @@ public sealed class ComInterfaceExtractor
 
         // Base interface
         if (baseInterfaceFQN != null)
-            imports.AddType(baseInterfaceFQN);
-
-        // BSTR import
-        if (methods.Any(m => m.HasStringParam))
-            imports.AddType("Windows.Win32.Foundation.BSTR");
+            imports.AddType(baseInterfaceFQN);            
 
         // Per-method imports
         foreach (ComMethodMember method in methods)
         {
             imports.MergeFrom(method.Imports);
+
+            // BSTR import
+            if (method.HasStringParam)
+                imports.AddType("Windows.Win32.Foundation.BSTR");
 
             // COM output parameter types (computed separately from base method extraction)
             if (method.OutputParameter is { } outParam)

--- a/Generator/Metadata/ComInterfaceExtractor.cs
+++ b/Generator/Metadata/ComInterfaceExtractor.cs
@@ -20,8 +20,11 @@ public sealed class ComInterfaceExtractor
     private readonly ILogger<ComInterfaceExtractor> _logger;
 
     public ComInterfaceExtractor(
-        MetadataLoader loader, DocumentationLoader docs,
-        MethodExtractor methodExtractor, ILogger<ComInterfaceExtractor> logger)
+        MetadataLoader loader,
+        DocumentationLoader docs,
+        MethodExtractor methodExtractor,
+        ILogger<ComInterfaceExtractor> logger
+    )
     {
         _loader = loader;
         _docs = docs;
@@ -33,8 +36,12 @@ public sealed class ComInterfaceExtractor
     /// Extract a ComInterfaceType from a TypeDefinition.
     /// </summary>
     public ComInterfaceType? ExtractComInterface(
-        MetadataReader reader, TypeDefinition typeDef,
-        string assemblyName, string version, TypeAttrs attrs)
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        string assemblyName,
+        string version,
+        TypeAttrs attrs
+    )
     {
         string typeName = reader.GetString(typeDef.Name);
         string typeNamespace = reader.GetString(typeDef.Namespace);
@@ -42,8 +49,7 @@ public sealed class ComInterfaceExtractor
 
         try
         {
-            return ExtractComInterfaceCore(reader, typeDef, typeName, typeNamespace, fqn,
-                assemblyName, version, attrs);
+            return ExtractComInterfaceCore(reader, typeDef, typeName, typeNamespace, fqn, assemblyName, version, attrs);
         }
         catch (Exception ex)
         {
@@ -53,9 +59,15 @@ public sealed class ComInterfaceExtractor
     }
 
     private ComInterfaceType ExtractComInterfaceCore(
-        MetadataReader reader, TypeDefinition typeDef,
-        string typeName, string typeNamespace, string fqn,
-        string assemblyName, string version, TypeAttrs attrs)
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        string typeName,
+        string typeNamespace,
+        string fqn,
+        string assemblyName,
+        string version,
+        TypeAttrs attrs
+    )
     {
         // Extract IID
         Guid? iid = AttributeReader.DecodeGuid(reader, typeDef);
@@ -73,8 +85,7 @@ public sealed class ComInterfaceExtractor
         ApiDetails? apiDetails = _docs.GetApiDetails(reader, typeDef);
 
         // Extract methods
-        List<ComMethodMember> methods = ExtractComMethods(
-            reader, typeDef, typeNamespace, vTableOffset, apiDetails);
+        List<ComMethodMember> methods = ExtractComMethods(reader, typeDef, typeNamespace, vTableOffset, apiDetails);
 
         // Group properties from special-name get_/put_ methods
         List<ComPropertyMember> properties = GroupProperties(methods, apiDetails);
@@ -106,12 +117,16 @@ public sealed class ComInterfaceExtractor
             HelpLink = apiDetails?.HelpLink,
             DeprecationMessage = attrs.DeprecationMessage,
             SupportedOSPlatform = attrs.SupportedOSPlatform,
-            Imports = imports
+            Imports = imports,
         };
 
         _logger.LogDebug(
             "Extracted ComInterfaceType {FQN} ({MethodCount} methods, {PropCount} properties, vtableOffset={Offset})",
-            fqn, methods.Count, properties.Count, vTableOffset);
+            fqn,
+            methods.Count,
+            properties.Count,
+            vTableOffset
+        );
 
         return result;
     }
@@ -126,11 +141,14 @@ public sealed class ComInterfaceExtractor
 
         foreach (TypeDefinitionHandle hTd in reader.TypeDefinitions)
         {
-            if (hTd.IsNil) continue;
+            if (hTd.IsNil)
+                continue;
 
             TypeDefinition td = reader.GetTypeDefinition(hTd);
-            if (reader.StringComparer.Equals(td.Namespace, typeNamespace) &&
-                reader.StringComparer.Equals(td.Name, coclassName))
+            if (
+                reader.StringComparer.Equals(td.Namespace, typeNamespace)
+                && reader.StringComparer.Equals(td.Name, coclassName)
+            )
             {
                 return AttributeReader.DecodeGuid(reader, td);
             }
@@ -145,10 +163,16 @@ public sealed class ComInterfaceExtractor
     /// Port of AhkComInterface.GetBaseTypeDef.
     /// </summary>
     private (string? FQN, string? Name) ResolveBaseInterface(
-        MetadataReader reader, TypeDefinition typeDef,
-        string typeNamespace, string typeName)
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        string typeNamespace,
+        string typeName
+    )
     {
-        List<(MetadataReader Reader, TypeDefinition TypeDef)> impls = GetResolvedInterfaceImplementations(reader, typeDef);
+        List<(MetadataReader Reader, TypeDefinition TypeDef)> impls = GetResolvedInterfaceImplementations(
+            reader,
+            typeDef
+        );
 
         if (impls.Count == 0)
             return (null, null);
@@ -157,8 +181,11 @@ public sealed class ComInterfaceExtractor
         {
             _logger.LogWarning(
                 "Interface {Namespace}.{Name} implements {Count} interfaces, expected 0 or 1: [{Names}]",
-                typeNamespace, typeName, impls.Count,
-                string.Join(", ", impls.Select(i => i.Reader.GetString(i.TypeDef.Name))));
+                typeNamespace,
+                typeName,
+                impls.Count,
+                string.Join(", ", impls.Select(i => i.Reader.GetString(i.TypeDef.Name)))
+            );
         }
 
         var (baseReader, baseTd) = impls[0];
@@ -175,7 +202,9 @@ public sealed class ComInterfaceExtractor
     /// Port of AhkComInterface.GetResolvedInterfaceImplementations.
     /// </summary>
     private List<(MetadataReader Reader, TypeDefinition TypeDef)> GetResolvedInterfaceImplementations(
-        MetadataReader reader, TypeDefinition forType)
+        MetadataReader reader,
+        TypeDefinition forType
+    )
     {
         List<(MetadataReader, TypeDefinition)> results = [];
 
@@ -187,8 +216,7 @@ public sealed class ComInterfaceExtractor
             {
                 case HandleKind.TypeReference:
                 {
-                    var (targetReader, targetHandle) = _loader.ResolveTypeReference(
-                        reader, (TypeReferenceHandle)iface);
+                    var (targetReader, targetHandle) = _loader.ResolveTypeReference(reader, (TypeReferenceHandle)iface);
                     results.Add((targetReader, targetReader.GetTypeDefinition(targetHandle)));
                     break;
                 }
@@ -229,9 +257,12 @@ public sealed class ComInterfaceExtractor
     /// Extract COM methods from a type's method definitions.
     /// </summary>
     private List<ComMethodMember> ExtractComMethods(
-        MetadataReader reader, TypeDefinition typeDef,
-        string typeNamespace, int vTableOffset,
-        ApiDetails? apiDetails)
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        string typeNamespace,
+        int vTableOffset,
+        ApiDetails? apiDetails
+    )
     {
         List<ComMethodMember> methods = [];
         int methodIndex = 0;
@@ -245,15 +276,20 @@ public sealed class ComInterfaceExtractor
             try
             {
                 ComMethodMember? comMethod = ExtractComMethod(
-                    reader, methodDef, methodName, typeNamespace, vTableIndex, methods);
+                    reader,
+                    methodDef,
+                    methodName,
+                    typeNamespace,
+                    vTableIndex,
+                    methods
+                );
 
                 if (comMethod != null)
                     methods.Add(comMethod);
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to extract COM method {Namespace}.{Method}",
-                    typeNamespace, methodName);
+                _logger.LogError(ex, "Failed to extract COM method {Namespace}.{Method}", typeNamespace, methodName);
             }
 
             methodIndex++;
@@ -266,20 +302,23 @@ public sealed class ComInterfaceExtractor
     /// Extract a single COM method into a ComMethodMember.
     /// </summary>
     private ComMethodMember? ExtractComMethod(
-        MetadataReader reader, MethodDefinition methodDef,
-        string methodName, string typeNamespace, int vTableIndex,
-        List<ComMethodMember> previousMethods)
+        MetadataReader reader,
+        MethodDefinition methodDef,
+        string methodName,
+        string typeNamespace,
+        int vTableIndex,
+        List<ComMethodMember> previousMethods
+    )
     {
         // Use MethodExtractor for base method data
-        MethodMember? baseMember = _methodExtractor.ExtractMethod(
-            reader, methodDef, typeNamespace);
+        MethodMember? baseMember = _methodExtractor.ExtractMethod(reader, methodDef, typeNamespace);
 
         if (baseMember == null)
             return null;
 
         // Check for string (BSTR) parameters
-        bool hasStringParam = baseMember.Parameters
-            .Skip(1) // skip return type
+        bool hasStringParam = baseMember
+            .Parameters.Skip(1) // skip return type
             .Any(p => p.TypeDefName is "BSTR");
 
         // Check for special name (get_/put_ for property backing)
@@ -287,7 +326,9 @@ public sealed class ComInterfaceExtractor
 
         // Compute COM-specific output parameter (different logic from DllImport)
         ParameterMember? outputParameter = GetComOutputParameter(
-            baseMember.Parameters, baseMember.CanReturnErrorsAsSuccess);
+            baseMember.Parameters,
+            baseMember.CanReturnErrorsAsSuccess
+        );
 
         // Compute deduplicated name (append counter for overloaded methods)
         int overloadCount = previousMethods.Count(m => m.Name == methodName && m.VTableIndex < vTableIndex);
@@ -320,7 +361,7 @@ public sealed class ComInterfaceExtractor
             VTableIndex = vTableIndex,
             HasStringParam = hasStringParam,
             IsSpecialName = isSpecialName,
-            DeduplicatedName = deduplicatedName
+            DeduplicatedName = deduplicatedName,
         };
     }
 
@@ -330,7 +371,9 @@ public sealed class ComInterfaceExtractor
     /// Port of AhkComMethod.GetOutputParameter.
     /// </summary>
     private static ParameterMember? GetComOutputParameter(
-        IReadOnlyList<ParameterMember> parameters, bool canReturnErrorsAsSuccess)
+        IReadOnlyList<ParameterMember> parameters,
+        bool canReturnErrorsAsSuccess
+    )
     {
         if (parameters.Count == 0 || parameters[0].Type is not HResultType)
             return null;
@@ -356,8 +399,7 @@ public sealed class ComInterfaceExtractor
     /// Group special-name get_/put_ methods into ComPropertyMember instances.
     /// Port of AhkComInterface property collection logic.
     /// </summary>
-    private static List<ComPropertyMember> GroupProperties(
-        List<ComMethodMember> methods, ApiDetails? apiDetails)
+    private static List<ComPropertyMember> GroupProperties(List<ComMethodMember> methods, ApiDetails? apiDetails)
     {
         List<ComPropertyMember> properties = [];
 
@@ -367,21 +409,25 @@ public sealed class ComInterfaceExtractor
             if (properties.Any(p => p.Name == normalizedName))
                 continue;
 
-            ComMethodMember? getter = methods.FirstOrDefault(
-                m => m.IsSpecialName && m.DeduplicatedName == "get_" + normalizedName);
-            ComMethodMember? setter = methods.FirstOrDefault(
-                m => m.IsSpecialName && m.DeduplicatedName == "put_" + normalizedName);
+            ComMethodMember? getter = methods.FirstOrDefault(m =>
+                m.IsSpecialName && m.DeduplicatedName == "get_" + normalizedName
+            );
+            ComMethodMember? setter = methods.FirstOrDefault(m =>
+                m.IsSpecialName && m.DeduplicatedName == "put_" + normalizedName
+            );
 
             string? description = null;
             apiDetails?.Fields.TryGetValue(normalizedName, out description);
 
-            properties.Add(new ComPropertyMember
-            {
-                Name = normalizedName,
-                Getter = getter,
-                Setter = setter,
-                Description = description
-            });
+            properties.Add(
+                new ComPropertyMember
+                {
+                    Name = normalizedName,
+                    Getter = getter,
+                    Setter = setter,
+                    Description = description,
+                }
+            );
         }
 
         return properties;
@@ -390,14 +436,13 @@ public sealed class ComInterfaceExtractor
     /// <summary>
     /// Collect imports for a COM interface.
     /// </summary>
-    private static ImportCollection CollectImports(
-        List<ComMethodMember> methods, string? baseInterfaceFQN)
+    private static ImportCollection CollectImports(List<ComMethodMember> methods, string? baseInterfaceFQN)
     {
         var imports = new ImportCollection();
 
         // Base interface
         if (baseInterfaceFQN != null)
-            imports.AddType(baseInterfaceFQN);            
+            imports.AddType(baseInterfaceFQN);
 
         // Per-method imports
         foreach (ComMethodMember method in methods)
@@ -416,7 +461,7 @@ public sealed class ComInterfaceExtractor
                     PointerType { Pointee: StructRef s } => s.FQN,
                     PointerType { Pointee: ComRef c } => c.FQN,
                     PointerType { Pointee: HandleRef h } => h.FQN,
-                    _ => null
+                    _ => null,
                 };
                 if (outFqn != null)
                     imports.AddType(outFqn);

--- a/Generator/Metadata/DocumentationLoader.cs
+++ b/Generator/Metadata/DocumentationLoader.cs
@@ -40,8 +40,7 @@ public sealed class DocumentationLoader
         }
 
         watch.Stop();
-        _logger.LogInformation("Loaded {Count} ApiDetails records in {Elapsed}ms",
-            count, watch.ElapsedMilliseconds);
+        _logger.LogInformation("Loaded {Count} ApiDetails records in {Elapsed}ms", count, watch.ElapsedMilliseconds);
     }
 
     /// <summary>
@@ -51,7 +50,10 @@ public sealed class DocumentationLoader
     public ApiDetails? GetApiDetails(MetadataReader reader, TypeDefinition typeDef)
     {
         CustomAttribute? docAttr = AttributeReader.FindAttribute(
-            reader, typeDef.GetCustomAttributes(), "DocumentationAttribute");
+            reader,
+            typeDef.GetCustomAttributes(),
+            "DocumentationAttribute"
+        );
 
         string fqn = $"{reader.GetString(typeDef.Namespace)}.{reader.GetString(typeDef.Name)}";
 
@@ -69,7 +71,10 @@ public sealed class DocumentationLoader
     {
         string methodName = reader.GetString(def.Name);
         CustomAttribute? docAttr = AttributeReader.FindAttribute(
-            reader, def.GetCustomAttributes(), "DocumentationAttribute");
+            reader,
+            def.GetCustomAttributes(),
+            "DocumentationAttribute"
+        );
         ApiDetails? details = null;
 
         // Check parent type for qualified lookup
@@ -107,8 +112,9 @@ public sealed class DocumentationLoader
         if (details.HelpLink == null && documentationAttr != null)
         {
             var decoded = documentationAttr.Value.DecodeValue(s_attrProvider);
-            string uriString = (string)(decoded.FixedArguments[0].Value
-                ?? throw new NullReferenceException("Null DocumentationAttribute URI"));
+            string uriString = (string)(
+                decoded.FixedArguments[0].Value ?? throw new NullReferenceException("Null DocumentationAttribute URI")
+            );
             details.HelpLink = new Uri(uriString);
         }
 

--- a/Generator/Metadata/DocumentationLoader.cs
+++ b/Generator/Metadata/DocumentationLoader.cs
@@ -1,8 +1,8 @@
 namespace AhkWin32.Generator.Metadata;
 
+using System.Collections.Frozen;
 using System.Diagnostics;
 using System.Reflection.Metadata;
-using Gma.DataStructures.StringSearch;
 using MessagePack;
 using Microsoft.Extensions.Logging;
 using Microsoft.Windows.SDK.Win32Docs;
@@ -15,7 +15,7 @@ public sealed class DocumentationLoader
 {
     private static readonly CaTypeProvider s_attrProvider = new();
 
-    private readonly PatriciaTrie<ApiDetails> _apiDocs = new();
+    private FrozenDictionary<string, ApiDetails> _apiDocs = FrozenDictionary<string, ApiDetails>.Empty;
     private readonly ILogger<DocumentationLoader> _logger;
 
     public DocumentationLoader(ILogger<DocumentationLoader> logger)
@@ -32,15 +32,16 @@ public sealed class DocumentationLoader
         Stopwatch watch = Stopwatch.StartNew();
 
         using FileStream stream = File.OpenRead(filepath);
-        int count = 0;
-        foreach (var pair in MessagePackSerializer.Deserialize<Dictionary<string, ApiDetails>>(stream))
-        {
-            _apiDocs.Add(pair.Key, pair.Value);
-            count++;
-        }
+        _apiDocs = MessagePackSerializer
+            .Deserialize<Dictionary<string, ApiDetails>>(stream)
+            .ToFrozenDictionary(StringComparer.Ordinal);
 
         watch.Stop();
-        _logger.LogInformation("Loaded {Count} ApiDetails records in {Elapsed}ms", count, watch.ElapsedMilliseconds);
+        _logger.LogInformation(
+            "Loaded {Count} ApiDetails records in {Elapsed}ms",
+            _apiDocs.Count,
+            watch.ElapsedMilliseconds
+        );
     }
 
     /// <summary>
@@ -102,11 +103,10 @@ public sealed class DocumentationLoader
     /// </summary>
     private ApiDetails? GetApiDetails(string forName, CustomAttribute? documentationAttr)
     {
-        IEnumerable<ApiDetails> matches = _apiDocs.Retrieve(forName);
-        if (!matches.Any())
+        if (!_apiDocs.TryGetValue(forName, out ApiDetails? details))
+        {
             return null;
-
-        ApiDetails details = matches.First();
+        }
 
         // Fall back to [Documentation] attribute if HelpLink is null
         if (details.HelpLink == null && documentationAttr != null)

--- a/Generator/Metadata/FieldExtractor.cs
+++ b/Generator/Metadata/FieldExtractor.cs
@@ -209,6 +209,14 @@ public sealed class FieldExtractor
         bool isAnsi
     )
     {
+        // System.Guid is the one external type we don't treat as opaque — it maps to the
+        // hand-written Guid.ahk fixture at the projection root. It has no TypeDefinition in
+        // the Win32 metadata, so skip the lookup below (which would fail and fall back to a
+        // pointer) and keep the StructRef. Size/alignment are handled in ComputeFieldSize /
+        // ComputeLogicalFieldSize; the emitters render it as the embedded `Guid` type.
+        if (structRef.FQN == "System.Guid")
+            return (structRef, null, false);
+
         // We need to find the actual TypeDefinition to check if it's nested and get its namespace
         // The StructRef.FQN gives us the namespace.name but we need the TypeDefinition for nested check
         // Pass parentTypeDef so nested types (e.g. _Anonymous_e__Struct) are resolved within
@@ -298,6 +306,8 @@ public sealed class FieldExtractor
         return type switch
         {
             StructRef when embeddedStruct != null => embeddedStruct.Size,
+            // System.Guid has no embedded StructType (it's the Guid.ahk fixture) — 16 bytes.
+            StructRef { FQN: "System.Guid" } => 16,
             ArrayType a when embeddedStruct != null => a.Length * embeddedStruct.Size,
             ArrayType a => a.Width,
             StringType s => s.Width,
@@ -327,6 +337,10 @@ public sealed class FieldExtractor
 
             // Embedded struct = packing size of the embedded struct
             StructRef when embeddedStruct != null => embeddedStruct.PackingSize,
+
+            // System.Guid aligns to 4 (its largest member is the 4-byte Data1), matching
+            // the real Win32 GUID and the Guid.ahk fixture.
+            StructRef { FQN: "System.Guid" } => 4,
 
             // Everything else = field size
             _ => fieldSize,

--- a/Generator/Metadata/FieldExtractor.cs
+++ b/Generator/Metadata/FieldExtractor.cs
@@ -10,10 +10,7 @@ using Microsoft.Extensions.Logging;
 /// <summary>
 /// Result of extracting fields from a struct, including computed layout.
 /// </summary>
-public sealed record StructLayout(
-    IReadOnlyList<FieldMember> Fields,
-    int TotalSize,
-    int PackingSize);
+public sealed record StructLayout(IReadOnlyList<FieldMember> Fields, int TotalSize, int PackingSize);
 
 /// <summary>
 /// Extracts fields from a TypeDefinition, decodes their signatures via SignatureDecoder,
@@ -34,7 +31,8 @@ public sealed class FieldExtractor
     public FieldExtractor(
         MetadataLoader loader,
         ILogger logger,
-        Func<MetadataReader, TypeDefinition, bool, StructType?> extractStructCallback)
+        Func<MetadataReader, TypeDefinition, bool, StructType?> extractStructCallback
+    )
     {
         _loader = loader;
         _logger = logger;
@@ -53,7 +51,8 @@ public sealed class FieldExtractor
         bool isUnion,
         bool isAnsi,
         string parentFQN,
-        Dictionary<string, string>? apiFields = null)
+        Dictionary<string, string>? apiFields = null
+    )
     {
         List<FieldMember> members = [];
         int offset = 0;
@@ -75,7 +74,12 @@ public sealed class FieldExtractor
             StructType? embeddedStruct = null;
             bool isNested = false;
             (resolvedType, embeddedStruct, isNested) = ResolveEmbeddedStruct(
-                reader, typeDef, resolvedType, fieldName, isAnsi);
+                reader,
+                typeDef,
+                resolvedType,
+                fieldName,
+                isAnsi
+            );
 
             // Compute field size
             int fieldSize = ComputeFieldSize(resolvedType, embeddedStruct, isAnsi);
@@ -90,9 +94,7 @@ public sealed class FieldExtractor
             offset += padding;
 
             // Set member offset
-            int memberOffset = layoutKind == StructLayoutKind.Explicit
-                ? fieldDef.GetOffset()
-                : offset;
+            int memberOffset = layoutKind == StructLayoutKind.Explicit ? fieldDef.GetOffset() : offset;
 
             // For unions, all fields overlap at offset 0 — don't advance
             if (!isUnion)
@@ -116,23 +118,29 @@ public sealed class FieldExtractor
                 DeprecationMessage = fieldAttrs.DeprecationMessage,
                 EmbeddedStruct = embeddedStruct,
                 Bitfields = fieldAttrs.Bitfields ?? [],
-                IsNested = isNested
+                IsNested = isNested,
             };
 
             members.Add(member);
 
             _logger.LogTrace(
                 "Extracting field {ParentFQN}.{FieldName}: {ResolvedType} at offset {Offset} (size {Size})",
-                parentFQN, fieldName, resolvedType.DisplayName, memberOffset, fieldSize);
+                parentFQN,
+                fieldName,
+                resolvedType.DisplayName,
+                memberOffset,
+                fieldSize
+            );
             _logger.LogTrace(
                 "Layout: alignment={Alignment}, padding={Padding}, logicalSize={LogicalSize}",
-                alignment, padding, logicalFieldSize);
+                alignment,
+                padding,
+                logicalFieldSize
+            );
         }
 
         // Compute total size
-        int totalSize = isUnion
-            ? (members.Count > 0 ? members.Max(m => m.Size) : 0)
-            : offset;
+        int totalSize = isUnion ? (members.Count > 0 ? members.Max(m => m.Size) : 0) : offset;
 
         // Cap packing size to max alignment seen
         packingSize = Math.Min(packingSize, maxAlignment);
@@ -143,7 +151,11 @@ public sealed class FieldExtractor
 
         _logger.LogDebug(
             "Computed layout for {FQN}: {FieldCount} fields, {TotalSize} bytes, packing {PackingSize}",
-            parentFQN, members.Count, totalSize, packingSize);
+            parentFQN,
+            members.Count,
+            totalSize,
+            packingSize
+        );
 
         return new StructLayout(members, totalSize, packingSize);
     }
@@ -153,7 +165,12 @@ public sealed class FieldExtractor
     /// Port of AhkStructMember constructor logic for Struct and Array fields.
     /// </summary>
     private (ResolvedType Type, StructType? Embedded, bool IsNested) ResolveEmbeddedStruct(
-        MetadataReader reader, TypeDefinition parentTypeDef, ResolvedType resolvedType, string fieldName, bool isAnsi)
+        MetadataReader reader,
+        TypeDefinition parentTypeDef,
+        ResolvedType resolvedType,
+        string fieldName,
+        bool isAnsi
+    )
     {
         if (resolvedType is StructRef structRef)
         {
@@ -162,7 +179,13 @@ public sealed class FieldExtractor
 
         if (resolvedType is ArrayType arrayType && arrayType.ElementType is StructRef arrayStructRef)
         {
-            var (_, embedded, isNested) = ResolveStructRefField(reader, parentTypeDef, arrayStructRef, fieldName, isAnsi);
+            var (_, embedded, isNested) = ResolveStructRefField(
+                reader,
+                parentTypeDef,
+                arrayStructRef,
+                fieldName,
+                isAnsi
+            );
             if (embedded != null)
             {
                 // Keep the ArrayType but with the embedded struct for size info
@@ -179,7 +202,12 @@ public sealed class FieldExtractor
     /// Resolve a StructRef field — either build the embedded struct or convert to pointer.
     /// </summary>
     private (ResolvedType Type, StructType? Embedded, bool IsNested) ResolveStructRefField(
-        MetadataReader reader, TypeDefinition parentTypeDef, StructRef structRef, string fieldName, bool isAnsi)
+        MetadataReader reader,
+        TypeDefinition parentTypeDef,
+        StructRef structRef,
+        string fieldName,
+        bool isAnsi
+    )
     {
         // We need to find the actual TypeDefinition to check if it's nested and get its namespace
         // The StructRef.FQN gives us the namespace.name but we need the TypeDefinition for nested check
@@ -190,8 +218,11 @@ public sealed class FieldExtractor
         if (fieldTypeDef == null)
         {
             // Can't find the type definition — treat as pointer
-            _logger.LogTrace("Converting non-resolvable type {FQN} to pointer for field {FieldName}",
-                structRef.FQN, fieldName);
+            _logger.LogTrace(
+                "Converting non-resolvable type {FQN} to pointer for field {FieldName}",
+                structRef.FQN,
+                fieldName
+            );
             return (new PointerType(null), null, false);
         }
 
@@ -209,13 +240,17 @@ public sealed class FieldExtractor
         StructType? embedded = _extractStructCallback(reader, fieldTypeDef.Value, isAnsi);
         if (embedded == null)
         {
-            _logger.LogTrace("Embedded struct extraction returned null for {FQN}, treating as pointer",
-                structRef.FQN);
+            _logger.LogTrace("Embedded struct extraction returned null for {FQN}, treating as pointer", structRef.FQN);
             return (new PointerType(null), null, false);
         }
 
-        _logger.LogTrace("Embedded struct {FieldName}: {EmbeddedFQN} (size {Size}, packing {PackingSize})",
-            fieldName, structRef.FQN, embedded.Size, embedded.PackingSize);
+        _logger.LogTrace(
+            "Embedded struct {FieldName}: {EmbeddedFQN} (size {Size}, packing {PackingSize})",
+            fieldName,
+            structRef.FQN,
+            embedded.Size,
+            embedded.PackingSize
+        );
 
         return (structRef, embedded, isNested);
     }
@@ -226,7 +261,8 @@ public sealed class FieldExtractor
     private static TypeDefinition? FindTypeDefByFqn(MetadataReader reader, string fqn, TypeDefinition? parent = null)
     {
         int lastDot = fqn.LastIndexOf('.');
-        if (lastDot < 0) return null;
+        if (lastDot < 0)
+            return null;
 
         string ns = fqn[..lastDot];
         string name = fqn[(lastDot + 1)..];
@@ -245,8 +281,7 @@ public sealed class FieldExtractor
         foreach (TypeDefinitionHandle tdHandle in reader.TypeDefinitions)
         {
             TypeDefinition td = reader.GetTypeDefinition(tdHandle);
-            if (reader.StringComparer.Equals(td.Name, name) &&
-                reader.StringComparer.Equals(td.Namespace, ns))
+            if (reader.StringComparer.Equals(td.Name, name) && reader.StringComparer.Equals(td.Namespace, ns))
             {
                 return td;
             }
@@ -266,7 +301,7 @@ public sealed class FieldExtractor
             ArrayType a when embeddedStruct != null => a.Length * embeddedStruct.Size,
             ArrayType a => a.Width,
             StringType s => s.Width,
-            _ => type.Width
+            _ => type.Width,
         };
     }
 
@@ -275,24 +310,26 @@ public sealed class FieldExtractor
     /// This determines how the field aligns within the struct.
     /// </summary>
     private static int ComputeLogicalFieldSize(
-        ResolvedType type, StructType? embeddedStruct, int fieldSize, bool isAnsi)
+        ResolvedType type,
+        StructType? embeddedStruct,
+        int fieldSize,
+        bool isAnsi
+    )
     {
         return type switch
         {
             // Array = element width (for struct arrays, use element's packing size)
-            ArrayType { ElementType: StructRef } when embeddedStruct != null
-                => embeddedStruct.PackingSize,
+            ArrayType { ElementType: StructRef } when embeddedStruct != null => embeddedStruct.PackingSize,
             ArrayType a => a.ElementType.Width,
 
             // String = character width
             StringType => isAnsi ? 1 : 2,
 
             // Embedded struct = packing size of the embedded struct
-            StructRef when embeddedStruct != null
-                => embeddedStruct.PackingSize,
+            StructRef when embeddedStruct != null => embeddedStruct.PackingSize,
 
             // Everything else = field size
-            _ => fieldSize
+            _ => fieldSize,
         };
     }
 
@@ -301,7 +338,11 @@ public sealed class FieldExtractor
     /// Port of AhkStructMember.GetFlags.
     /// </summary>
     private static MemberFlags ComputeFieldFlags(
-        FieldAttrs attrs, string fieldName, ResolvedType resolvedType, StructType? embeddedStruct)
+        FieldAttrs attrs,
+        string fieldName,
+        ResolvedType resolvedType,
+        StructType? embeddedStruct
+    )
     {
         MemberFlags flags = attrs.Flags; // Already has Deprecated, Reserved, NativeBitField
 
@@ -313,7 +354,7 @@ public sealed class FieldExtractor
         {
             StructRef s => s.Name,
             ArrayType { ElementType: StructRef s } => s.Name,
-            _ => ""
+            _ => "",
         };
 
         if (typeName.EndsWith("_e__Union") || (embeddedStruct?.IsUnion ?? false))

--- a/Generator/Metadata/MetadataLoader.cs
+++ b/Generator/Metadata/MetadataLoader.cs
@@ -15,7 +15,10 @@ using Microsoft.Extensions.Logging;
 public sealed class MetadataLoader : IDisposable
 {
     private readonly ConcurrentDictionary<string, (PEReader PeReader, MetadataReader Reader)> _primaryAssemblies = [];
-    private readonly ConcurrentDictionary<string, Lazy<(PEReader PeReader, MetadataReader Reader)>> _externalAssemblies = [];
+    private readonly ConcurrentDictionary<
+        string,
+        Lazy<(PEReader PeReader, MetadataReader Reader)>
+    > _externalAssemblies = [];
     private readonly Dictionary<string, string> _packageVersions = [];
     private readonly string _metadataDir;
     private readonly ILogger<MetadataLoader> _logger;
@@ -37,15 +40,18 @@ public sealed class MetadataLoader : IDisposable
 
         LoadPackageVersions();
 
-        var winmdPaths = Directory.EnumerateFiles(_metadataDir)
+        var winmdPaths = Directory
+            .EnumerateFiles(_metadataDir)
             .Where(path => Path.GetExtension(path).Equals(".winmd", StringComparison.OrdinalIgnoreCase));
 
         foreach (string path in winmdPaths)
         {
             string fileName = Path.GetFileNameWithoutExtension(path);
 
-            if (assemblyFilter is { Length: > 0 } &&
-                !assemblyFilter.Any(f => fileName.Equals(f, StringComparison.OrdinalIgnoreCase)))
+            if (
+                assemblyFilter is { Length: > 0 }
+                && !assemblyFilter.Any(f => fileName.Equals(f, StringComparison.OrdinalIgnoreCase))
+            )
             {
                 _logger.LogWarning("Assembly {AssemblyName} skipped by filter", fileName);
                 continue;
@@ -62,13 +68,20 @@ public sealed class MetadataLoader : IDisposable
 
             string packageVersion = ResolvePackageVersion(name);
             int typeCount = reader.TypeDefinitions.Count;
-            _logger.LogInformation("Loaded {AssemblyName} (package {PackageVersion}, {TypeCount} types)",
-                name, packageVersion, typeCount);
+            _logger.LogInformation(
+                "Loaded {AssemblyName} (package {PackageVersion}, {TypeCount} types)",
+                name,
+                packageVersion,
+                typeCount
+            );
         }
 
         watch.Stop();
-        _logger.LogInformation("Loaded {Count} primary assemblies in {Elapsed:F1}s",
-            _primaryAssemblies.Count, watch.Elapsed.TotalSeconds);
+        _logger.LogInformation(
+            "Loaded {Count} primary assemblies in {Elapsed:F1}s",
+            _primaryAssemblies.Count,
+            watch.Elapsed.TotalSeconds
+        );
     }
 
     /// <summary>
@@ -104,8 +117,10 @@ public sealed class MetadataLoader : IDisposable
             ? assemblyName[..^".winmd".Length]
             : assemblyName;
 
-        if (s_assemblyToPackage.TryGetValue(normalized, out string? packageName) &&
-            _packageVersions.TryGetValue(packageName, out string? version))
+        if (
+            s_assemblyToPackage.TryGetValue(normalized, out string? packageName)
+            && _packageVersions.TryGetValue(packageName, out string? version)
+        )
         {
             return version;
         }
@@ -139,7 +154,9 @@ public sealed class MetadataLoader : IDisposable
     /// Returns the matched (MetadataReader, TypeDefinitionHandle) pair.
     /// </summary>
     public (MetadataReader Reader, TypeDefinitionHandle Handle) ResolveTypeReference(
-        MetadataReader sourceReader, TypeReferenceHandle trHandle)
+        MetadataReader sourceReader,
+        TypeReferenceHandle trHandle
+    )
     {
         TypeReference tr = sourceReader.GetTypeReference(trHandle);
         string name = sourceReader.GetString(tr.Name);
@@ -169,12 +186,14 @@ public sealed class MetadataLoader : IDisposable
                 string parentNs = parentReader.GetString(parentTd.Namespace);
                 string parentName = parentReader.GetString(parentTd.Name);
                 throw new TypeLoadException(
-                    $"Could not resolve nested type '{ns}.{name}' under '{parentNs}.{parentName}'");
+                    $"Could not resolve nested type '{ns}.{name}' under '{parentNs}.{parentName}'"
+                );
 
             case HandleKind.AssemblyReference:
                 // Type is in a different assembly, load it if necessary and search there
                 AssemblyReference asmRef = sourceReader.GetAssemblyReference(
-                    (AssemblyReferenceHandle)tr.ResolutionScope);
+                    (AssemblyReferenceHandle)tr.ResolutionScope
+                );
                 string asmName = sourceReader.GetString(asmRef.Name);
                 MetadataReader extReader = ResolveExternalAssembly(asmName);
 
@@ -182,7 +201,8 @@ public sealed class MetadataLoader : IDisposable
 
             default:
                 throw new NotSupportedException(
-                    $"Cannot resolve '{ns}.{name}' — unsupported resolution scope kind '{tr.ResolutionScope.Kind}'");
+                    $"Cannot resolve '{ns}.{name}' — unsupported resolution scope kind '{tr.ResolutionScope.Kind}'"
+                );
         }
     }
 
@@ -198,19 +218,22 @@ public sealed class MetadataLoader : IDisposable
         // Lazy ensures the load delegate runs exactly once per assembly name even
         // under concurrent access; GetOrAdd's factory may run multiple times but
         // only one Lazy.Value invocation will actually open the file.
-        var lazy = _externalAssemblies.GetOrAdd(assemblyName, name =>
-            new Lazy<(PEReader, MetadataReader)>(
+        var lazy = _externalAssemblies.GetOrAdd(
+            assemblyName,
+            name => new Lazy<(PEReader, MetadataReader)>(
                 () => LoadExternalAssembly(name),
-                LazyThreadSafetyMode.ExecutionAndPublication));
+                LazyThreadSafetyMode.ExecutionAndPublication
+            )
+        );
         return lazy.Value.Reader;
     }
 
     private (PEReader PeReader, MetadataReader Reader) LoadExternalAssembly(string assemblyName)
     {
         string runtimeDir = RuntimeEnvironment.GetRuntimeDirectory();
-        string sdkRoot = Environment.GetEnvironmentVariable("WindowsSdkDir") ??
-            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
-                "Windows Kits", "10");
+        string sdkRoot =
+            Environment.GetEnvironmentVariable("WindowsSdkDir")
+            ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Windows Kits", "10");
 
         // We search these paths in order. The first assembly that we can load succesfully is returned
         List<string> probePaths =
@@ -279,14 +302,16 @@ public sealed class MetadataLoader : IDisposable
     /// following type forwarders (ExportedTypes) if necessary.
     /// </summary>
     private (MetadataReader Reader, TypeDefinitionHandle Handle) FindTypeDefinition(
-        MetadataReader reader, string ns, string name)
+        MetadataReader reader,
+        string ns,
+        string name
+    )
     {
         // Try normal type definitions first
         foreach (TypeDefinitionHandle tdHandle in reader.TypeDefinitions)
         {
             TypeDefinition td = reader.GetTypeDefinition(tdHandle);
-            if (reader.StringComparer.Equals(td.Name, name) &&
-                reader.StringComparer.Equals(td.Namespace, ns))
+            if (reader.StringComparer.Equals(td.Name, name) && reader.StringComparer.Equals(td.Namespace, ns))
             {
                 return (reader, tdHandle);
             }
@@ -296,46 +321,55 @@ public sealed class MetadataLoader : IDisposable
         foreach (ExportedTypeHandle exportedHandle in reader.ExportedTypes)
         {
             ExportedType exported = reader.GetExportedType(exportedHandle);
-            if (reader.StringComparer.Equals(exported.Name, name) &&
-                reader.StringComparer.Equals(exported.Namespace, ns))
+            if (
+                reader.StringComparer.Equals(exported.Name, name)
+                && reader.StringComparer.Equals(exported.Namespace, ns)
+            )
             {
                 return FollowTypeForwarder(reader, exported, ns, name);
             }
         }
 
         string? asmName = reader.GetAssemblyDefinition().GetAssemblyName().Name;
-        throw new TypeLoadException(
-            $"Could not resolve '{ns}.{name}' in assembly '{asmName}'");
+        throw new TypeLoadException($"Could not resolve '{ns}.{name}' in assembly '{asmName}'");
     }
 
     /// <summary>
     /// Follow a type forwarder chain to find the actual TypeDefinition.
     /// </summary>
     private (MetadataReader Reader, TypeDefinitionHandle Handle) FollowTypeForwarder(
-        MetadataReader reader, ExportedType exported, string ns, string name)
+        MetadataReader reader,
+        ExportedType exported,
+        string ns,
+        string name
+    )
     {
         switch (exported.Implementation.Kind)
         {
             case HandleKind.AssemblyReference:
                 AssemblyReference targetAsmRef = reader.GetAssemblyReference(
-                    (AssemblyReferenceHandle)exported.Implementation);
+                    (AssemblyReferenceHandle)exported.Implementation
+                );
                 string targetAsmName = reader.GetString(targetAsmRef.Name);
 
                 _logger.LogTrace(
                     "Following type forwarder for {Namespace}.{Name} -> {TargetAssembly}",
-                    ns, name, targetAsmName);
+                    ns,
+                    name,
+                    targetAsmName
+                );
 
                 MetadataReader targetReader = ResolveExternalAssembly(targetAsmName);
                 return FindTypeDefinition(targetReader, ns, name);
 
             case HandleKind.ExportedType:
-                ExportedType parentExported = reader.GetExportedType(
-                    (ExportedTypeHandle)exported.Implementation);
+                ExportedType parentExported = reader.GetExportedType((ExportedTypeHandle)exported.Implementation);
                 return FollowTypeForwarder(reader, parentExported, ns, name);
 
             default:
                 throw new InvalidOperationException(
-                    $"Invalid type forwarder target for '{ns}.{name}': {exported.Implementation.Kind}");
+                    $"Invalid type forwarder target for '{ns}.{name}': {exported.Implementation.Kind}"
+                );
         }
     }
 

--- a/Generator/Metadata/MetadataLoader.cs
+++ b/Generator/Metadata/MetadataLoader.cs
@@ -15,7 +15,7 @@ using Microsoft.Extensions.Logging;
 public sealed class MetadataLoader : IDisposable
 {
     private readonly ConcurrentDictionary<string, (PEReader PeReader, MetadataReader Reader)> _primaryAssemblies = [];
-    private readonly ConcurrentDictionary<string, (PEReader PeReader, MetadataReader Reader)> _externalAssemblies = [];
+    private readonly ConcurrentDictionary<string, Lazy<(PEReader PeReader, MetadataReader Reader)>> _externalAssemblies = [];
     private readonly Dictionary<string, string> _packageVersions = [];
     private readonly string _metadataDir;
     private readonly ILogger<MetadataLoader> _logger;
@@ -191,13 +191,22 @@ public sealed class MetadataLoader : IDisposable
     /// </summary>
     public MetadataReader ResolveExternalAssembly(string assemblyName)
     {
-        if (_externalAssemblies.TryGetValue(assemblyName, out var cached))
-            return cached.Reader;
+        // Check primary assemblies first
+        if (_primaryAssemblies.TryGetValue(assemblyName, out var primary))
+            return primary.Reader;
 
-        // Also check primary assemblies
-        if (_primaryAssemblies.TryGetValue(assemblyName, out cached))
-            return cached.Reader;
+        // Lazy ensures the load delegate runs exactly once per assembly name even
+        // under concurrent access; GetOrAdd's factory may run multiple times but
+        // only one Lazy.Value invocation will actually open the file.
+        var lazy = _externalAssemblies.GetOrAdd(assemblyName, name =>
+            new Lazy<(PEReader, MetadataReader)>(
+                () => LoadExternalAssembly(name),
+                LazyThreadSafetyMode.ExecutionAndPublication));
+        return lazy.Value.Reader;
+    }
 
+    private (PEReader PeReader, MetadataReader Reader) LoadExternalAssembly(string assemblyName)
+    {
         string runtimeDir = RuntimeEnvironment.GetRuntimeDirectory();
         string sdkRoot = Environment.GetEnvironmentVariable("WindowsSdkDir") ??
             Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
@@ -257,10 +266,9 @@ public sealed class MetadataLoader : IDisposable
 
             PEReader peReader = new(File.OpenRead(path));
             MetadataReader reader = peReader.GetMetadataReader();
-            _externalAssemblies[assemblyName] = (peReader, reader);
 
-            _logger.LogDebug("Loaded external assembly {AssemblyName} from {Path}", assemblyName, path);
-            return reader;
+            _logger.LogInformation("Loaded external assembly '{AssemblyName}' from '{Path}'", assemblyName, path);
+            return (peReader, reader);
         }
 
         throw new DllNotFoundException($"Failed to load external assembly '{assemblyName}'");
@@ -336,8 +344,11 @@ public sealed class MetadataLoader : IDisposable
         foreach (var (_, (peReader, _)) in _primaryAssemblies)
             peReader.Dispose();
 
-        foreach (var (_, (peReader, _)) in _externalAssemblies)
-            peReader.Dispose();
+        foreach (var (_, lazy) in _externalAssemblies)
+        {
+            if (lazy.IsValueCreated)
+                lazy.Value.PeReader.Dispose();
+        }
 
         _primaryAssemblies.Clear();
         _externalAssemblies.Clear();

--- a/Generator/Metadata/MethodExtractor.cs
+++ b/Generator/Metadata/MethodExtractor.cs
@@ -19,9 +19,7 @@ public sealed class MethodExtractor
     private readonly ParameterExtractor _paramExtractor;
     private readonly ILogger<MethodExtractor> _logger;
 
-    public MethodExtractor(
-        DocumentationLoader docs,
-        ParameterExtractor paramExtractor, ILogger<MethodExtractor> logger)
+    public MethodExtractor(DocumentationLoader docs, ParameterExtractor paramExtractor, ILogger<MethodExtractor> logger)
     {
         _docs = docs;
         _paramExtractor = paramExtractor;
@@ -32,9 +30,7 @@ public sealed class MethodExtractor
     /// Extract a MethodMember from a MethodDefinition.
     /// Returns null if extraction fails.
     /// </summary>
-    public MethodMember? ExtractMethod(
-        MetadataReader reader, MethodDefinition methodDef,
-        string declaringNamespace)
+    public MethodMember? ExtractMethod(MetadataReader reader, MethodDefinition methodDef, string declaringNamespace)
     {
         string methodName = reader.GetString(methodDef.Name);
 
@@ -44,15 +40,17 @@ public sealed class MethodExtractor
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to extract method {Namespace}.{Method}",
-                declaringNamespace, methodName);
+            _logger.LogError(ex, "Failed to extract method {Namespace}.{Method}", declaringNamespace, methodName);
             return null;
         }
     }
 
     private MethodMember ExtractMethodCore(
-        MetadataReader reader, MethodDefinition methodDef,
-        string methodName, string declaringNamespace)
+        MetadataReader reader,
+        MethodDefinition methodDef,
+        string methodName,
+        string declaringNamespace
+    )
     {
         // Detect variadic methods (__arglist) via signature calling convention
         SignatureHeader sigHeader = reader.GetBlobReader(methodDef.Signature).ReadSignatureHeader();
@@ -74,7 +72,7 @@ public sealed class MethodExtractor
             MethodImportAttributes.CallingConventionThisCall => CallingConvention.ThisCall,
             MethodImportAttributes.CallingConventionFastCall => CallingConvention.FastCall,
             MethodImportAttributes.CallingConventionWinApi => CallingConvention.WinApi,
-            _ => CallingConvention.StdCall
+            _ => CallingConvention.StdCall,
         };
 
         // Map character set
@@ -82,7 +80,7 @@ public sealed class MethodExtractor
         {
             MethodImportAttributes.CharSetAnsi => StringEncoding.Ansi,
             MethodImportAttributes.CharSetUnicode => StringEncoding.Unicode,
-            _ => StringEncoding.None
+            _ => StringEncoding.None,
         };
 
         bool setsLastError = import.Attributes.HasFlag(MethodImportAttributes.SetLastError);
@@ -94,21 +92,25 @@ public sealed class MethodExtractor
         ApiDetails? apiDetails = _docs.GetApiDetails(reader, methodDef);
 
         // Extract parameters
-        List<ParameterMember> parameters = _paramExtractor.ExtractParameters(
-            reader, methodDef, apiDetails);
+        List<ParameterMember> parameters = _paramExtractor.ExtractParameters(reader, methodDef, apiDetails);
 
         // Compute output parameter
         ParameterMember? outputParameter = GetOutputParameter(
-            parameters, methodAttrs.PreserveSig, methodAttrs.CanReturnErrorsAsSuccess);
+            parameters,
+            methodAttrs.PreserveSig,
+            methodAttrs.CanReturnErrorsAsSuccess
+        );
 
         // Compute ShouldThrowOnHResult
         bool shouldThrow = ShouldThrowOnHResult(
-            parameters, methodAttrs.PreserveSigValue,
-            methodAttrs.CanReturnErrorsAsSuccess, methodAttrs.CanReturnMultipleSuccessValues);
+            parameters,
+            methodAttrs.PreserveSigValue,
+            methodAttrs.CanReturnErrorsAsSuccess,
+            methodAttrs.CanReturnMultipleSuccessValues
+        );
 
         // Collect referenced types/functions
-        ImportCollection imports = CollectImports(
-            parameters, entryPoint, outputParameter);
+        ImportCollection imports = CollectImports(parameters, entryPoint, outputParameter);
 
         MethodMember result = new()
         {
@@ -132,11 +134,16 @@ public sealed class MethodExtractor
             DeprecationMessage = methodAttrs.DeprecationMessage,
             ReturnValueDoc = apiDetails?.ReturnValue,
             SupportedOSPlatform = methodAttrs.SupportedOSPlatform,
-            Imports = imports
+            Imports = imports,
         };
 
-        _logger.LogTrace("Extracted method {Namespace}.{Method} ({ParamCount} params, dll={Dll})",
-            declaringNamespace, methodName, parameters.Count - 1, dllName);
+        _logger.LogTrace(
+            "Extracted method {Namespace}.{Method} ({ParamCount} params, dll={Dll})",
+            declaringNamespace,
+            methodName,
+            parameters.Count - 1,
+            dllName
+        );
 
         return result;
     }
@@ -164,9 +171,8 @@ public sealed class MethodExtractor
                 {
                     preserveSig = true;
                     CustomAttributeValue<string> decoded = attr.DecodeValue(new CaTypeProvider());
-                    preserveSigValue = decoded.FixedArguments.Length > 0
-                        ? decoded.FixedArguments[0].Value as bool? ?? true
-                        : true;
+                    preserveSigValue =
+                        decoded.FixedArguments.Length > 0 ? decoded.FixedArguments[0].Value as bool? ?? true : true;
                     break;
                 }
 
@@ -181,9 +187,8 @@ public sealed class MethodExtractor
                 case "ObsoleteAttribute":
                 {
                     CustomAttributeValue<string> decoded = attr.DecodeValue(new CaTypeProvider());
-                    deprecationMessage = decoded.FixedArguments.Length > 0
-                        ? decoded.FixedArguments[0].Value as string
-                        : null;
+                    deprecationMessage =
+                        decoded.FixedArguments.Length > 0 ? decoded.FixedArguments[0].Value as string : null;
                     break;
                 }
 
@@ -196,8 +201,14 @@ public sealed class MethodExtractor
             }
         }
 
-        return new MethodAttrs(preserveSig, preserveSigValue, canReturnErrorsAsSuccess,
-            canReturnMultipleSuccessValues, deprecationMessage, supportedOSPlatform);
+        return new MethodAttrs(
+            preserveSig,
+            preserveSigValue,
+            canReturnErrorsAsSuccess,
+            canReturnMultipleSuccessValues,
+            deprecationMessage,
+            supportedOSPlatform
+        );
     }
 
     /// <summary>
@@ -205,7 +216,10 @@ public sealed class MethodExtractor
     /// Port of AhkMethod.GetOutputParameter.
     /// </summary>
     internal static ParameterMember? GetOutputParameter(
-        List<ParameterMember> parameters, bool preserveSig, bool canReturnErrorsAsSuccess)
+        List<ParameterMember> parameters,
+        bool preserveSig,
+        bool canReturnErrorsAsSuccess
+    )
     {
         // If we have PreserveSig OR CanReturnErrorsAsSuccess OR the function doesn't return HRESULT,
         // don't collapse [out] parameters
@@ -229,8 +243,11 @@ public sealed class MethodExtractor
     /// Port of AhkMethod.ShouldThrowForReturnValue.
     /// </summary>
     private static bool ShouldThrowOnHResult(
-        List<ParameterMember> parameters, bool? preserveSigValue,
-        bool canReturnErrorsAsSuccess, bool canReturnMultipleSuccessValues)
+        List<ParameterMember> parameters,
+        bool? preserveSigValue,
+        bool canReturnErrorsAsSuccess,
+        bool canReturnMultipleSuccessValues
+    )
     {
         // Must return HRESULT
         if (parameters.Count == 0 || parameters[0].Type is not HResultType)
@@ -253,8 +270,10 @@ public sealed class MethodExtractor
     /// Port of AhkMethod.GetReferencedTypes.
     /// </summary>
     private static ImportCollection CollectImports(
-        List<ParameterMember> parameters, string entryPoint,
-        ParameterMember? outputParameter)
+        List<ParameterMember> parameters,
+        string entryPoint,
+        ParameterMember? outputParameter
+    )
     {
         var imports = new ImportCollection();
 
@@ -262,8 +281,7 @@ public sealed class MethodExtractor
         if (entryPoint.StartsWith('#'))
         {
             imports.AddFunction("Windows.Win32.Foundation.Apis", "FreeLibrary");
-            imports.AddFunctions("Windows.Win32.System.LibraryLoader.Apis", 
-                ["LoadLibraryW", "GetProcAddress"]);
+            imports.AddFunctions("Windows.Win32.System.LibraryLoader.Apis", ["LoadLibraryW", "GetProcAddress"]);
         }
 
         // Import every named type referenced anywhere in the signature (return + params).
@@ -296,5 +314,6 @@ public sealed class MethodExtractor
         bool CanReturnErrorsAsSuccess,
         bool CanReturnMultipleSuccessValues,
         string? DeprecationMessage,
-        string? SupportedOSPlatform);
+        string? SupportedOSPlatform
+    );
 }

--- a/Generator/Metadata/MethodExtractor.cs
+++ b/Generator/Metadata/MethodExtractor.cs
@@ -5,6 +5,7 @@ using System.Reflection.Metadata;
 using AhkWin32.Generator.Model;
 using AhkWin32.Generator.Model.Members;
 using Microsoft.Extensions.Logging;
+using Microsoft.VisualBasic;
 using Microsoft.Windows.SDK.Win32Docs;
 
 /// <summary>
@@ -261,32 +262,19 @@ public sealed class MethodExtractor
         if (entryPoint.StartsWith('#'))
         {
             imports.AddFunction("Windows.Win32.Foundation.Apis", "FreeLibrary");
-            imports.AddFunction("Windows.Win32.System.LibraryLoader.Apis", "LoadLibraryW");
-            imports.AddFunction("Windows.Win32.System.LibraryLoader.Apis", "GetProcAddress");
+            imports.AddFunctions("Windows.Win32.System.LibraryLoader.Apis", 
+                ["LoadLibraryW", "GetProcAddress"]);
         }
 
-        // Import handle if we return a handle
-        if (parameters.Count > 0 && parameters[0].Type is HandleRef hr)
+        // Import every named type referenced anywhere in the signature (return + params).
+        // v2.1's DllCall uses class refs (HWND, RECT.Ptr, BOOL) as type tokens, so the
+        // declaring Apis file must import them; v2.0 string-typed DllCall doesn't need
+        // these but extra #Includes are harmless.
+        foreach (ParameterMember p in parameters)
         {
-            imports.AddType(hr.FQN);
-        }
-
-        // Import NTSTATUS if we return NTStatus
-        if (parameters.Count > 0 && parameters[0].Type is NtStatusType)
-        {
-            imports.AddType("Windows.Win32.Foundation.NTSTATUS");
-        }
-
-        // Import output parameter pointee type
-        if (outputParameter != null)
-        {
-            ResolvedType? pointee = outputParameter.Pointee;
-            if (pointee is StructRef sr)
-                imports.AddType(sr.FQN);
-            else if (pointee is ComRef cr)
-                imports.AddType(cr.FQN);
-            else if (pointee is HandleRef ohr)
-                imports.AddType(ohr.FQN);
+            List<string> fqns = [];
+            TypeExtractor.CollectTypeReferences(p.Type, fqns);
+            imports.AddTypes(fqns);
         }
 
         // Import [FreeWith] parameter functions

--- a/Generator/Metadata/MethodExtractor.cs
+++ b/Generator/Metadata/MethodExtractor.cs
@@ -9,6 +9,28 @@ using Microsoft.VisualBasic;
 using Microsoft.Windows.SDK.Win32Docs;
 
 /// <summary>
+/// Reason an attempted method extraction did not produce a MethodMember.
+/// </summary>
+public enum MethodSkipReason
+{
+    /// <summary>Method's [SupportedArchitecture] excludes x64.</summary>
+    ArchFiltered,
+
+    /// <summary>Extraction threw — already logged at Error level.</summary>
+    Error,
+}
+
+/// <summary>
+/// Outcome of a single ExtractMethod call. Exactly one of Method / SkipReason is set.
+/// </summary>
+public readonly record struct MethodExtractionResult(MethodMember? Method, MethodSkipReason? SkipReason)
+{
+    public static MethodExtractionResult Success(MethodMember m) => new(m, null);
+
+    public static MethodExtractionResult Skipped(MethodSkipReason reason) => new(null, reason);
+}
+
+/// <summary>
 /// Extracts method definitions from metadata into MethodMember instances.
 /// Ports logic from AhkMethod constructor, GetOutputParameter, ShouldThrowForReturnValue,
 /// and GetReferencedTypes.
@@ -27,21 +49,43 @@ public sealed class MethodExtractor
     }
 
     /// <summary>
-    /// Extract a MethodMember from a MethodDefinition.
-    /// Returns null if extraction fails.
+    /// Extract a MethodMember from a MethodDefinition. The returned result distinguishes
+    /// successful extraction, architecture-filtered skips, and errors so callers can
+    /// report skip counts the same way TypeExtractor does for type-level filters.
     /// </summary>
-    public MethodMember? ExtractMethod(MetadataReader reader, MethodDefinition methodDef, string declaringNamespace)
+    public MethodExtractionResult ExtractMethod(
+        MetadataReader reader,
+        MethodDefinition methodDef,
+        string declaringNamespace
+    )
     {
         string methodName = reader.GetString(methodDef.Name);
 
         try
         {
-            return ExtractMethodCore(reader, methodDef, methodName, declaringNamespace);
+            // Decode method attributes first so we can architecture-filter before doing
+            // the rest of the work.
+            MethodAttrs methodAttrs = AttributeReader.DecodeMethodAttributes(reader, methodDef);
+
+            if (!methodAttrs.Architecture.HasFlag(Architecture.X64))
+            {
+                _logger.LogDebug(
+                    "Skipping method {Namespace}.{Method}: unsupported architecture {Arch}",
+                    declaringNamespace,
+                    methodName,
+                    methodAttrs.Architecture
+                );
+                return MethodExtractionResult.Skipped(MethodSkipReason.ArchFiltered);
+            }
+
+            return MethodExtractionResult.Success(
+                ExtractMethodCore(reader, methodDef, methodName, declaringNamespace, methodAttrs)
+            );
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to extract method {Namespace}.{Method}", declaringNamespace, methodName);
-            return null;
+            return MethodExtractionResult.Skipped(MethodSkipReason.Error);
         }
     }
 
@@ -49,7 +93,8 @@ public sealed class MethodExtractor
         MetadataReader reader,
         MethodDefinition methodDef,
         string methodName,
-        string declaringNamespace
+        string declaringNamespace,
+        MethodAttrs methodAttrs
     )
     {
         // Detect variadic methods (__arglist) via signature calling convention
@@ -84,9 +129,6 @@ public sealed class MethodExtractor
         };
 
         bool setsLastError = import.Attributes.HasFlag(MethodImportAttributes.SetLastError);
-
-        // Decode method-level custom attributes
-        var methodAttrs = DecodeMethodAttributes(reader, methodDef);
 
         // Load documentation
         ApiDetails? apiDetails = _docs.GetApiDetails(reader, methodDef);
@@ -135,6 +177,7 @@ public sealed class MethodExtractor
             ReturnValueDoc = apiDetails?.ReturnValue,
             SupportedOSPlatform = methodAttrs.SupportedOSPlatform,
             Imports = imports,
+            SupportedArchitecture = methodAttrs.Architecture,
         };
 
         _logger.LogTrace(
@@ -146,69 +189,6 @@ public sealed class MethodExtractor
         );
 
         return result;
-    }
-
-    /// <summary>
-    /// Decode method-level custom attributes in a single pass.
-    /// </summary>
-    private static MethodAttrs DecodeMethodAttributes(MetadataReader reader, MethodDefinition methodDef)
-    {
-        bool preserveSig = false;
-        bool? preserveSigValue = null;
-        bool canReturnErrorsAsSuccess = false;
-        bool canReturnMultipleSuccessValues = false;
-        string? deprecationMessage = null;
-        string? supportedOSPlatform = null;
-
-        foreach (CustomAttributeHandle attrHandle in methodDef.GetCustomAttributes())
-        {
-            CustomAttribute attr = reader.GetCustomAttribute(attrHandle);
-            (_, string attrName) = AttributeReader.GetAttributeTypeName(reader, attr);
-
-            switch (attrName)
-            {
-                case "PreserveSigAttribute":
-                {
-                    preserveSig = true;
-                    CustomAttributeValue<string> decoded = attr.DecodeValue(new CaTypeProvider());
-                    preserveSigValue =
-                        decoded.FixedArguments.Length > 0 ? decoded.FixedArguments[0].Value as bool? ?? true : true;
-                    break;
-                }
-
-                case "CanReturnErrorsAsSuccessAttribute":
-                    canReturnErrorsAsSuccess = true;
-                    break;
-
-                case "CanReturnMultipleSuccessValuesAttribute":
-                    canReturnMultipleSuccessValues = true;
-                    break;
-
-                case "ObsoleteAttribute":
-                {
-                    CustomAttributeValue<string> decoded = attr.DecodeValue(new CaTypeProvider());
-                    deprecationMessage =
-                        decoded.FixedArguments.Length > 0 ? decoded.FixedArguments[0].Value as string : null;
-                    break;
-                }
-
-                case "SupportedOSPlatformAttribute":
-                {
-                    CustomAttributeValue<string> decoded = attr.DecodeValue(new CaTypeProvider());
-                    supportedOSPlatform = (string?)decoded.FixedArguments[0].Value;
-                    break;
-                }
-            }
-        }
-
-        return new MethodAttrs(
-            preserveSig,
-            preserveSigValue,
-            canReturnErrorsAsSuccess,
-            canReturnMultipleSuccessValues,
-            deprecationMessage,
-            supportedOSPlatform
-        );
     }
 
     /// <summary>
@@ -304,16 +284,4 @@ public sealed class MethodExtractor
 
         return imports;
     }
-
-    /// <param name="PreserveSig">Whether [PreserveSig] attribute is present.</param>
-    /// <param name="PreserveSigValue">The boolean value of [PreserveSig], or true if present with no args.
-    /// Null if attribute is not present.</param>
-    private sealed record MethodAttrs(
-        bool PreserveSig,
-        bool? PreserveSigValue,
-        bool CanReturnErrorsAsSuccess,
-        bool CanReturnMultipleSuccessValues,
-        string? DeprecationMessage,
-        string? SupportedOSPlatform
-    );
 }

--- a/Generator/Metadata/MethodExtractor.cs
+++ b/Generator/Metadata/MethodExtractor.cs
@@ -152,7 +152,12 @@ public sealed class MethodExtractor
         );
 
         // Collect referenced types/functions
-        ImportCollection imports = CollectImports(parameters, entryPoint, outputParameter);
+        ImportCollection imports = CollectImports(
+            parameters,
+            entryPoint,
+            outputParameter,
+            $"{declaringNamespace}.Apis"
+        );
 
         MethodMember result = new()
         {
@@ -252,7 +257,8 @@ public sealed class MethodExtractor
     private static ImportCollection CollectImports(
         List<ParameterMember> parameters,
         string entryPoint,
-        ParameterMember? outputParameter
+        ParameterMember? outputParameter,
+        string ownApisFqn
     )
     {
         var imports = new ImportCollection();
@@ -275,11 +281,22 @@ public sealed class MethodExtractor
             imports.AddTypes(fqns);
         }
 
-        // Import [FreeWith] parameter functions
+        // Import [FreeWith] parameter functions. Skip self-imports: a function in this same Apis
+        // module is already in scope and referenced by its bare name.
         foreach (ParameterMember param in parameters.Where(p => p.FreeWith != null))
         {
             FreeFuncRef fw = param.FreeWith!;
-            imports.AddFunction(fw.ApisFQN, fw.Name);
+            if (fw.ApisFQN != ownApisFqn)
+                imports.AddFunction(fw.ApisFQN, fw.Name);
+        }
+
+        // Import context-specific [RAIIFree] functions for owned handle returns/out-params; the
+        // emitter references them via `Handle.OwnedWith(<freeFunc>)`. Same self-import skip.
+        foreach (ParameterMember param in parameters.Where(p => p.RAIIFree != null))
+        {
+            FreeFuncRef raii = param.RAIIFree!;
+            if (raii.ApisFQN != ownApisFqn)
+                imports.AddFunction(raii.ApisFQN, raii.Name);
         }
 
         return imports;

--- a/Generator/Metadata/MethodExtractor.cs
+++ b/Generator/Metadata/MethodExtractor.cs
@@ -105,8 +105,8 @@ public sealed class MethodExtractor
             parameters, methodAttrs.PreserveSigValue,
             methodAttrs.CanReturnErrorsAsSuccess, methodAttrs.CanReturnMultipleSuccessValues);
 
-        // Collect referenced types
-        List<string> referencedTypes = CollectReferencedTypes(
+        // Collect referenced types/functions
+        ImportCollection imports = CollectImports(
             parameters, entryPoint, outputParameter);
 
         MethodMember result = new()
@@ -131,7 +131,7 @@ public sealed class MethodExtractor
             DeprecationMessage = methodAttrs.DeprecationMessage,
             ReturnValueDoc = apiDetails?.ReturnValue,
             SupportedOSPlatform = methodAttrs.SupportedOSPlatform,
-            ReferencedTypes = referencedTypes
+            Imports = imports
         };
 
         _logger.LogTrace("Extracted method {Namespace}.{Method} ({ParamCount} params, dll={Dll})",
@@ -248,32 +248,33 @@ public sealed class MethodExtractor
     }
 
     /// <summary>
-    /// Collect FQNs of types referenced by a method for #Include generation.
+    /// Collect types and functions referenced by a method, for #Include / #Import generation.
     /// Port of AhkMethod.GetReferencedTypes.
     /// </summary>
-    private static List<string> CollectReferencedTypes(
+    private static ImportCollection CollectImports(
         List<ParameterMember> parameters, string entryPoint,
         ParameterMember? outputParameter)
     {
-        List<string> refs = [];
+        var imports = new ImportCollection();
 
-        // Ordinal entry points need LibraryLoader + Foundation
+        // Ordinal entry points need LibraryLoader.LoadLibraryW/GetProcAddress + Foundation.FreeLibrary
         if (entryPoint.StartsWith('#'))
         {
-            refs.Add("Windows.Win32.Foundation.Apis");
-            refs.Add("Windows.Win32.System.LibraryLoader.Apis");
+            imports.AddFunction("Windows.Win32.Foundation.Apis", "FreeLibrary");
+            imports.AddFunction("Windows.Win32.System.LibraryLoader.Apis", "LoadLibraryW");
+            imports.AddFunction("Windows.Win32.System.LibraryLoader.Apis", "GetProcAddress");
         }
 
         // Import handle if we return a handle
         if (parameters.Count > 0 && parameters[0].Type is HandleRef hr)
         {
-            refs.Add(hr.FQN);
+            imports.AddType(hr.FQN);
         }
 
         // Import NTSTATUS if we return NTStatus
         if (parameters.Count > 0 && parameters[0].Type is NtStatusType)
         {
-            refs.Add("Windows.Win32.Foundation.NTSTATUS");
+            imports.AddType("Windows.Win32.Foundation.NTSTATUS");
         }
 
         // Import output parameter pointee type
@@ -281,20 +282,21 @@ public sealed class MethodExtractor
         {
             ResolvedType? pointee = outputParameter.Pointee;
             if (pointee is StructRef sr)
-                refs.Add(sr.FQN);
+                imports.AddType(sr.FQN);
             else if (pointee is ComRef cr)
-                refs.Add(cr.FQN);
+                imports.AddType(cr.FQN);
             else if (pointee is HandleRef ohr)
-                refs.Add(ohr.FQN);
+                imports.AddType(ohr.FQN);
         }
 
-        // Import [FreeWith] parameter Apis types
+        // Import [FreeWith] parameter functions
         foreach (ParameterMember param in parameters.Where(p => p.FreeWith != null))
         {
-            refs.Add(param.FreeWith!.ApisFQN);
+            FreeFuncRef fw = param.FreeWith!;
+            imports.AddFunction(fw.ApisFQN, fw.Name);
         }
 
-        return refs.Distinct().ToList();
+        return imports;
     }
 
     /// <param name="PreserveSig">Whether [PreserveSig] attribute is present.</param>

--- a/Generator/Metadata/ParameterExtractor.cs
+++ b/Generator/Metadata/ParameterExtractor.cs
@@ -23,8 +23,12 @@ public sealed class ParameterExtractor
     /// </summary>
     private readonly FrozenSet<string> _reservedNames;
 
-    public ParameterExtractor(MetadataLoader loader, ILogger<ParameterExtractor> logger,
-        IReadOnlySet<string> builtinReservedNames, int maxParallelism = 0)
+    public ParameterExtractor(
+        MetadataLoader loader,
+        ILogger<ParameterExtractor> logger,
+        IReadOnlySet<string> builtinReservedNames,
+        int maxParallelism = 0
+    )
     {
         _loader = loader;
         _logger = logger;
@@ -32,11 +36,12 @@ public sealed class ParameterExtractor
         int dop = maxParallelism > 0 ? maxParallelism : Environment.ProcessorCount;
 
         // Pre-populate type names from all primary assemblies
-        _reservedNames = _loader.GetPrimaryAssemblies()
-            .SelectMany(tup => tup.Reader.TypeDefinitions
-                .AsParallel()
-                .WithDegreeOfParallelism(dop)
-                .Select(td => tup.Reader.GetString(tup.Reader.GetTypeDefinition(td).Name))
+        _reservedNames = _loader
+            .GetPrimaryAssemblies()
+            .SelectMany(tup =>
+                tup.Reader.TypeDefinitions.AsParallel()
+                    .WithDegreeOfParallelism(dop)
+                    .Select(td => tup.Reader.GetString(tup.Reader.GetTypeDefinition(td).Name))
             )
             .Concat(builtinReservedNames)
             .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
@@ -49,12 +54,20 @@ public sealed class ParameterExtractor
     /// Parameter[0] is always the return type. Parameters[1..n] are actual parameters.
     /// </summary>
     public List<ParameterMember> ExtractParameters(
-        MetadataReader reader, MethodDefinition methodDef,
-        ApiDetails? apiDetails, TypeDefinition? resolutionContext = null)
+        MetadataReader reader,
+        MethodDefinition methodDef,
+        ApiDetails? apiDetails,
+        TypeDefinition? resolutionContext = null
+    )
     {
         // Decode method signature to get return type + parameter types
         var (returnType, parameterTypes) = SignatureDecoder.DecodeMethodSignature(
-            reader, methodDef, _loader, _logger, resolutionContext);
+            reader,
+            methodDef,
+            _loader,
+            _logger,
+            resolutionContext
+        );
 
         // Build lookup of SequenceNumber → Parameter metadata
         Dictionary<int, Parameter> paramInfos = [];
@@ -74,15 +87,17 @@ public sealed class ParameterExtractor
         else
         {
             // No explicit return parameter metadata — create a minimal one
-            result.Add(new ParameterMember
-            {
-                Name = "result",
-                Type = returnType,
-                SequenceNumber = 0,
-                Direction = ParameterDirection.None,
-                Attributes = ParameterFlags.None,
-                SizedBufferBytesParamIndex = -1
-            });
+            result.Add(
+                new ParameterMember
+                {
+                    Name = "result",
+                    Type = returnType,
+                    SequenceNumber = 0,
+                    Direction = ParameterDirection.None,
+                    Attributes = ParameterFlags.None,
+                    SizedBufferBytesParamIndex = -1,
+                }
+            );
         }
 
         // Parameters[1..n]: actual method parameters
@@ -95,7 +110,8 @@ public sealed class ParameterExtractor
             ResolvedType paramType = parameterTypes[i];
             if (!param.Name.IsNil)
             {
-                bool hasMemorySize = AttributeReader.GetAllAttributeNames(reader, param.GetCustomAttributes())
+                bool hasMemorySize = AttributeReader
+                    .GetAllAttributeNames(reader, param.GetCustomAttributes())
                     .Any(n => n == "MemorySizeAttribute");
                 if (hasMemorySize)
                     paramType = new PrimitiveType("ptr");
@@ -108,8 +124,12 @@ public sealed class ParameterExtractor
     }
 
     private ParameterMember BuildParameterMember(
-        MetadataReader reader, Parameter param, ResolvedType type,
-        int sequenceNumber, ApiDetails? apiDetails)
+        MetadataReader reader,
+        Parameter param,
+        ResolvedType type,
+        int sequenceNumber,
+        ApiDetails? apiDetails
+    )
     {
         // Get parameter name with deconfliction
         string name = GetParameterName(reader, param, sequenceNumber);
@@ -149,7 +169,7 @@ public sealed class ParameterExtractor
             RAIIFree = raiiFree,
             FreeWith = freeWith,
             SizedBufferBytesParamIndex = attrs.SizedBufferBytesParamIndex,
-            Description = description
+            Description = description,
         };
     }
 
@@ -200,7 +220,9 @@ public sealed class ParameterExtractor
                 {
                     _logger.LogDebug(
                         "FreeFuncRef {FuncName} has {ParamCount} parameter rows, expected 1 or 2 — skipping",
-                        funcName, paramCount);
+                        funcName,
+                        paramCount
+                    );
                     return null;
                 }
 

--- a/Generator/Metadata/SignatureDecoder.cs
+++ b/Generator/Metadata/SignatureDecoder.cs
@@ -24,15 +24,9 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
     private readonly TypeDefinition? _resolutionContext;
 
     /// <summary>
-    /// WinRT namespaces that are external to Win32 — treated as pointers.
+    /// List of Win32 namespaces that we will generate
     /// </summary>
-    private static readonly string[] s_excludeNamespaces =
-    [
-        "Windows.UI",
-        "Windows.Foundation",
-        "Windows.Graphics",
-        "Windows.Storage",
-    ];
+    private static readonly string[] s_includeNamespaces = ["Windows.Win32", "Windows.Wdk"];
 
     private static readonly string[] s_handleAttrNames =
     [
@@ -188,15 +182,20 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
         string rawName = reader.GetString(td.Name);
         string typeNamespace = reader.GetString(td.Namespace);
         string fqn = $"{typeNamespace}.{rawName}";
-        // *Ref.Name carries the display name â€” strip the generator-injected
+        // *Ref.Name carries the display name - strip the generator-injected
         // _e__Struct / _e__Union suffixes so it matches DeconflictName on the
         // referent. FQN stays as the metadata-form for registry lookups.
         string typeName = StripGeneratedSuffix(rawName);
 
-        // Exclude WinRT namespaces — treat as pointer
-        if (s_excludeNamespaces.Any(typeNamespace.StartsWith))
+        // Exclude non-Win32 / Wdk namespaces - treat these as opaque pointers.
+        // These are mostly WinRT types, but include a handful of System types.
+        if (
+            !string.IsNullOrWhiteSpace(typeNamespace) // Anonymous types don't have namespaces, and should be included
+            && !s_includeNamespaces.Any(typeNamespace.StartsWith)
+            && !typeName.Equals("Guid") // Special case System.Guid
+        )
         {
-            _logger.LogWarning("Treating external type {Namespace}.{TypeName} as pointer", typeNamespace, typeName);
+            _logger.LogWarning("Treating external type '{Namespace}.{TypeName}' as pointer", typeNamespace, typeName);
             return new PointerType(null);
         }
 

--- a/Generator/Metadata/SignatureDecoder.cs
+++ b/Generator/Metadata/SignatureDecoder.cs
@@ -210,7 +210,7 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
         if (IsNonHandleNativeTypedef(reader, td))
         {
             ResolvedType resolved = DecodeNativeTypedef(reader, td);
-            _logger.LogDebug(
+            _logger.LogTrace(
                 "Decoded NativeTypedef {Name} → {UnderlyingType}",
                 typeName,
                 ((NativeTypedefRef)resolved).Underlying.DisplayName

--- a/Generator/Metadata/SignatureDecoder.cs
+++ b/Generator/Metadata/SignatureDecoder.cs
@@ -165,9 +165,13 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
     internal ResolvedType ClassifyTypeDef(MetadataReader reader, TypeDefinitionHandle tdHandle)
     {
         TypeDefinition td = reader.GetTypeDefinition(tdHandle);
-        string typeName = reader.GetString(td.Name);
+        string rawName = reader.GetString(td.Name);
         string typeNamespace = reader.GetString(td.Namespace);
-        string fqn = $"{typeNamespace}.{typeName}";
+        string fqn = $"{typeNamespace}.{rawName}";
+        // *Ref.Name carries the display name â€” strip the generator-injected
+        // _e__Struct / _e__Union suffixes so it matches DeconflictName on the
+        // referent. FQN stays as the metadata-form for registry lookups.
+        string typeName = StripGeneratedSuffix(rawName);
 
         // Exclude WinRT namespaces — treat as pointer
         if (s_excludeNamespaces.Any(typeNamespace.StartsWith))
@@ -364,9 +368,9 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
     /// </summary>
     private NativeTypedefRef DecodeNativeTypedef(MetadataReader reader, TypeDefinition td)
     {
-        string typeName = reader.GetString(td.Name);
+        string rawName = reader.GetString(td.Name);
         string typeNamespace = reader.GetString(td.Namespace);
-        string fqn = $"{typeNamespace}.{typeName}";
+        string fqn = $"{typeNamespace}.{rawName}";
 
         FieldDefinitionHandle fieldHandle = td.GetFields().First();
         FieldDefinition fieldDef = reader.GetFieldDefinition(fieldHandle);
@@ -375,6 +379,20 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
         var innerDecoder = new SignatureDecoder(reader, _loader, _logger, td);
         ResolvedType underlying = fieldDef.DecodeSignature(innerDecoder, new SignatureGenericContext());
 
-        return new NativeTypedefRef(typeName, fqn, underlying);
+        return new NativeTypedefRef(StripGeneratedSuffix(rawName), fqn, underlying);
+    }
+
+    /// <summary>
+    /// Strip Win32 metadata's generated suffixes (_e__Struct / _e__Union) from a
+    /// type name. The stripped form is the display name; the original (with
+    /// suffix) remains in the FQN for registry lookup.
+    /// </summary>
+    internal static string StripGeneratedSuffix(string name)
+    {
+        const string structSuffix = "_e__Struct";
+        const string unionSuffix = "_e__Union";
+        if (name.EndsWith(structSuffix)) return name[..^structSuffix.Length];
+        if (name.EndsWith(unionSuffix)) return name[..^unionSuffix.Length];
+        return name;
     }
 }

--- a/Generator/Metadata/SignatureDecoder.cs
+++ b/Generator/Metadata/SignatureDecoder.cs
@@ -27,13 +27,26 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
     /// WinRT namespaces that are external to Win32 — treated as pointers.
     /// </summary>
     private static readonly string[] s_excludeNamespaces =
-        ["Windows.UI", "Windows.Foundation", "Windows.Graphics", "Windows.Storage"];
+    [
+        "Windows.UI",
+        "Windows.Foundation",
+        "Windows.Graphics",
+        "Windows.Storage",
+    ];
 
     private static readonly string[] s_handleAttrNames =
-        ["RAIIFreeAttribute", "AlsoUsableForAttribute", "InvalidHandleValueAttribute"];
+    [
+        "RAIIFreeAttribute",
+        "AlsoUsableForAttribute",
+        "InvalidHandleValueAttribute",
+    ];
 
-    public SignatureDecoder(MetadataReader reader, MetadataLoader loader, ILogger logger,
-        TypeDefinition? resolutionContext = null)
+    public SignatureDecoder(
+        MetadataReader reader,
+        MetadataLoader loader,
+        ILogger logger,
+        TypeDefinition? resolutionContext = null
+    )
     {
         _reader = reader;
         _loader = loader;
@@ -43,11 +56,10 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
 
     // --- ISignatureTypeProvider implementation ---
 
-    public ResolvedType GetPrimitiveType(PrimitiveTypeCode typeCode)
-        => new PrimitiveType(typeCode.ToString());
+    public ResolvedType GetPrimitiveType(PrimitiveTypeCode typeCode) => new PrimitiveType(typeCode.ToString());
 
-    public ResolvedType GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
-        => ClassifyTypeDef(reader, handle);
+    public ResolvedType GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) =>
+        ClassifyTypeDef(reader, handle);
 
     public ResolvedType GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
     {
@@ -62,8 +74,11 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
                 TypeDefinition nestedTd = _reader.GetTypeDefinition(nestedHandle);
                 if (_reader.StringComparer.Equals(nestedTd.Name, typeName))
                 {
-                    _logger.LogTrace("Resolved nested type {Name} in context {ParentName}",
-                        typeName, _reader.GetString(_resolutionContext.Value.Name));
+                    _logger.LogTrace(
+                        "Resolved nested type {Name} in context {ParentName}",
+                        typeName,
+                        _reader.GetString(_resolutionContext.Value.Name)
+                    );
                     return ClassifyTypeDef(_reader, nestedHandle);
                 }
             }
@@ -74,7 +89,12 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
         return ClassifyTypeDef(targetReader, targetHandle);
     }
 
-    public ResolvedType GetTypeFromSpecification(MetadataReader reader, SignatureGenericContext genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
+    public ResolvedType GetTypeFromSpecification(
+        MetadataReader reader,
+        SignatureGenericContext genericContext,
+        TypeSpecificationHandle handle,
+        byte rawTypeKind
+    )
     {
         TypeSpecification ts = reader.GetTypeSpecification(handle);
         return ts.DecodeSignature(this, genericContext);
@@ -91,7 +111,7 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
             NativeTypedefRef n when n.Name is "CHAR" or "WCHAR" or "TCHAR" => true,
             // SByte that comes from a CHAR typedef — in Win32Metadata, CHAR is NativeTypedef over SByte,
             // so by the time we see it here it's already a NativeTypedefRef, not raw SByte.
-            _ => false
+            _ => false,
         };
 
         if (isString)
@@ -99,7 +119,7 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
             StringEncoding encoding = elementType switch
             {
                 NativeTypedefRef n when n.Name is "CHAR" => StringEncoding.Ansi,
-                _ => StringEncoding.Unicode
+                _ => StringEncoding.Unicode,
             };
             return new StringType(length, encoding);
         }
@@ -107,29 +127,26 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
         return new ArrayType(elementType, length);
     }
 
-    public ResolvedType GetPointerType(ResolvedType elementType)
-        => new PointerType(elementType);
+    public ResolvedType GetPointerType(ResolvedType elementType) => new PointerType(elementType);
 
-    public ResolvedType GetByReferenceType(ResolvedType elementType)
-        => new PointerType(elementType);
+    public ResolvedType GetByReferenceType(ResolvedType elementType) => new PointerType(elementType);
 
-    public ResolvedType GetSZArrayType(ResolvedType elementType)
-        => throw new NotSupportedException("SZARRAY not supported in Win32Metadata");
+    public ResolvedType GetSZArrayType(ResolvedType elementType) =>
+        throw new NotSupportedException("SZARRAY not supported in Win32Metadata");
 
-    public ResolvedType GetGenericInstantiation(ResolvedType genericType, ImmutableArray<ResolvedType> typeArguments)
-        => new PrimitiveType($"{genericType.DisplayName}<{string.Join(",", typeArguments.Select(t => t.DisplayName))}>");
+    public ResolvedType GetGenericInstantiation(ResolvedType genericType, ImmutableArray<ResolvedType> typeArguments) =>
+        new PrimitiveType($"{genericType.DisplayName}<{string.Join(",", typeArguments.Select(t => t.DisplayName))}>");
 
-    public ResolvedType GetGenericMethodParameter(SignatureGenericContext genericContext, int index)
-        => new PrimitiveType($"!!{index}");
+    public ResolvedType GetGenericMethodParameter(SignatureGenericContext genericContext, int index) =>
+        new PrimitiveType($"!!{index}");
 
-    public ResolvedType GetGenericTypeParameter(SignatureGenericContext genericContext, int index)
-        => new PrimitiveType($"!{index}");
+    public ResolvedType GetGenericTypeParameter(SignatureGenericContext genericContext, int index) =>
+        new PrimitiveType($"!{index}");
 
-    public ResolvedType GetModifiedType(ResolvedType modifier, ResolvedType unmodifiedType, bool isRequired)
-        => unmodifiedType;
+    public ResolvedType GetModifiedType(ResolvedType modifier, ResolvedType unmodifiedType, bool isRequired) =>
+        unmodifiedType;
 
-    public ResolvedType GetPinnedType(ResolvedType elementType)
-        => elementType;
+    public ResolvedType GetPinnedType(ResolvedType elementType) => elementType;
 
     public ResolvedType GetFunctionPointerType(MethodSignature<ResolvedType> signature)
     {
@@ -145,9 +162,12 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
     /// Convenience wrapper that creates a SignatureDecoder and invokes DecodeSignature.
     /// </summary>
     public static (ResolvedType ReturnType, ResolvedType[] ParameterTypes) DecodeMethodSignature(
-        MetadataReader reader, MethodDefinition methodDef,
-        MetadataLoader loader, ILogger logger,
-        TypeDefinition? resolutionContext = null)
+        MetadataReader reader,
+        MethodDefinition methodDef,
+        MetadataLoader loader,
+        ILogger logger,
+        TypeDefinition? resolutionContext = null
+    )
     {
         var decoder = new SignatureDecoder(reader, loader, logger, resolutionContext);
 #pragma warning disable CS8620 // Argument nullability — Win32Metadata has no generics
@@ -176,8 +196,7 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
         // Exclude WinRT namespaces — treat as pointer
         if (s_excludeNamespaces.Any(typeNamespace.StartsWith))
         {
-            _logger.LogWarning("Treating external type {Namespace}.{TypeName} as pointer",
-                typeNamespace, typeName);
+            _logger.LogWarning("Treating external type {Namespace}.{TypeName} as pointer", typeNamespace, typeName);
             return new PointerType(null);
         }
 
@@ -191,8 +210,11 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
         if (IsNonHandleNativeTypedef(reader, td))
         {
             ResolvedType resolved = DecodeNativeTypedef(reader, td);
-            _logger.LogDebug("Decoded NativeTypedef {Name} → {UnderlyingType}",
-                typeName, ((NativeTypedefRef)resolved).Underlying.DisplayName);
+            _logger.LogDebug(
+                "Decoded NativeTypedef {Name} → {UnderlyingType}",
+                typeName,
+                ((NativeTypedefRef)resolved).Underlying.DisplayName
+            );
             return resolved;
         }
 
@@ -200,38 +222,38 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
         if (IsEnum(reader, tdHandle))
         {
             string underlying = GetEnumUnderlyingType(reader, tdHandle);
-            _logger.LogTrace("Resolved {Namespace}.{TypeName} → EnumRef ({FQN})",
-                typeNamespace, typeName, fqn);
+            _logger.LogTrace("Resolved {Namespace}.{TypeName} → EnumRef ({FQN})", typeNamespace, typeName, fqn);
             return new EnumRef(fqn, typeName, new PrimitiveType(underlying));
         }
 
         // Function pointer (via UnmanagedFunctionPointerAttribute)
         if (IsFunctionPointer(reader, td))
         {
-            _logger.LogTrace("Resolved {Namespace}.{TypeName} → FunctionPointerType ({FQN})",
-                typeNamespace, typeName, fqn);
+            _logger.LogTrace(
+                "Resolved {Namespace}.{TypeName} → FunctionPointerType ({FQN})",
+                typeNamespace,
+                typeName,
+                fqn
+            );
             return new FunctionPointerType(typeName, "");
         }
 
         // COM interface
         if (IsComInterface(reader, tdHandle))
         {
-            _logger.LogTrace("Resolved {Namespace}.{TypeName} → ComRef ({FQN})",
-                typeNamespace, typeName, fqn);
+            _logger.LogTrace("Resolved {Namespace}.{TypeName} → ComRef ({FQN})", typeNamespace, typeName, fqn);
             return new ComRef(fqn, typeName);
         }
 
         // Handle (single field + handle attributes)
         if (IsHandle(reader, td))
         {
-            _logger.LogTrace("Resolved {Namespace}.{TypeName} → HandleRef ({FQN})",
-                typeNamespace, typeName, fqn);
+            _logger.LogTrace("Resolved {Namespace}.{TypeName} → HandleRef ({FQN})", typeNamespace, typeName, fqn);
             return new HandleRef(fqn, typeName);
         }
 
         // Default: struct reference
-        _logger.LogTrace("Resolved {Namespace}.{TypeName} → StructRef ({FQN})",
-            typeNamespace, typeName, fqn);
+        _logger.LogTrace("Resolved {Namespace}.{TypeName} → StructRef ({FQN})", typeNamespace, typeName, fqn);
         return new StructRef(fqn, typeName);
     }
 
@@ -247,8 +269,8 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
         if (baseHandle.Kind == HandleKind.TypeReference)
         {
             TypeReference tr = reader.GetTypeReference((TypeReferenceHandle)baseHandle);
-            return reader.StringComparer.Equals(tr.Namespace, "System") &&
-                   reader.StringComparer.Equals(tr.Name, "Enum");
+            return reader.StringComparer.Equals(tr.Namespace, "System")
+                && reader.StringComparer.Equals(tr.Name, "Enum");
         }
         return false;
     }
@@ -277,7 +299,7 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
                     0x09 => "UInt32",
                     0x0A => "Int64",
                     0x0B => "UInt64",
-                    var code => throw new NotSupportedException($"Unknown enum underlying type code: 0x{code:X2}")
+                    var code => throw new NotSupportedException($"Unknown enum underlying type code: 0x{code:X2}"),
                 };
             }
         }
@@ -305,10 +327,12 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
             string baseName = td.BaseType.Kind switch
             {
                 HandleKind.TypeReference => reader.GetString(
-                    reader.GetTypeReference((TypeReferenceHandle)td.BaseType).Name),
+                    reader.GetTypeReference((TypeReferenceHandle)td.BaseType).Name
+                ),
                 HandleKind.TypeDefinition => reader.GetString(
-                    reader.GetTypeDefinition((TypeDefinitionHandle)td.BaseType).Name),
-                _ => ""
+                    reader.GetTypeDefinition((TypeDefinitionHandle)td.BaseType).Name
+                ),
+                _ => "",
             };
 
             if (baseName is "IUnknown" or "IDispatch")
@@ -329,7 +353,8 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
     /// </summary>
     internal static bool IsFunctionPointer(MetadataReader reader, TypeDefinition td)
     {
-        return AttributeReader.GetAllAttributeNames(reader, td.GetCustomAttributes())
+        return AttributeReader
+            .GetAllAttributeNames(reader, td.GetCustomAttributes())
             .Contains("UnmanagedFunctionPointerAttribute");
     }
 
@@ -344,8 +369,10 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
 
         foreach (string attr in attrs)
         {
-            if (attr == "NativeTypedefAttribute") hasNativeTypedef = true;
-            if (s_handleAttrNames.Contains(attr)) hasHandleAttr = true;
+            if (attr == "NativeTypedefAttribute")
+                hasNativeTypedef = true;
+            if (s_handleAttrNames.Contains(attr))
+                hasHandleAttr = true;
         }
 
         return hasNativeTypedef && !hasHandleAttr && td.GetFields().Count == 1;
@@ -359,8 +386,7 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
         if (td.GetFields().Count != 1)
             return false;
 
-        return AttributeReader.GetAllAttributeNames(reader, td.GetCustomAttributes())
-            .Any(s_handleAttrNames.Contains);
+        return AttributeReader.GetAllAttributeNames(reader, td.GetCustomAttributes()).Any(s_handleAttrNames.Contains);
     }
 
     /// <summary>
@@ -391,8 +417,10 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
     {
         const string structSuffix = "_e__Struct";
         const string unionSuffix = "_e__Union";
-        if (name.EndsWith(structSuffix)) return name[..^structSuffix.Length];
-        if (name.EndsWith(unionSuffix)) return name[..^unionSuffix.Length];
+        if (name.EndsWith(structSuffix))
+            return name[..^structSuffix.Length];
+        if (name.EndsWith(unionSuffix))
+            return name[..^unionSuffix.Length];
         return name;
     }
 }

--- a/Generator/Metadata/SignatureDecoder.cs
+++ b/Generator/Metadata/SignatureDecoder.cs
@@ -291,14 +291,14 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
                 blob.ReadByte(); // field signature header
                 return blob.ReadCompressedInteger() switch
                 {
-                    0x04 => "SByte",
-                    0x05 => "Byte",
+                    0x04 => "Int8",
+                    0x05 => "UInt8",
                     0x06 => "Int16",
                     0x07 => "UInt16",
                     0x08 => "Int32",
                     0x09 => "UInt32",
                     0x0A => "Int64",
-                    0x0B => "UInt64",
+                    0x0B => "Int64", // Ahk has no explicit UInt64 type
                     var code => throw new NotSupportedException($"Unknown enum underlying type code: 0x{code:X2}"),
                 };
             }

--- a/Generator/Metadata/SignatureDecoder.cs
+++ b/Generator/Metadata/SignatureDecoder.cs
@@ -88,9 +88,9 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
         bool isString = elementType switch
         {
             PrimitiveType p when p.Name.Equals("Char", StringComparison.OrdinalIgnoreCase) => true,
-            NativeTypedefType n when n.Name is "CHAR" or "WCHAR" or "TCHAR" => true,
+            NativeTypedefRef n when n.Name is "CHAR" or "WCHAR" or "TCHAR" => true,
             // SByte that comes from a CHAR typedef — in Win32Metadata, CHAR is NativeTypedef over SByte,
-            // so by the time we see it here it's already a NativeTypedefType, not raw SByte.
+            // so by the time we see it here it's already a NativeTypedefRef, not raw SByte.
             _ => false
         };
 
@@ -98,7 +98,7 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
         {
             StringEncoding encoding = elementType switch
             {
-                NativeTypedefType n when n.Name is "CHAR" => StringEncoding.Ansi,
+                NativeTypedefRef n when n.Name is "CHAR" => StringEncoding.Ansi,
                 _ => StringEncoding.Unicode
             };
             return new StringType(length, encoding);
@@ -188,7 +188,7 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
         {
             ResolvedType resolved = DecodeNativeTypedef(reader, td);
             _logger.LogDebug("Decoded NativeTypedef {Name} → {UnderlyingType}",
-                typeName, ((NativeTypedefType)resolved).Underlying.DisplayName);
+                typeName, ((NativeTypedefRef)resolved).Underlying.DisplayName);
             return resolved;
         }
 
@@ -362,7 +362,7 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
     /// <summary>
     /// Decode a NativeTypedef's underlying type by reading its single field.
     /// </summary>
-    private NativeTypedefType DecodeNativeTypedef(MetadataReader reader, TypeDefinition td)
+    private NativeTypedefRef DecodeNativeTypedef(MetadataReader reader, TypeDefinition td)
     {
         string typeName = reader.GetString(td.Name);
         string typeNamespace = reader.GetString(td.Namespace);
@@ -375,6 +375,6 @@ public sealed class SignatureDecoder : ISignatureTypeProvider<ResolvedType, Sign
         var innerDecoder = new SignatureDecoder(reader, _loader, _logger, td);
         ResolvedType underlying = fieldDef.DecodeSignature(innerDecoder, new SignatureGenericContext());
 
-        return new NativeTypedefType(typeName, fqn, underlying);
+        return new NativeTypedefRef(typeName, fqn, underlying);
     }
 }

--- a/Generator/Metadata/TypeExtractor.cs
+++ b/Generator/Metadata/TypeExtractor.cs
@@ -807,7 +807,7 @@ public sealed class TypeExtractor
         {
             return new ConstantMember
             {
-                Name = fieldName,
+                Name = DeconflictName(fieldName),
                 Value = new GuidConstantValue(guid.Value),
                 Type = new PrimitiveType("Guid"),
                 Description = description,
@@ -840,7 +840,7 @@ public sealed class TypeExtractor
 
         return new ConstantMember
         {
-            Name = fieldName,
+            Name = DeconflictName(fieldName),
             Value = new PrimitiveConstantValue(formattedValue, ahkTypeName),
             Type = new PrimitiveType(constant.TypeCode.ToString()),
             Description = description,

--- a/Generator/Metadata/TypeExtractor.cs
+++ b/Generator/Metadata/TypeExtractor.cs
@@ -1,5 +1,6 @@
 namespace AhkWin32.Generator.Metadata;
 
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
@@ -935,7 +936,7 @@ public sealed class TypeExtractor
         (MetadataReader structReader, TypeDefinitionHandle structHandle) = ResolveStructType(reader, fieldDef);
 
         TypeDefinition structTypeDef = structReader.GetTypeDefinition(structHandle);
-        List<StructFieldInit> fieldInits = BuildStructFieldInits(structReader, structTypeDef, values, "value");
+        List<StructFieldInit> fieldInits = BuildStructFieldInits(structReader, structTypeDef, values, []); // TODO don't hardcode 'value' as base
 
         bool needsGuid = fieldInits.Any(f => f.Kind == StructFieldInitKind.GuidPointer);
 
@@ -982,7 +983,7 @@ public sealed class TypeExtractor
         MetadataReader reader,
         TypeDefinition typeDef,
         Queue<string> values,
-        string pathPrefix
+        IEnumerable<string> pathPrefix
     )
     {
         List<StructFieldInit> inits = [];
@@ -992,7 +993,7 @@ public sealed class TypeExtractor
         {
             FieldDefinition fd = reader.GetFieldDefinition(hField);
             string memberName = reader.GetString(fd.Name);
-            string fieldPath = $"{pathPrefix}.{memberName}";
+            string[] fieldPath = [.. pathPrefix, memberName];
             ResolvedType memberType = fd.DecodeSignature(sigDecoder, new SignatureGenericContext());
 
             switch (memberType)
@@ -1006,7 +1007,7 @@ public sealed class TypeExtractor
                         new StructFieldInit(
                             fieldPath,
                             $"{memberName}_guid.ptr",
-                            StructFieldInitKind.GuidPointer,
+                            memberType is StructRef ? StructFieldInitKind.Guid : StructFieldInitKind.GuidPointer,
                             GuidValue: guidValue
                         )
                     );

--- a/Generator/Metadata/TypeExtractor.cs
+++ b/Generator/Metadata/TypeExtractor.cs
@@ -1022,6 +1022,13 @@ public sealed class TypeExtractor
             case EnumRef e:
                 refs.Add(e.FQN);
                 break;
+            case NativeTypedefRef n:
+                refs.Add(n.FQN);
+                CollectTypeReferences(n.Underlying, refs);
+                break;
+            case HResultType or NtStatusType:
+                refs.Add($"Windows.Win32.Foundation.{type.DisplayName}");
+                break;
             case PointerType p when p.Pointee != null:
                 CollectTypeReferences(p.Pointee, refs);
                 break;

--- a/Generator/Metadata/TypeExtractor.cs
+++ b/Generator/Metadata/TypeExtractor.cs
@@ -305,8 +305,7 @@ public sealed class TypeExtractor
 
         // Build imports
         ImportCollection imports = new();
-        foreach (string refFqn in CollectStructReferencedTypes(layout.Fields))
-            imports.AddType(refFqn);
+        imports.AddTypes(CollectStructReferencedTypes(layout.Fields));
 
         // Name deconfliction
         string displayName = DeconflictName(typeName);
@@ -369,8 +368,7 @@ public sealed class TypeExtractor
 
         // Build imports
         ImportCollection imports = new();
-        foreach (string refFqn in CollectStructReferencedTypes(layout.Fields))
-            imports.AddType(refFqn);
+        imports.AddTypes(CollectStructReferencedTypes(layout.Fields));
         if (freeFunc != null)
             imports.AddFunction(freeFunc.ApisFQN, freeFunc.Name);
 
@@ -431,8 +429,7 @@ public sealed class TypeExtractor
 
         // Imports for the underlying type, if it references another named type
         ImportCollection imports = new();
-        foreach (string refFqn in CollectTypeReferenceFqns(underlying))
-            imports.AddType(refFqn);
+        imports.AddTypes(CollectTypeReferenceFqns(underlying));
 
         string displayName = DeconflictName(typeName);
 
@@ -1004,7 +1001,7 @@ public sealed class TypeExtractor
     /// <summary>
     /// Recursively collect type FQN references from a ResolvedType.
     /// </summary>
-    private static void CollectTypeReferences(ResolvedType type, List<string> refs)
+    public static void CollectTypeReferences(ResolvedType type, List<string> refs)
     {
         switch (type)
         {

--- a/Generator/Metadata/TypeExtractor.cs
+++ b/Generator/Metadata/TypeExtractor.cs
@@ -28,8 +28,13 @@ public sealed class TypeExtractor
     private readonly ComInterfaceExtractor _comExtractor;
     private readonly int _maxParallelism;
 
-    public TypeExtractor(MetadataLoader loader, DocumentationLoader docs,
-        ILoggerFactory loggerFactory, IReadOnlySet<string> reservedNames, int maxParallelism = 0)
+    public TypeExtractor(
+        MetadataLoader loader,
+        DocumentationLoader docs,
+        ILoggerFactory loggerFactory,
+        IReadOnlySet<string> reservedNames,
+        int maxParallelism = 0
+    )
     {
         _loader = loader;
         _docs = docs;
@@ -38,11 +43,19 @@ public sealed class TypeExtractor
         _maxParallelism = maxParallelism > 0 ? maxParallelism : Environment.ProcessorCount;
         _fieldExtractor = new FieldExtractor(loader, _logger, ExtractStructRecursive);
 
-        var paramExtractor = new ParameterExtractor(loader, loggerFactory.CreateLogger<ParameterExtractor>(), reservedNames, _maxParallelism);
-        _methodExtractor = new MethodExtractor(docs, paramExtractor,
-            loggerFactory.CreateLogger<MethodExtractor>());
-        _comExtractor = new ComInterfaceExtractor(loader, docs, _methodExtractor,
-            loggerFactory.CreateLogger<ComInterfaceExtractor>());
+        var paramExtractor = new ParameterExtractor(
+            loader,
+            loggerFactory.CreateLogger<ParameterExtractor>(),
+            reservedNames,
+            _maxParallelism
+        );
+        _methodExtractor = new MethodExtractor(docs, paramExtractor, loggerFactory.CreateLogger<MethodExtractor>());
+        _comExtractor = new ComInterfaceExtractor(
+            loader,
+            docs,
+            _methodExtractor,
+            loggerFactory.CreateLogger<ComInterfaceExtractor>()
+        );
     }
 
     /// <summary>
@@ -55,8 +68,7 @@ public sealed class TypeExtractor
 
         foreach (var (assemblyName, version, reader) in _loader.GetPrimaryAssemblies())
         {
-            _logger.LogInformation("Extracting types from {AssemblyName} v{Version}...",
-                assemblyName, version);
+            _logger.LogInformation("Extracting types from {AssemblyName} v{Version}...", assemblyName, version);
 
             Stopwatch asmWatch = Stopwatch.StartNew();
             ExtractionCounts counts = ExtractFromAssembly(reader, assemblyName, version, registry);
@@ -64,23 +76,39 @@ public sealed class TypeExtractor
 
             _logger.LogInformation(
                 "Extracted {StructCount} structs, {HandleCount} handles, {TypedefCount} typedefs, {EnumCount} enums, {ComCount} COM, {ApiCount} APIs from {AssemblyName} in {Elapsed:F1}s",
-                counts.Structs, counts.Handles, counts.NativeTypedefs, counts.Enums, counts.ComInterfaces, counts.ApiTypes,
-                assemblyName, asmWatch.Elapsed.TotalSeconds);
+                counts.Structs,
+                counts.Handles,
+                counts.NativeTypedefs,
+                counts.Enums,
+                counts.ComInterfaces,
+                counts.ApiTypes,
+                assemblyName,
+                asmWatch.Elapsed.TotalSeconds
+            );
             _logger.LogInformation(
                 "  Skipped: {Arch} arch-filtered, {Nested} nested, {Delegate} delegates, {Other} other, {Errors} errors",
-                counts.SkippedArch, counts.SkippedNested, counts.SkippedDelegate, counts.SkippedOther, counts.Errors);
+                counts.SkippedArch,
+                counts.SkippedNested,
+                counts.SkippedDelegate,
+                counts.SkippedOther,
+                counts.Errors
+            );
 
             if (counts.SkippedArch > 0)
             {
                 _logger.LogWarning(
                     "Skipped {Count} types due to unsupported architecture (use --log-level Debug for details)",
-                    counts.SkippedArch);
+                    counts.SkippedArch
+                );
             }
         }
 
         totalWatch.Stop();
-        _logger.LogInformation("Extraction complete: {TotalTypes} types in TypeRegistry ({Elapsed:F1}s total)",
-            registry.Count, totalWatch.Elapsed.TotalSeconds);
+        _logger.LogInformation(
+            "Extraction complete: {TotalTypes} types in TypeRegistry ({Elapsed:F1}s total)",
+            registry.Count,
+            totalWatch.Elapsed.TotalSeconds
+        );
 
         return registry;
     }
@@ -89,139 +117,197 @@ public sealed class TypeExtractor
     /// Counts from a single assembly extraction pass.
     /// </summary>
     public sealed record ExtractionCounts(
-        int Structs, int Handles, int NativeTypedefs, int Enums,
-        int ComInterfaces, int ApiTypes,
-        int SkippedArch, int SkippedNested, int SkippedDelegate, int SkippedOther,
-        int Errors);
+        int Structs,
+        int Handles,
+        int NativeTypedefs,
+        int Enums,
+        int ComInterfaces,
+        int ApiTypes,
+        int SkippedArch,
+        int SkippedNested,
+        int SkippedDelegate,
+        int SkippedOther,
+        int Errors
+    );
 
     /// <summary>
     /// Extract all types from a single assembly's MetadataReader.
     /// </summary>
     private ExtractionCounts ExtractFromAssembly(
-        MetadataReader reader, string assemblyName, string version, TypeRegistry registry)
+        MetadataReader reader,
+        string assemblyName,
+        string version,
+        TypeRegistry registry
+    )
     {
-        int structCount = 0, handleCount = 0, typedefCount = 0, enumCount = 0;
-        int comCount = 0, apiCount = 0;
-        int archSkipCount = 0, nestedSkipCount = 0, delegateSkipCount = 0, otherSkipCount = 0;
+        int structCount = 0,
+            handleCount = 0,
+            typedefCount = 0,
+            enumCount = 0;
+        int comCount = 0,
+            apiCount = 0;
+        int archSkipCount = 0,
+            nestedSkipCount = 0,
+            delegateSkipCount = 0,
+            otherSkipCount = 0;
         int errorCount = 0;
 
-        reader.TypeDefinitions.AsParallel().WithDegreeOfParallelism(_maxParallelism).ForAll(hTypeDef =>
-        {
-            TypeDefinition typeDef = reader.GetTypeDefinition(hTypeDef);
-            string typeName = reader.GetString(typeDef.Name);
-            string typeNamespace = reader.GetString(typeDef.Namespace);
-            string fqn = $"{typeNamespace}.{typeName}";
-
-            // Skip non-extractable types
-            SkipReason? skipReason = ShouldSkipType(reader, hTypeDef, typeDef);
-            if (skipReason.HasValue)
+        reader
+            .TypeDefinitions.AsParallel()
+            .WithDegreeOfParallelism(_maxParallelism)
+            .ForAll(hTypeDef =>
             {
-                _logger.LogDebug("Skipping type {FQN}: {Reason}", fqn, skipReason.Value);
-                switch (skipReason.Value)
-                {
-                    case SkipReason.Nested: Interlocked.Increment(ref nestedSkipCount); break;
-                    case SkipReason.Delegate: Interlocked.Increment(ref delegateSkipCount); break;
-                    default: Interlocked.Increment(ref otherSkipCount); break;
-                }
-                return;
-            }
+                TypeDefinition typeDef = reader.GetTypeDefinition(hTypeDef);
+                string typeName = reader.GetString(typeDef.Name);
+                string typeNamespace = reader.GetString(typeDef.Namespace);
+                string fqn = $"{typeNamespace}.{typeName}";
 
-            try
-            {
-                // Decode attributes (single pass)
-                int fieldCount = typeDef.GetFields().Count;
-                TypeAttrs attrs = AttributeReader.DecodeTypeAttributes(reader, typeDef, fieldCount, _logger);
-
-                // Architecture filter
-                if (attrs.SupportedArchitecture.HasValue)
+                // Skip non-extractable types
+                SkipReason? skipReason = ShouldSkipType(reader, hTypeDef, typeDef);
+                if (skipReason.HasValue)
                 {
-                    Architecture arch = attrs.SupportedArchitecture.Value;
-                    if (!arch.HasFlag(Architecture.X64))
+                    _logger.LogDebug("Skipping type {FQN}: {Reason}", fqn, skipReason.Value);
+                    switch (skipReason.Value)
                     {
-                        Interlocked.Increment(ref archSkipCount);
-                        _logger.LogDebug("Skipping type {FQN}: unsupported architecture {Arch}",
-                            fqn, arch);
-                        return;
+                        case SkipReason.Nested:
+                            Interlocked.Increment(ref nestedSkipCount);
+                            break;
+                        case SkipReason.Delegate:
+                            Interlocked.Increment(ref delegateSkipCount);
+                            break;
+                        default:
+                            Interlocked.Increment(ref otherSkipCount);
+                            break;
                     }
-                }
-
-                // Classify and extract
-                TypeKind? kind = ClassifyType(reader, hTypeDef, typeDef, attrs);
-                if (kind == null)
-                {
-                    _logger.LogDebug("Skipping type {FQN}: non-extractable", fqn);
-                    Interlocked.Increment(ref otherSkipCount);
                     return;
                 }
 
-                Win32Type? extracted = kind.Value switch
+                try
                 {
-                    TypeKind.Handle => ExtractHandle(reader, typeDef, assemblyName, version, attrs),
-                    TypeKind.NativeTypedef => ExtractNativeTypedef(reader, typeDef, assemblyName, version, attrs),
-                    TypeKind.Struct => ExtractStruct(reader, typeDef, assemblyName, version, attrs),
-                    TypeKind.Enum => ExtractEnum(reader, typeDef, assemblyName, version, attrs),
-                    TypeKind.ComInterface => _comExtractor.ExtractComInterface(reader, typeDef, assemblyName, version, attrs),
-                    TypeKind.ApiType => ExtractApiType(reader, typeDef, assemblyName, version, attrs),
-                    _ => null
-                };
+                    // Decode attributes (single pass)
+                    int fieldCount = typeDef.GetFields().Count;
+                    TypeAttrs attrs = AttributeReader.DecodeTypeAttributes(reader, typeDef, fieldCount, _logger);
 
-                if (extracted != null)
-                {
-                    registry.Register(extracted);
-
-                    switch (extracted)
+                    // Architecture filter
+                    if (attrs.SupportedArchitecture.HasValue)
                     {
-                        case HandleType:
-                            Interlocked.Increment(ref handleCount);
-                            break;
-                        case NativeTypedefType:
-                            Interlocked.Increment(ref typedefCount);
-                            break;
-                        case StructType:
-                            Interlocked.Increment(ref structCount);
-                            break;
-                        case EnumType:
-                            Interlocked.Increment(ref enumCount);
-                            break;
-                        case ComInterfaceType:
-                            Interlocked.Increment(ref comCount);
-                            break;
-                        case ApiType:
-                            Interlocked.Increment(ref apiCount);
-                            break;
+                        Architecture arch = attrs.SupportedArchitecture.Value;
+                        if (!arch.HasFlag(Architecture.X64))
+                        {
+                            Interlocked.Increment(ref archSkipCount);
+                            _logger.LogDebug("Skipping type {FQN}: unsupported architecture {Arch}", fqn, arch);
+                            return;
+                        }
+                    }
+
+                    // Classify and extract
+                    TypeKind? kind = ClassifyType(reader, hTypeDef, typeDef, attrs);
+                    if (kind == null)
+                    {
+                        _logger.LogDebug("Skipping type {FQN}: non-extractable", fqn);
+                        Interlocked.Increment(ref otherSkipCount);
+                        return;
+                    }
+
+                    Win32Type? extracted = kind.Value switch
+                    {
+                        TypeKind.Handle => ExtractHandle(reader, typeDef, assemblyName, version, attrs),
+                        TypeKind.NativeTypedef => ExtractNativeTypedef(reader, typeDef, assemblyName, version, attrs),
+                        TypeKind.Struct => ExtractStruct(reader, typeDef, assemblyName, version, attrs),
+                        TypeKind.Enum => ExtractEnum(reader, typeDef, assemblyName, version, attrs),
+                        TypeKind.ComInterface => _comExtractor.ExtractComInterface(
+                            reader,
+                            typeDef,
+                            assemblyName,
+                            version,
+                            attrs
+                        ),
+                        TypeKind.ApiType => ExtractApiType(reader, typeDef, assemblyName, version, attrs),
+                        _ => null,
+                    };
+
+                    if (extracted != null)
+                    {
+                        registry.Register(extracted);
+
+                        switch (extracted)
+                        {
+                            case HandleType:
+                                Interlocked.Increment(ref handleCount);
+                                break;
+                            case NativeTypedefType:
+                                Interlocked.Increment(ref typedefCount);
+                                break;
+                            case StructType:
+                                Interlocked.Increment(ref structCount);
+                                break;
+                            case EnumType:
+                                Interlocked.Increment(ref enumCount);
+                                break;
+                            case ComInterfaceType:
+                                Interlocked.Increment(ref comCount);
+                                break;
+                            case ApiType:
+                                Interlocked.Increment(ref apiCount);
+                                break;
+                        }
                     }
                 }
-            }
-            catch (Exception ex)
-            {
-                Interlocked.Increment(ref errorCount);
-                _logger.LogError(ex, "Failed to extract {FQN}", fqn);
-            }
-        });
+                catch (Exception ex)
+                {
+                    Interlocked.Increment(ref errorCount);
+                    _logger.LogError(ex, "Failed to extract {FQN}", fqn);
+                }
+            });
 
         return new ExtractionCounts(
-            structCount, handleCount, typedefCount, enumCount,
-            comCount, apiCount,
-            archSkipCount, nestedSkipCount, delegateSkipCount, otherSkipCount,
-            errorCount);
+            structCount,
+            handleCount,
+            typedefCount,
+            enumCount,
+            comCount,
+            apiCount,
+            archSkipCount,
+            nestedSkipCount,
+            delegateSkipCount,
+            otherSkipCount,
+            errorCount
+        );
     }
 
     // --- Type classification ---
 
-    private enum TypeKind { Struct, Handle, NativeTypedef, Enum, ComInterface, ApiType }
+    private enum TypeKind
+    {
+        Struct,
+        Handle,
+        NativeTypedef,
+        Enum,
+        ComInterface,
+        ApiType,
+    }
 
-    private enum SkipReason { Module, NotTypeReference, Delegate, Attribute, Nested }
+    private enum SkipReason
+    {
+        Module,
+        NotTypeReference,
+        Delegate,
+        Attribute,
+        Nested,
+    }
 
     /// <summary>
     /// Check if a type should be skipped entirely. Port of Program.ShouldSkipType.
     /// </summary>
     private static SkipReason? ShouldSkipType(
-        MetadataReader reader, TypeDefinitionHandle handle, TypeDefinition typeDef)
+        MetadataReader reader,
+        TypeDefinitionHandle handle,
+        TypeDefinition typeDef
+    )
     {
         if (typeDef.BaseType.IsNil)
         {
-            return reader.StringComparer.Equals(typeDef.Name, "<Module>")
-                ? SkipReason.Module : null;
+            return reader.StringComparer.Equals(typeDef.Name, "<Module>") ? SkipReason.Module : null;
         }
 
         if (typeDef.BaseType.Kind is not HandleKind.TypeReference)
@@ -247,7 +333,11 @@ public sealed class TypeExtractor
     /// Classify a non-skipped type into its extraction kind. Port of Program.ParseType.
     /// </summary>
     private static TypeKind? ClassifyType(
-        MetadataReader reader, TypeDefinitionHandle handle, TypeDefinition typeDef, TypeAttrs attrs)
+        MetadataReader reader,
+        TypeDefinitionHandle handle,
+        TypeDefinition typeDef,
+        TypeAttrs attrs
+    )
     {
         // Interface = COM. There are no other kinds of interfaces in win32metadata
         if ((typeDef.Attributes & TypeAttributes.Interface) != 0)
@@ -271,7 +361,7 @@ public sealed class TypeExtractor
             "Struct" or "ValueType" when attrs.IsHandle => TypeKind.Handle,
             "Struct" or "ValueType" when attrs.IsNativeTypedef => TypeKind.NativeTypedef,
             "Struct" or "ValueType" => TypeKind.Struct,
-            _ => null
+            _ => null,
         };
     }
 
@@ -281,8 +371,12 @@ public sealed class TypeExtractor
     /// Extract a StructType from a TypeDefinition.
     /// </summary>
     private StructType ExtractStruct(
-        MetadataReader reader, TypeDefinition typeDef,
-        string assemblyName, string version, TypeAttrs attrs)
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        string assemblyName,
+        string version,
+        TypeAttrs attrs
+    )
     {
         string typeName = reader.GetString(typeDef.Name);
         string typeNamespace = reader.GetString(typeDef.Namespace);
@@ -301,7 +395,15 @@ public sealed class TypeExtractor
 
         // Extract fields with layout computation
         StructLayout layout = _fieldExtractor.ExtractFields(
-            reader, typeDef, layoutKind, packingSize, isUnion, isAnsi, fqn, apiFields);
+            reader,
+            typeDef,
+            layoutKind,
+            packingSize,
+            isUnion,
+            isAnsi,
+            fqn,
+            apiFields
+        );
 
         // Build imports
         ImportCollection imports = new();
@@ -329,11 +431,15 @@ public sealed class TypeExtractor
             DeprecationMessage = attrs.DeprecationMessage,
             SupportedOSPlatform = attrs.SupportedOSPlatform,
             Imports = imports,
-            IsNested = typeDef.IsNested
+            IsNested = typeDef.IsNested,
         };
 
-        _logger.LogDebug("Extracted StructType {FQN} ({FieldCount} fields, {Size} bytes)",
-            fqn, layout.Fields.Count, layout.TotalSize);
+        _logger.LogDebug(
+            "Extracted StructType {FQN} ({FieldCount} fields, {Size} bytes)",
+            fqn,
+            layout.Fields.Count,
+            layout.TotalSize
+        );
 
         return result;
     }
@@ -342,8 +448,12 @@ public sealed class TypeExtractor
     /// Extract a HandleType from a TypeDefinition (extends struct extraction).
     /// </summary>
     private HandleType ExtractHandle(
-        MetadataReader reader, TypeDefinition typeDef,
-        string assemblyName, string version, TypeAttrs attrs)
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        string assemblyName,
+        string version,
+        TypeAttrs attrs
+    )
     {
         string typeName = reader.GetString(typeDef.Name);
         string typeNamespace = reader.GetString(typeDef.Namespace);
@@ -360,7 +470,15 @@ public sealed class TypeExtractor
 
         // Extract fields
         StructLayout layout = _fieldExtractor.ExtractFields(
-            reader, typeDef, layoutKind, packingSize, false, isAnsi, fqn, apiDetails?.Fields);
+            reader,
+            typeDef,
+            layoutKind,
+            packingSize,
+            false,
+            isAnsi,
+            fqn,
+            apiDetails?.Fields
+        );
 
         // Handle-specific attributes
         IReadOnlyList<long> invalidValues = AttributeReader.DecodeInvalidHandleValues(attrs.All);
@@ -394,11 +512,15 @@ public sealed class TypeExtractor
             DeprecationMessage = attrs.DeprecationMessage,
             SupportedOSPlatform = attrs.SupportedOSPlatform,
             Imports = imports,
-            IsNested = typeDef.IsNested
+            IsNested = typeDef.IsNested,
         };
 
-        _logger.LogDebug("Extracted HandleType {FQN} (invalidValues=[{Values}], freeFunc={FuncName})",
-            fqn, string.Join(", ", invalidValues), freeFunc?.Name ?? "null");
+        _logger.LogDebug(
+            "Extracted HandleType {FQN} (invalidValues=[{Values}], freeFunc={FuncName})",
+            fqn,
+            string.Join(", ", invalidValues),
+            freeFunc?.Name ?? "null"
+        );
 
         return result;
     }
@@ -410,8 +532,12 @@ public sealed class TypeExtractor
     /// type is read from its single field's signature.
     /// </summary>
     private NativeTypedefType ExtractNativeTypedef(
-        MetadataReader reader, TypeDefinition typeDef,
-        string assemblyName, string version, TypeAttrs attrs)
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        string assemblyName,
+        string version,
+        TypeAttrs attrs
+    )
     {
         string typeName = reader.GetString(typeDef.Name);
         string typeNamespace = reader.GetString(typeDef.Namespace);
@@ -422,7 +548,10 @@ public sealed class TypeExtractor
         // Decode the single field's signature to get the underlying type
         FieldDefinitionHandle hField = typeDef.GetFields().Single();
         FieldDefinition fieldDef = reader.GetFieldDefinition(hField);
-        ResolvedType underlying = fieldDef.DecodeSignature(new SignatureDecoder(reader, _loader, _logger, typeDef), new());
+        ResolvedType underlying = fieldDef.DecodeSignature(
+            new SignatureDecoder(reader, _loader, _logger, typeDef),
+            new()
+        );
 
         // Get API documentation
         ApiDetails? apiDetails = _docs.GetApiDetails(reader, typeDef);
@@ -447,11 +576,10 @@ public sealed class TypeExtractor
             HelpLink = apiDetails?.HelpLink,
             DeprecationMessage = attrs.DeprecationMessage,
             SupportedOSPlatform = attrs.SupportedOSPlatform,
-            Imports = imports
+            Imports = imports,
         };
 
-        _logger.LogDebug("Extracted NativeTypedefType {FQN} (underlying={Underlying})",
-            fqn, underlying.DisplayName);
+        _logger.LogDebug("Extracted NativeTypedefType {FQN} (underlying={Underlying})", fqn, underlying.DisplayName);
 
         return result;
     }
@@ -471,8 +599,12 @@ public sealed class TypeExtractor
     /// Port of AhkEnum constructor + AhkConstant for constant value decoding.
     /// </summary>
     private EnumType ExtractEnum(
-        MetadataReader reader, TypeDefinition typeDef,
-        string assemblyName, string version, TypeAttrs attrs)
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        string assemblyName,
+        string version,
+        TypeAttrs attrs
+    )
     {
         string typeName = reader.GetString(typeDef.Name);
         string typeNamespace = reader.GetString(typeDef.Namespace);
@@ -484,15 +616,18 @@ public sealed class TypeExtractor
         ApiDetails? apiDetails = _docs.GetApiDetails(reader, typeDef);
 
         // Get underlying type
-        string underlyingTypeName = SignatureDecoder.GetEnumUnderlyingType(reader,
-            FindTypeDefHandle(reader, typeDef));
+        string underlyingTypeName = SignatureDecoder.GetEnumUnderlyingType(reader, FindTypeDefHandle(reader, typeDef));
 
         // Extract constants
-       List<ConstantMember> constants = [.. typeDef.GetFields()
-            .Select(reader.GetFieldDefinition)
-            .Where(fieldDef => !reader.StringComparer.Equals(fieldDef.Name, "value__", true))
-            .Select(fieldDef => ExtractConstant(reader, fieldDef, reader.GetString(fieldDef.Name), apiDetails))
-            .OfType<ConstantMember>()];
+        List<ConstantMember> constants =
+        [
+            .. typeDef
+                .GetFields()
+                .Select(reader.GetFieldDefinition)
+                .Where(fieldDef => !reader.StringComparer.Equals(fieldDef.Name, "value__", true))
+                .Select(fieldDef => ExtractConstant(reader, fieldDef, reader.GetString(fieldDef.Name), apiDetails))
+                .OfType<ConstantMember>(),
+        ];
 
         string displayName = DeconflictName(typeName);
 
@@ -511,11 +646,15 @@ public sealed class TypeExtractor
             Remarks = apiDetails?.Remarks,
             HelpLink = apiDetails?.HelpLink,
             DeprecationMessage = attrs.DeprecationMessage,
-            SupportedOSPlatform = attrs.SupportedOSPlatform
+            SupportedOSPlatform = attrs.SupportedOSPlatform,
         };
 
-        _logger.LogDebug("Extracted EnumType {FQN} ({ConstantCount} constants, flags={IsFlags})",
-            fqn, constants.Count, attrs.IsFlags);
+        _logger.LogDebug(
+            "Extracted EnumType {FQN} ({ConstantCount} constants, flags={IsFlags})",
+            fqn,
+            constants.Count,
+            attrs.IsFlags
+        );
 
         return result;
     }
@@ -527,8 +666,12 @@ public sealed class TypeExtractor
     /// Port of AhkApiType constructor.
     /// </summary>
     private ApiType ExtractApiType(
-        MetadataReader reader, TypeDefinition typeDef,
-        string assemblyName, string version, TypeAttrs attrs)
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        string assemblyName,
+        string version,
+        TypeAttrs attrs
+    )
     {
         string typeName = reader.GetString(typeDef.Name);
         string typeNamespace = reader.GetString(typeDef.Namespace);
@@ -540,19 +683,27 @@ public sealed class TypeExtractor
         ApiDetails? apiDetails = _docs.GetApiDetails(reader, typeDef);
 
         // Extract constants (same as enum constants — reuse existing logic)
-        List<ConstantMember> constants = [.. typeDef.GetFields()
-            .Select(reader.GetFieldDefinition)
-            .Where(fieldDef => !reader.StringComparer.Equals(fieldDef.Name, "value__", true))
-            .Select(fieldDef => ExtractConstant(reader, fieldDef, reader.GetString(fieldDef.Name), apiDetails))
-            .OfType<ConstantMember>()];
+        List<ConstantMember> constants =
+        [
+            .. typeDef
+                .GetFields()
+                .Select(reader.GetFieldDefinition)
+                .Where(fieldDef => !reader.StringComparer.Equals(fieldDef.Name, "value__", true))
+                .Select(fieldDef => ExtractConstant(reader, fieldDef, reader.GetString(fieldDef.Name), apiDetails))
+                .OfType<ConstantMember>(),
+        ];
 
         // Extract methods, deduplicating by name (matching legacy AhkApiType behavior)
-        List<MethodMember> methods = [.. typeDef.GetMethods()
-            .Select(reader.GetMethodDefinition)
-            .DistinctBy(methodDef => reader.GetString(methodDef.Name))
-            .Select(methodDef => _methodExtractor.ExtractMethod(reader, methodDef, typeNamespace))
-            .OfType<MethodMember>()];
-            
+        List<MethodMember> methods =
+        [
+            .. typeDef
+                .GetMethods()
+                .Select(reader.GetMethodDefinition)
+                .DistinctBy(methodDef => reader.GetString(methodDef.Name))
+                .Select(methodDef => _methodExtractor.ExtractMethod(reader, methodDef, typeNamespace))
+                .OfType<MethodMember>(),
+        ];
+
         // Collect imports from both constants and methods
         ImportCollection imports = new();
         imports.MergeFrom(constants.Select(c => c.Imports));
@@ -575,11 +726,15 @@ public sealed class TypeExtractor
             HelpLink = apiDetails?.HelpLink,
             DeprecationMessage = attrs.DeprecationMessage,
             SupportedOSPlatform = attrs.SupportedOSPlatform,
-            Imports = imports
+            Imports = imports,
         };
 
-        _logger.LogDebug("Extracted ApiType {FQN} ({ConstantCount} constants, {MethodCount} methods)",
-            fqn, constants.Count, methods.Count);
+        _logger.LogDebug(
+            "Extracted ApiType {FQN} ({ConstantCount} constants, {MethodCount} methods)",
+            fqn,
+            constants.Count,
+            methods.Count
+        );
 
         return result;
     }
@@ -589,8 +744,11 @@ public sealed class TypeExtractor
     /// Handles GUID, primitive, handle, and struct constants.
     /// </summary>
     private ConstantMember? ExtractConstant(
-        MetadataReader reader, FieldDefinition fieldDef, string fieldName,
-        ApiDetails? apiDetails)
+        MetadataReader reader,
+        FieldDefinition fieldDef,
+        string fieldName,
+        ApiDetails? apiDetails
+    )
     {
         FieldAttrs fieldAttrs = AttributeReader.DecodeFieldAttributes(reader, fieldDef);
         string? description = null;
@@ -608,7 +766,7 @@ public sealed class TypeExtractor
                 Description = description,
                 IsDeprecated = fieldAttrs.IsDeprecated,
                 DeprecationMessage = fieldAttrs.DeprecationMessage,
-                NeedsGuid = true
+                NeedsGuid = true,
             };
         }
 
@@ -640,7 +798,7 @@ public sealed class TypeExtractor
             Type = new PrimitiveType(constant.TypeCode.ToString()),
             Description = description,
             IsDeprecated = fieldAttrs.IsDeprecated,
-            DeprecationMessage = fieldAttrs.DeprecationMessage
+            DeprecationMessage = fieldAttrs.DeprecationMessage,
         };
     }
 
@@ -648,20 +806,25 @@ public sealed class TypeExtractor
     /// Extract a struct-typed constant (handle constant or struct with [ConstantAttribute]).
     /// </summary>
     private ConstantMember? ExtractStructConstant(
-        MetadataReader reader, FieldDefinition fieldDef, string fieldName,
-        ResolvedType fieldType, FieldAttrs fieldAttrs, string? description)
+        MetadataReader reader,
+        FieldDefinition fieldDef,
+        string fieldName,
+        ResolvedType fieldType,
+        FieldAttrs fieldAttrs,
+        string? description
+    )
     {
         string structFqn = fieldType switch
         {
             StructRef s => s.FQN,
             HandleRef h => h.FQN,
-            _ => throw new InvalidOperationException()
+            _ => throw new InvalidOperationException(),
         };
         string structName = fieldType switch
         {
             StructRef s => s.Name,
             HandleRef h => h.Name,
-            _ => throw new InvalidOperationException()
+            _ => throw new InvalidOperationException(),
         };
         bool isHandle = fieldType is HandleRef;
 
@@ -682,37 +845,48 @@ public sealed class TypeExtractor
             return new ConstantMember
             {
                 Name = fieldName,
-                Value = new StructConstantValue(structName, structFqn, IsHandle: true,
-                    HandleValue: handleValue, FieldInits: null),
+                Value = new StructConstantValue(
+                    structName,
+                    structFqn,
+                    IsHandle: true,
+                    HandleValue: handleValue,
+                    FieldInits: null
+                ),
                 Type = fieldType,
                 Description = description,
                 IsDeprecated = fieldAttrs.IsDeprecated,
                 DeprecationMessage = fieldAttrs.DeprecationMessage,
-                Imports = MakeTypeImports(structFqn)
+                Imports = MakeTypeImports(structFqn),
             };
         }
 
         // Non-handle struct constant — decode [ConstantAttribute]
         CustomAttribute? constAttr = AttributeReader.FindAttribute(
-            reader, fieldDef.GetCustomAttributes(), "ConstantAttribute");
+            reader,
+            fieldDef.GetCustomAttributes(),
+            "ConstantAttribute"
+        );
 
         if (constAttr is null)
         {
-            _logger.LogWarning("Struct constant {Name} ({StructFQN}) has no [ConstantAttribute], skipping",
-                fieldName, structFqn);
+            _logger.LogWarning(
+                "Struct constant {Name} ({StructFQN}) has no [ConstantAttribute], skipping",
+                fieldName,
+                structFqn
+            );
             return null;
         }
 
         CustomAttributeValue<string> decoded = constAttr.Value.DecodeValue(new CaTypeProvider());
-        string raw = (string)(decoded.FixedArguments[0].Value
-            ?? throw new InvalidOperationException($"Null ConstantAttribute value for '{fieldName}'"));
+        string raw = (string)(
+            decoded.FixedArguments[0].Value
+            ?? throw new InvalidOperationException($"Null ConstantAttribute value for '{fieldName}'")
+        );
 
-        Queue<string> values = new(raw.Split(',')
-            .Select(s => s.TrimStart('{').TrimEnd('}').Trim()));
+        Queue<string> values = new(raw.Split(',').Select(s => s.TrimStart('{').TrimEnd('}').Trim()));
 
         // Resolve the struct's TypeDefinition to walk its fields
-        (MetadataReader structReader, TypeDefinitionHandle structHandle) =
-            ResolveStructType(reader, fieldDef);
+        (MetadataReader structReader, TypeDefinitionHandle structHandle) = ResolveStructType(reader, fieldDef);
 
         TypeDefinition structTypeDef = structReader.GetTypeDefinition(structHandle);
         List<StructFieldInit> fieldInits = BuildStructFieldInits(structReader, structTypeDef, values, "value");
@@ -722,14 +896,19 @@ public sealed class TypeExtractor
         return new ConstantMember
         {
             Name = fieldName,
-            Value = new StructConstantValue(structName, structFqn, IsHandle: false,
-                HandleValue: null, FieldInits: fieldInits),
+            Value = new StructConstantValue(
+                structName,
+                structFqn,
+                IsHandle: false,
+                HandleValue: null,
+                FieldInits: fieldInits
+            ),
             Type = fieldType,
             Description = description,
             IsDeprecated = fieldAttrs.IsDeprecated,
             DeprecationMessage = fieldAttrs.DeprecationMessage,
             NeedsGuid = needsGuid,
-            Imports = MakeTypeImports(structFqn)
+            Imports = MakeTypeImports(structFqn),
         };
     }
 
@@ -738,7 +917,9 @@ public sealed class TypeExtractor
     /// Reads the field signature blob: FIELD header, VALUETYPE element type, compressed token.
     /// </summary>
     private (MetadataReader Reader, TypeDefinitionHandle Handle) ResolveStructType(
-        MetadataReader reader, FieldDefinition fieldDef)
+        MetadataReader reader,
+        FieldDefinition fieldDef
+    )
     {
         BlobReader sigReader = reader.GetBlobReader(fieldDef.Signature);
         sigReader.ReadSignatureHeader(); // FIELD (0x06)
@@ -752,7 +933,11 @@ public sealed class TypeExtractor
     /// and consuming values from the [ConstantAttribute] queue.
     /// </summary>
     private List<StructFieldInit> BuildStructFieldInits(
-        MetadataReader reader, TypeDefinition typeDef, Queue<string> values, string pathPrefix)
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        Queue<string> values,
+        string pathPrefix
+    )
     {
         List<StructFieldInit> inits = [];
         var sigDecoder = new SignatureDecoder(reader, _loader, _logger, typeDef);
@@ -771,16 +956,21 @@ public sealed class TypeExtractor
                 {
                     // GUID field or GUID pointer — dequeue 11 values for the GUID
                     Guid guidValue = AttributeReader.DecodeGuidFromQueue(values);
-                    inits.Add(new StructFieldInit(fieldPath, $"{memberName}_guid.ptr",
-                        StructFieldInitKind.GuidPointer, GuidValue: guidValue));
+                    inits.Add(
+                        new StructFieldInit(
+                            fieldPath,
+                            $"{memberName}_guid.ptr",
+                            StructFieldInitKind.GuidPointer,
+                            GuidValue: guidValue
+                        )
+                    );
                     break;
                 }
 
                 case StructRef:
                 {
                     // Nested struct — recurse into Win32 struct fields
-                    (MetadataReader nestedReader, TypeDefinitionHandle nestedHandle) =
-                        ResolveStructRef(reader, fd);
+                    (MetadataReader nestedReader, TypeDefinitionHandle nestedHandle) = ResolveStructRef(reader, fd);
                     TypeDefinition nestedTypeDef = nestedReader.GetTypeDefinition(nestedHandle);
                     inits.AddRange(BuildStructFieldInits(nestedReader, nestedTypeDef, values, fieldPath));
                     break;
@@ -791,8 +981,14 @@ public sealed class TypeExtractor
                     // Array — dequeue Length times with 1-based indices
                     for (int i = 0; i < arr.Length; i++)
                     {
-                        inits.Add(new StructFieldInit(fieldPath, values.Dequeue(),
-                            StructFieldInitKind.ArrayElement, ArrayIndex: i + 1));
+                        inits.Add(
+                            new StructFieldInit(
+                                fieldPath,
+                                values.Dequeue(),
+                                StructFieldInitKind.ArrayElement,
+                                ArrayIndex: i + 1
+                            )
+                        );
                     }
                     break;
                 }
@@ -800,8 +996,7 @@ public sealed class TypeExtractor
                 default:
                 {
                     // Primitive or void pointer — dequeue once
-                    inits.Add(new StructFieldInit(fieldPath, values.Dequeue(),
-                        StructFieldInitKind.Direct));
+                    inits.Add(new StructFieldInit(fieldPath, values.Dequeue(), StructFieldInitKind.Direct));
                     break;
                 }
             }
@@ -814,7 +1009,9 @@ public sealed class TypeExtractor
     /// Resolve a nested struct field's TypeDefinition from its field signature.
     /// </summary>
     private (MetadataReader Reader, TypeDefinitionHandle Handle) ResolveStructRef(
-        MetadataReader reader, FieldDefinition fieldDef)
+        MetadataReader reader,
+        FieldDefinition fieldDef
+    )
     {
         BlobReader sigReader = reader.GetBlobReader(fieldDef.Signature);
         sigReader.ReadSignatureHeader(); // FIELD (0x06)
@@ -828,7 +1025,9 @@ public sealed class TypeExtractor
     /// Returns the resolved (MetadataReader, TypeDefinitionHandle) pair.
     /// </summary>
     private (MetadataReader Reader, TypeDefinitionHandle Handle) DecodeTypeDefOrRefHandle(
-        MetadataReader reader, ref BlobReader sigReader)
+        MetadataReader reader,
+        ref BlobReader sigReader
+    )
     {
         int coded = sigReader.ReadCompressedInteger();
         int table = coded & 0x3;
@@ -838,8 +1037,7 @@ public sealed class TypeExtractor
         {
             0 => (reader, MetadataTokens.TypeDefinitionHandle(row)),
             1 => _loader.ResolveTypeReference(reader, MetadataTokens.TypeReferenceHandle(row)),
-            _ => throw new NotSupportedException(
-                $"Unexpected TypeDefOrRef table {table} in struct constant signature")
+            _ => throw new NotSupportedException($"Unexpected TypeDefOrRef table {table} in struct constant signature"),
         };
     }
 
@@ -863,8 +1061,7 @@ public sealed class TypeExtractor
             ConstantTypeCode.Double => blob.ReadDouble(),
             ConstantTypeCode.Char => blob.ReadChar(),
             ConstantTypeCode.String => blob.ReadUTF16(blob.Length),
-            _ => throw new NotSupportedException(
-                $"Unexpected constant type {typeCode} for '{name}'")
+            _ => throw new NotSupportedException($"Unexpected constant type {typeCode} for '{name}'"),
         };
 
         return typeCode switch
@@ -872,19 +1069,20 @@ public sealed class TypeExtractor
             ConstantTypeCode.Byte => $"0x{(byte)value:X2}",
             ConstantTypeCode.SByte => $"0x{(sbyte)value:X2}",
             ConstantTypeCode.String => EscapeAhkStringLiteral($"\"{value}\""),
-            _ => value.ToString() ?? throw new InvalidOperationException($"Null ToString for constant '{name}'")
+            _ => value.ToString() ?? throw new InvalidOperationException($"Null ToString for constant '{name}'"),
         };
     }
 
     /// <summary>
     /// Map ConstantTypeCode to AHK display type name.
     /// </summary>
-    private static string ConstantTypeCodeToAhkType(ConstantTypeCode typeCode) => typeCode switch
-    {
-        ConstantTypeCode.Single or ConstantTypeCode.Double => "Float",
-        ConstantTypeCode.String => "String",
-        _ => $"Integer ({typeCode})"
-    };
+    private static string ConstantTypeCodeToAhkType(ConstantTypeCode typeCode) =>
+        typeCode switch
+        {
+            ConstantTypeCode.Single or ConstantTypeCode.Double => "Float",
+            ConstantTypeCode.String => "String",
+            _ => $"Integer ({typeCode})",
+        };
 
     /// <summary>
     /// Escape a string literal for AHK output.
@@ -900,14 +1098,16 @@ public sealed class TypeExtractor
                 continue;
             }
 
-            sb.Append(c switch
-            {
-                '\n' => "`n",
-                '\t' => "`t",
-                '\r' => "`r",
-                '`' => "``",
-                _ => c
-            });
+            sb.Append(
+                c switch
+                {
+                    '\n' => "`n",
+                    '\t' => "`t",
+                    '\r' => "`r",
+                    '`' => "``",
+                    _ => c,
+                }
+            );
         }
         return sb.ToString();
     }
@@ -934,7 +1134,7 @@ public sealed class TypeExtractor
             TypeAttributes.SequentialLayout => StructLayoutKind.Sequential,
             TypeAttributes.ExplicitLayout => StructLayoutKind.Explicit,
             TypeAttributes.AutoLayout => StructLayoutKind.Auto,
-            _ => StructLayoutKind.Sequential
+            _ => StructLayoutKind.Sequential,
         };
     }
 
@@ -1054,7 +1254,14 @@ public sealed class TypeExtractor
         bool isUnion = attrs.Flags.HasFlag(MemberFlags.Union);
 
         StructLayout layout = _fieldExtractor.ExtractFields(
-            reader, typeDef, layoutKind, packingSize, isUnion, isAnsi, fqn);
+            reader,
+            typeDef,
+            layoutKind,
+            packingSize,
+            isUnion,
+            isAnsi,
+            fqn
+        );
 
         string displayName = DeconflictName(typeName);
 
@@ -1071,7 +1278,7 @@ public sealed class TypeExtractor
             LayoutKind = layoutKind,
             Members = layout.Fields,
             StructSizeFieldName = attrs.StructSizeFieldName,
-            IsNested = true
+            IsNested = true,
         };
     }
 
@@ -1086,8 +1293,7 @@ public sealed class TypeExtractor
         foreach (TypeDefinitionHandle handle in reader.TypeDefinitions)
         {
             TypeDefinition td = reader.GetTypeDefinition(handle);
-            if (reader.StringComparer.Equals(td.Name, name) &&
-                reader.StringComparer.Equals(td.Namespace, ns))
+            if (reader.StringComparer.Equals(td.Name, name) && reader.StringComparer.Equals(td.Namespace, ns))
             {
                 return handle;
             }

--- a/Generator/Metadata/TypeExtractor.cs
+++ b/Generator/Metadata/TypeExtractor.cs
@@ -63,8 +63,8 @@ public sealed class TypeExtractor
             asmWatch.Stop();
 
             _logger.LogInformation(
-                "Extracted {StructCount} structs, {HandleCount} handles, {EnumCount} enums, {ComCount} COM, {ApiCount} APIs from {AssemblyName} in {Elapsed:F1}s",
-                counts.Structs, counts.Handles, counts.Enums, counts.ComInterfaces, counts.ApiTypes,
+                "Extracted {StructCount} structs, {HandleCount} handles, {TypedefCount} typedefs, {EnumCount} enums, {ComCount} COM, {ApiCount} APIs from {AssemblyName} in {Elapsed:F1}s",
+                counts.Structs, counts.Handles, counts.NativeTypedefs, counts.Enums, counts.ComInterfaces, counts.ApiTypes,
                 assemblyName, asmWatch.Elapsed.TotalSeconds);
             _logger.LogInformation(
                 "  Skipped: {Arch} arch-filtered, {Nested} nested, {Delegate} delegates, {Other} other, {Errors} errors",
@@ -89,7 +89,7 @@ public sealed class TypeExtractor
     /// Counts from a single assembly extraction pass.
     /// </summary>
     public sealed record ExtractionCounts(
-        int Structs, int Handles, int Enums,
+        int Structs, int Handles, int NativeTypedefs, int Enums,
         int ComInterfaces, int ApiTypes,
         int SkippedArch, int SkippedNested, int SkippedDelegate, int SkippedOther,
         int Errors);
@@ -100,7 +100,7 @@ public sealed class TypeExtractor
     private ExtractionCounts ExtractFromAssembly(
         MetadataReader reader, string assemblyName, string version, TypeRegistry registry)
     {
-        int structCount = 0, handleCount = 0, enumCount = 0;
+        int structCount = 0, handleCount = 0, typedefCount = 0, enumCount = 0;
         int comCount = 0, apiCount = 0;
         int archSkipCount = 0, nestedSkipCount = 0, delegateSkipCount = 0, otherSkipCount = 0;
         int errorCount = 0;
@@ -157,6 +157,7 @@ public sealed class TypeExtractor
                 Win32Type? extracted = kind.Value switch
                 {
                     TypeKind.Handle => ExtractHandle(reader, typeDef, assemblyName, version, attrs),
+                    TypeKind.NativeTypedef => ExtractNativeTypedef(reader, typeDef, assemblyName, version, attrs),
                     TypeKind.Struct => ExtractStruct(reader, typeDef, assemblyName, version, attrs),
                     TypeKind.Enum => ExtractEnum(reader, typeDef, assemblyName, version, attrs),
                     TypeKind.ComInterface => _comExtractor.ExtractComInterface(reader, typeDef, assemblyName, version, attrs),
@@ -172,6 +173,9 @@ public sealed class TypeExtractor
                     {
                         case HandleType:
                             Interlocked.Increment(ref handleCount);
+                            break;
+                        case NativeTypedefType:
+                            Interlocked.Increment(ref typedefCount);
                             break;
                         case StructType:
                             Interlocked.Increment(ref structCount);
@@ -196,7 +200,7 @@ public sealed class TypeExtractor
         });
 
         return new ExtractionCounts(
-            structCount, handleCount, enumCount,
+            structCount, handleCount, typedefCount, enumCount,
             comCount, apiCount,
             archSkipCount, nestedSkipCount, delegateSkipCount, otherSkipCount,
             errorCount);
@@ -204,7 +208,7 @@ public sealed class TypeExtractor
 
     // --- Type classification ---
 
-    private enum TypeKind { Struct, Handle, Enum, ComInterface, ApiType }
+    private enum TypeKind { Struct, Handle, NativeTypedef, Enum, ComInterface, ApiType }
 
     private enum SkipReason { Module, NotTypeReference, Delegate, Attribute, Nested }
 
@@ -265,6 +269,7 @@ public sealed class TypeExtractor
         {
             "Enum" => TypeKind.Enum,
             "Struct" or "ValueType" when attrs.IsHandle => TypeKind.Handle,
+            "Struct" or "ValueType" when attrs.IsNativeTypedef => TypeKind.NativeTypedef,
             "Struct" or "ValueType" => TypeKind.Struct,
             _ => null
         };
@@ -398,6 +403,68 @@ public sealed class TypeExtractor
             fqn, string.Join(", ", invalidValues), freeFunc?.Name ?? "null");
 
         return result;
+    }
+
+    // --- NativeTypedef extraction ---
+
+    /// <summary>
+    /// Extract a NativeTypedefType from a TypeDefinition. The typedef's underlying
+    /// type is read from its single field's signature.
+    /// </summary>
+    private NativeTypedefType ExtractNativeTypedef(
+        MetadataReader reader, TypeDefinition typeDef,
+        string assemblyName, string version, TypeAttrs attrs)
+    {
+        string typeName = reader.GetString(typeDef.Name);
+        string typeNamespace = reader.GetString(typeDef.Namespace);
+        string fqn = $"{typeNamespace}.{typeName}";
+
+        TypeIdentity identity = BuildIdentity(fqn, attrs);
+
+        // Decode the single field's signature to get the underlying type
+        FieldDefinitionHandle hField = typeDef.GetFields().Single();
+        FieldDefinition fieldDef = reader.GetFieldDefinition(hField);
+        ResolvedType underlying = fieldDef.DecodeSignature(new SignatureDecoder(reader, _loader, _logger, typeDef), new());
+
+        // Get API documentation
+        ApiDetails? apiDetails = _docs.GetApiDetails(reader, typeDef);
+
+        // Imports for the underlying type, if it references another named type
+        ImportCollection imports = new();
+        foreach (string refFqn in CollectTypeReferenceFqns(underlying))
+            imports.AddType(refFqn);
+
+        string displayName = DeconflictName(typeName);
+
+        NativeTypedefType result = new()
+        {
+            Identity = identity,
+            Name = displayName,
+            CanonicalName = typeName,
+            AssemblyName = assemblyName,
+            MetadataVersion = version,
+            Flags = attrs.Flags,
+            Underlying = underlying,
+            Description = apiDetails?.Description,
+            Remarks = apiDetails?.Remarks,
+            HelpLink = apiDetails?.HelpLink,
+            DeprecationMessage = attrs.DeprecationMessage,
+            SupportedOSPlatform = attrs.SupportedOSPlatform,
+            Imports = imports
+        };
+
+        _logger.LogDebug("Extracted NativeTypedefType {FQN} (underlying={Underlying})",
+            fqn, underlying.DisplayName);
+
+        return result;
+    }
+
+    /// <summary>Collect FQN references from a single ResolvedType (for typedef imports).</summary>
+    private static List<string> CollectTypeReferenceFqns(ResolvedType type)
+    {
+        List<string> refs = [];
+        CollectTypeReferences(type, refs);
+        return refs;
     }
 
     // --- Enum extraction ---

--- a/Generator/Metadata/TypeExtractor.cs
+++ b/Generator/Metadata/TypeExtractor.cs
@@ -298,8 +298,10 @@ public sealed class TypeExtractor
         StructLayout layout = _fieldExtractor.ExtractFields(
             reader, typeDef, layoutKind, packingSize, isUnion, isAnsi, fqn, apiFields);
 
-        // Build referenced types list
-        List<string> referencedTypes = CollectStructReferencedTypes(layout.Fields);
+        // Build imports
+        ImportCollection imports = new();
+        foreach (string refFqn in CollectStructReferencedTypes(layout.Fields))
+            imports.AddType(refFqn);
 
         // Name deconfliction
         string displayName = DeconflictName(typeName);
@@ -322,7 +324,7 @@ public sealed class TypeExtractor
             HelpLink = apiDetails?.HelpLink,
             DeprecationMessage = attrs.DeprecationMessage,
             SupportedOSPlatform = attrs.SupportedOSPlatform,
-            ReferencedTypes = referencedTypes,
+            Imports = imports,
             IsNested = typeDef.IsNested
         };
 
@@ -360,10 +362,12 @@ public sealed class TypeExtractor
         IReadOnlyList<long> invalidValues = AttributeReader.DecodeInvalidHandleValues(attrs.All);
         FreeFuncRef? freeFunc = AttributeReader.DecodeRAIIFreeFunc(attrs.All, typeNamespace);
 
-        // Build referenced types
-        List<string> referencedTypes = CollectStructReferencedTypes(layout.Fields);
+        // Build imports
+        ImportCollection imports = new();
+        foreach (string refFqn in CollectStructReferencedTypes(layout.Fields))
+            imports.AddType(refFqn);
         if (freeFunc != null)
-            referencedTypes.Add(freeFunc.ApisFQN);
+            imports.AddFunction(freeFunc.ApisFQN, freeFunc.Name);
 
         string displayName = DeconflictName(typeName);
 
@@ -386,7 +390,7 @@ public sealed class TypeExtractor
             HelpLink = apiDetails?.HelpLink,
             DeprecationMessage = attrs.DeprecationMessage,
             SupportedOSPlatform = attrs.SupportedOSPlatform,
-            ReferencedTypes = referencedTypes,
+            Imports = imports,
             IsNested = typeDef.IsNested
         };
 
@@ -485,10 +489,10 @@ public sealed class TypeExtractor
             .Select(methodDef => _methodExtractor.ExtractMethod(reader, methodDef, typeNamespace))
             .OfType<MethodMember>()];
             
-        // Collect referenced types from both constants and methods
-        List<string> referencedTypes =[
-            .. constants.SelectMany(c => c.ReferencedTypes), 
-            .. methods.SelectMany(m => m.ReferencedTypes)];
+        // Collect imports from both constants and methods
+        ImportCollection imports = new();
+        imports.MergeFrom(constants.Select(c => c.Imports));
+        imports.MergeFrom(methods.Select(m => m.Imports));
 
         string displayName = DeconflictName(typeName);
 
@@ -507,7 +511,7 @@ public sealed class TypeExtractor
             HelpLink = apiDetails?.HelpLink,
             DeprecationMessage = attrs.DeprecationMessage,
             SupportedOSPlatform = attrs.SupportedOSPlatform,
-            ReferencedTypes = referencedTypes.Distinct().ToList()
+            Imports = imports
         };
 
         _logger.LogDebug("Extracted ApiType {FQN} ({ConstantCount} constants, {MethodCount} methods)",
@@ -620,7 +624,7 @@ public sealed class TypeExtractor
                 Description = description,
                 IsDeprecated = fieldAttrs.IsDeprecated,
                 DeprecationMessage = fieldAttrs.DeprecationMessage,
-                ReferencedTypes = [structFqn]
+                Imports = MakeTypeImports(structFqn)
             };
         }
 
@@ -650,7 +654,6 @@ public sealed class TypeExtractor
         List<StructFieldInit> fieldInits = BuildStructFieldInits(structReader, structTypeDef, values, "value");
 
         bool needsGuid = fieldInits.Any(f => f.Kind == StructFieldInitKind.GuidPointer);
-        List<string> referencedTypes = [structFqn];
 
         return new ConstantMember
         {
@@ -662,7 +665,7 @@ public sealed class TypeExtractor
             IsDeprecated = fieldAttrs.IsDeprecated,
             DeprecationMessage = fieldAttrs.DeprecationMessage,
             NeedsGuid = needsGuid,
-            ReferencedTypes = referencedTypes
+            Imports = MakeTypeImports(structFqn)
         };
     }
 
@@ -896,6 +899,16 @@ public sealed class TypeExtractor
             return $"Win32{candidate}";
 
         return candidate;
+    }
+
+    /// <summary>
+    /// Construct a single-type ImportCollection.
+    /// </summary>
+    private static ImportCollection MakeTypeImports(string fqn)
+    {
+        var c = new ImportCollection();
+        c.AddType(fqn);
+        return c;
     }
 
     /// <summary>

--- a/Generator/Metadata/TypeExtractor.cs
+++ b/Generator/Metadata/TypeExtractor.cs
@@ -86,11 +86,12 @@ public sealed class TypeExtractor
                 asmWatch.Elapsed.TotalSeconds
             );
             _logger.LogInformation(
-                "  Skipped: {Arch} arch-filtered, {Nested} nested, {Delegate} delegates, {Other} other, {Errors} errors",
+                "  Skipped: {Arch} arch-filtered, {Nested} nested, {Delegate} delegates, {Other} other, {MethodArch} arch-filtered methods, {Errors} errors",
                 counts.SkippedArch,
                 counts.SkippedNested,
                 counts.SkippedDelegate,
                 counts.SkippedOther,
+                counts.SkippedMethodsArch,
                 counts.Errors
             );
 
@@ -99,6 +100,14 @@ public sealed class TypeExtractor
                 _logger.LogWarning(
                     "Skipped {Count} types due to unsupported architecture (use --log-level Debug for details)",
                     counts.SkippedArch
+                );
+            }
+
+            if (counts.SkippedMethodsArch > 0)
+            {
+                _logger.LogWarning(
+                    "Skipped {Count} methods due to unsupported architecture (use --log-level Debug for details)",
+                    counts.SkippedMethodsArch
                 );
             }
         }
@@ -127,6 +136,7 @@ public sealed class TypeExtractor
         int SkippedNested,
         int SkippedDelegate,
         int SkippedOther,
+        int SkippedMethodsArch,
         int Errors
     );
 
@@ -150,6 +160,7 @@ public sealed class TypeExtractor
             nestedSkipCount = 0,
             delegateSkipCount = 0,
             otherSkipCount = 0;
+        int archMethodSkipCount = 0;
         int errorCount = 0;
 
         reader
@@ -209,22 +220,48 @@ public sealed class TypeExtractor
                         return;
                     }
 
-                    Win32Type? extracted = kind.Value switch
+                    Win32Type? extracted;
+                    int methodArchSkips = 0;
+                    switch (kind.Value)
                     {
-                        TypeKind.Handle => ExtractHandle(reader, typeDef, assemblyName, version, attrs),
-                        TypeKind.NativeTypedef => ExtractNativeTypedef(reader, typeDef, assemblyName, version, attrs),
-                        TypeKind.Struct => ExtractStruct(reader, typeDef, assemblyName, version, attrs),
-                        TypeKind.Enum => ExtractEnum(reader, typeDef, assemblyName, version, attrs),
-                        TypeKind.ComInterface => _comExtractor.ExtractComInterface(
-                            reader,
-                            typeDef,
-                            assemblyName,
-                            version,
-                            attrs
-                        ),
-                        TypeKind.ApiType => ExtractApiType(reader, typeDef, assemblyName, version, attrs),
-                        _ => null,
-                    };
+                        case TypeKind.Handle:
+                            extracted = ExtractHandle(reader, typeDef, assemblyName, version, attrs);
+                            break;
+                        case TypeKind.NativeTypedef:
+                            extracted = ExtractNativeTypedef(reader, typeDef, assemblyName, version, attrs);
+                            break;
+                        case TypeKind.Struct:
+                            extracted = ExtractStruct(reader, typeDef, assemblyName, version, attrs);
+                            break;
+                        case TypeKind.Enum:
+                            extracted = ExtractEnum(reader, typeDef, assemblyName, version, attrs);
+                            break;
+                        case TypeKind.ComInterface:
+                            extracted = _comExtractor.ExtractComInterface(
+                                reader,
+                                typeDef,
+                                assemblyName,
+                                version,
+                                attrs,
+                                out methodArchSkips
+                            );
+                            break;
+                        case TypeKind.ApiType:
+                            extracted = ExtractApiType(
+                                reader,
+                                typeDef,
+                                assemblyName,
+                                version,
+                                attrs,
+                                out methodArchSkips
+                            );
+                            break;
+                        default:
+                            extracted = null;
+                            break;
+                    }
+                    if (methodArchSkips > 0)
+                        Interlocked.Add(ref archMethodSkipCount, methodArchSkips);
 
                     if (extracted != null)
                     {
@@ -271,6 +308,7 @@ public sealed class TypeExtractor
             nestedSkipCount,
             delegateSkipCount,
             otherSkipCount,
+            archMethodSkipCount,
             errorCount
         );
     }
@@ -670,7 +708,8 @@ public sealed class TypeExtractor
         TypeDefinition typeDef,
         string assemblyName,
         string version,
-        TypeAttrs attrs
+        TypeAttrs attrs,
+        out int archMethodSkips
     )
     {
         string typeName = reader.GetString(typeDef.Name);
@@ -693,16 +732,23 @@ public sealed class TypeExtractor
                 .OfType<ConstantMember>(),
         ];
 
-        // Extract methods, deduplicating by name (matching legacy AhkApiType behavior)
-        List<MethodMember> methods =
-        [
-            .. typeDef
+        // Extract methods, deduplicating by name (matching legacy AhkApiType behavior).
+        // Track arch-filtered skips so the caller can surface a count to the user.
+        List<MethodMember> methods = [];
+        archMethodSkips = 0;
+        foreach (
+            MethodDefinition methodDef in typeDef
                 .GetMethods()
                 .Select(reader.GetMethodDefinition)
                 .DistinctBy(methodDef => reader.GetString(methodDef.Name))
-                .Select(methodDef => _methodExtractor.ExtractMethod(reader, methodDef, typeNamespace))
-                .OfType<MethodMember>(),
-        ];
+        )
+        {
+            MethodExtractionResult methodResult = _methodExtractor.ExtractMethod(reader, methodDef, typeNamespace);
+            if (methodResult.Method != null)
+                methods.Add(methodResult.Method);
+            else if (methodResult.SkipReason == MethodSkipReason.ArchFiltered)
+                archMethodSkips++;
+        }
 
         // Collect imports from both constants and methods
         ImportCollection imports = new();

--- a/Generator/Metadata/TypeExtractor.cs
+++ b/Generator/Metadata/TypeExtractor.cs
@@ -958,9 +958,7 @@ public sealed class TypeExtractor
     /// </summary>
     private string DeconflictName(string name)
     {
-        string candidate = name.EndsWith("_e__Struct")
-            ? name[..^"_e__Struct".Length]
-            : name;
+        string candidate = SignatureDecoder.StripGeneratedSuffix(name);
 
         if (_reservedNames.Contains(candidate))
             return $"Win32{candidate}";

--- a/Generator/Metadata/TypeExtractor.cs
+++ b/Generator/Metadata/TypeExtractor.cs
@@ -451,6 +451,11 @@ public sealed class TypeExtractor
         // Name deconfliction
         string displayName = DeconflictName(typeName);
 
+        // NOTE: [AlsoUsableFor] is deliberately NOT copied onto plain structs. The
+        // implicit-conversion mechanism is the scalar `__value` setter, which only
+        // single-field value types (HandleType/NativeTypedefType) emit. The lone
+        // struct->struct pair (DEVPROPKEY->PROPERTYKEY) has no `__value` to convert
+        // through, so carrying the attribute here would only produce a dead relationship.
         StructType result = new()
         {
             Identity = identity,
@@ -552,6 +557,7 @@ public sealed class TypeExtractor
             SupportedOSPlatform = attrs.SupportedOSPlatform,
             Imports = imports,
             IsNested = typeDef.IsNested,
+            AlsoUsableFor = attrs.AlsoUsableFor.Count > 0 ? attrs.AlsoUsableFor : null,
         };
 
         _logger.LogDebug(
@@ -615,6 +621,7 @@ public sealed class TypeExtractor
             HelpLink = apiDetails?.HelpLink,
             DeprecationMessage = attrs.DeprecationMessage,
             SupportedOSPlatform = attrs.SupportedOSPlatform,
+            AlsoUsableFor = attrs.AlsoUsableFor.Count > 0 ? attrs.AlsoUsableFor : null,
             Imports = imports,
         };
 

--- a/Generator/Program.cs
+++ b/Generator/Program.cs
@@ -157,7 +157,7 @@ public class Program
             new ComInterfaceEmitter(registry, ahkVersion)
         ];
         if (ahkVersion is AhkVersion.v21)
-            emitters = [.. emitters, new ApiConstantsEmitter21()];
+            emitters = [.. emitters, new ApiConstantsEmitter21(), new NativeTypedefEmitter21()];
         var pipeline = new TypeEmissionPipeline(emitters, loggerFactory.CreateLogger<TypeEmissionPipeline>(), maxParallelism);
         var (emitted, _, errors) = pipeline.EmitAll(registry, outputPath,
             namespaceFilter.Length > 0 ? namespaceFilter : null);

--- a/Generator/Program.cs
+++ b/Generator/Program.cs
@@ -191,6 +191,9 @@ public class Program
         );
         extensionApplier.Apply(registry, Path.Join(metadataPath, "extensions"));
 
+        var alsoUsableForResolver = new AlsoUsableForResolver(loggerFactory.CreateLogger<AlsoUsableForResolver>());
+        alsoUsableForResolver.Apply(registry);
+
         // Break struct import cycles (v2.1): mark pointer-to-struct fields on a cycle so the
         // emitter renders them as lazy accessors instead of eager X.Ptr typed properties.
         var cycleBreaker = new CyclicPointerBreaker(loggerFactory.CreateLogger<CyclicPointerBreaker>());

--- a/Generator/Program.cs
+++ b/Generator/Program.cs
@@ -147,8 +147,8 @@ public class Program
         // Emit
         ITypeEmitter[] emitters = [
             new EnumEmitter(),
-            new HandleEmitter(),
-            new StructEmitter(registry),
+            ahkVersion is AhkVersion.v21 ? new HandleEmitter21() : new HandleEmitter(),
+            ahkVersion is AhkVersion.v21 ? new StructEmitter21(registry) : new StructEmitter(registry),
             ahkVersion switch {
                 AhkVersion.v20 => new ApiTypeEmitter(registry),
                 AhkVersion.v21 => new ApiTypeEmitter21(registry),

--- a/Generator/Program.cs
+++ b/Generator/Program.cs
@@ -183,6 +183,11 @@ public class Program
         );
         extensionApplier.Apply(registry, Path.Join(metadataPath, "extensions"));
 
+        // Break struct import cycles (v2.1): mark pointer-to-struct fields on a cycle so the
+        // emitter renders them as lazy accessors instead of eager X.Ptr typed properties.
+        var cycleBreaker = new CyclicPointerBreaker(loggerFactory.CreateLogger<CyclicPointerBreaker>());
+        cycleBreaker.Apply(registry);
+
         // Emit
         ITypeEmitter[] emitters =
         [

--- a/Generator/Program.cs
+++ b/Generator/Program.cs
@@ -199,6 +199,14 @@ public class Program
         var cycleBreaker = new CyclicPointerBreaker(loggerFactory.CreateLogger<CyclicPointerBreaker>());
         cycleBreaker.Apply(registry);
 
+        // Mark handle types that need an `OwnedWith(...)` factory (returned/output with a context-
+        // specific RAIIFree that differs from their default). v2.1 emission concern only.
+        if (ahkVersion is AhkVersion.v21)
+        {
+            var ownedHandleResolver = new OwnedHandleResolver(loggerFactory.CreateLogger<OwnedHandleResolver>());
+            ownedHandleResolver.Apply(registry);
+        }
+
         // Emit
         ITypeEmitter[] emitters =
         [

--- a/Generator/Program.cs
+++ b/Generator/Program.cs
@@ -195,9 +195,7 @@ public class Program
                 AhkVersion.v21 => new ApiTypeEmitter21(registry),
                 _ => throw new NotImplementedException($"Unknown AHK version \"{ahkVersion}\""),
             },
-            ahkVersion is AhkVersion.v21
-                ? new ComInterfaceEmitter21(registry)
-                : new ComInterfaceEmitter(registry),
+            ahkVersion is AhkVersion.v21 ? new ComInterfaceEmitter21(registry) : new ComInterfaceEmitter(registry),
         ];
         if (ahkVersion is AhkVersion.v21)
             emitters = [.. emitters, new ApiConstantsEmitter21(), new NativeTypedefEmitter21()];

--- a/Generator/Program.cs
+++ b/Generator/Program.cs
@@ -192,13 +192,18 @@ public class Program
             ahkVersion switch
             {
                 AhkVersion.v20 => new ApiTypeEmitter(registry),
-                AhkVersion.v21 => new ApiTypeEmitter21(registry),
+                AhkVersion.v21 => new ApiTypeEmitter21(registry, loggerFactory.CreateLogger<ApiTypeEmitter21>()),
                 _ => throw new NotImplementedException($"Unknown AHK version \"{ahkVersion}\""),
             },
             ahkVersion is AhkVersion.v21 ? new ComInterfaceEmitter21(registry) : new ComInterfaceEmitter(registry),
         ];
         if (ahkVersion is AhkVersion.v21)
-            emitters = [.. emitters, new ApiConstantsEmitter21(), new NativeTypedefEmitter21()];
+            emitters =
+            [
+                .. emitters,
+                new ApiConstantsEmitter21(registry, loggerFactory.CreateLogger<ApiConstantsEmitter21>()),
+                new NativeTypedefEmitter21(),
+            ];
         var pipeline = new TypeEmissionPipeline(
             emitters,
             loggerFactory.CreateLogger<TypeEmissionPipeline>(),

--- a/Generator/Program.cs
+++ b/Generator/Program.cs
@@ -31,6 +31,10 @@ public class Program
         };
         assemblyOption.AddAlias("-a");
 
+        var versionOption = new Option<string>("--ahk-version", () => "2.0", "AutoHotkey version to emit for (2.0 or 2.1)")
+            .FromAmong("2.0", "2.1");
+        versionOption.AddAlias("-v");
+
         var logLevelOption = new Option<LogLevel>("--log-level", () => LogLevel.Information, "Minimum log level");
         var logFileOption = new Option<FileInfo?>("--log-file", "Write log output to a file");
         var maxParallelismOption = new Option<int>("--max-parallelism",
@@ -41,6 +45,7 @@ public class Program
         {
             metadataDirArg,
             outputDirArg,
+            versionOption,
             namespaceOption,
             assemblyOption,
             logLevelOption,
@@ -50,17 +55,31 @@ public class Program
 
         int exitCode = 0;
         rootCommand.SetHandler(
-            (metadataDir, outputDir, namespaceFilter, assemblyFilter, logLevel, logFile, maxParallelism) =>
+            (metadataDir, outputDir, ahkVersion, namespaceFilter, assemblyFilter, logLevel, logFile, maxParallelism) =>
             {
-                exitCode = RunGenerator(metadataDir, outputDir, namespaceFilter ?? [], assemblyFilter ?? [], logLevel, logFile, maxParallelism);
+                AhkVersion resolvedVersion = ahkVersion switch
+                {
+                    "2.0" => AhkVersion.v20,
+                    "2.1" => AhkVersion.v21,
+                    _ => throw new NotImplementedException($"Unknown AHK version \"{ahkVersion}\"")
+                };
+                exitCode = RunGenerator(metadataDir, outputDir, resolvedVersion, namespaceFilter ?? [], assemblyFilter ?? [], logLevel, logFile, maxParallelism);
             },
-            metadataDirArg, outputDirArg, namespaceOption, assemblyOption, logLevelOption, logFileOption, maxParallelismOption);
+            metadataDirArg, outputDirArg, versionOption, namespaceOption, assemblyOption, logLevelOption, logFileOption, maxParallelismOption);
 
         rootCommand.Invoke(args);
         return exitCode;
     }
 
-    private static int RunGenerator(DirectoryInfo metadataDir, DirectoryInfo outputDir, string[] namespaceFilter, string[] assemblyFilter, LogLevel logLevel, FileInfo? logFile, int maxParallelism = 0)
+    private static int RunGenerator(
+        DirectoryInfo metadataDir,
+        DirectoryInfo outputDir,
+        AhkVersion ahkVersion,
+        string[] namespaceFilter,
+        string[] assemblyFilter,
+        LogLevel logLevel,
+        FileInfo? logFile,
+        int maxParallelism = 0)
     {
         using var loggerFactory = LoggerFactory.Create(builder =>
         {
@@ -81,6 +100,7 @@ public class Program
         logger.LogInformation("Starting AhkWin32Structs Generator...");
         logger.LogInformation("Metadata Directory: {MetadataDir}", metadataPath);
         logger.LogInformation("Output Directory: {OutputDir}", outputPath);
+        logger.LogInformation("Emitting for AutoHotkey v{version}", ahkVersion.ToFriendlyString());
 
         // -1 is no hard max, which we want to allow
         // See https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.paralleloptions.maxdegreeofparallelism?view=net-10.0
@@ -129,7 +149,11 @@ public class Program
             new EnumEmitter(),
             new HandleEmitter(),
             new StructEmitter(registry),
-            new ApiTypeEmitter(registry),
+            ahkVersion switch {
+                AhkVersion.v20 => new ApiTypeEmitter(registry),
+                AhkVersion.v21 => new ApiTypeEmitter21(registry),
+                _ => throw new NotImplementedException($"Unknown AHK version \"{ahkVersion}\"")
+            },
             new ComInterfaceEmitter(registry)
         ];
         var pipeline = new TypeEmissionPipeline(emitters, loggerFactory.CreateLogger<TypeEmissionPipeline>(), maxParallelism);

--- a/Generator/Program.cs
+++ b/Generator/Program.cs
@@ -170,6 +170,14 @@ public class Program
         var extractor = new TypeExtractor(loader, docs, loggerFactory, reservedNames, maxParallelism);
         TypeRegistry registry = extractor.ExtractAll();
 
+        // Inject synthetic types (e.g. WCHAR) before transforms so extensions can attach.
+        // v2.1 only — the v2.0 emitter handles fixed char arrays via StringType/StrGet/StrPut.
+        if (ahkVersion is AhkVersion.v21)
+        {
+            var syntheticProvider = new SyntheticTypeProvider(loggerFactory.CreateLogger<SyntheticTypeProvider>());
+            syntheticProvider.Apply(registry);
+        }
+
         // Transforms
         var overrideApplier = new OverrideApplier(
             new OverrideReader(loggerFactory.CreateLogger<OverrideReader>(), maxParallelism),

--- a/Generator/Program.cs
+++ b/Generator/Program.cs
@@ -146,7 +146,7 @@ public class Program
 
         // Emit
         ITypeEmitter[] emitters = [
-            new EnumEmitter(),
+            ahkVersion is AhkVersion.v21 ? new EnumEmitter21() : new EnumEmitter(),
             ahkVersion is AhkVersion.v21 ? new HandleEmitter21() : new HandleEmitter(),
             ahkVersion is AhkVersion.v21 ? new StructEmitter21(registry) : new StructEmitter(registry),
             ahkVersion switch {

--- a/Generator/Program.cs
+++ b/Generator/Program.cs
@@ -16,32 +16,48 @@ public class Program
 {
     public static int Main(string[] args)
     {
-        var metadataDirArg = new Argument<DirectoryInfo>("metadata-dir", "Path to directory containing .winmd files and metadata");
-        var outputDirArg = new Argument<DirectoryInfo>("output-dir", "Path to output directory for generated .ahk files");
+        var metadataDirArg = new Argument<DirectoryInfo>(
+            "metadata-dir",
+            "Path to directory containing .winmd files and metadata"
+        );
+        var outputDirArg = new Argument<DirectoryInfo>(
+            "output-dir",
+            "Path to output directory for generated .ahk files"
+        );
 
-        var namespaceOption = new Option<string[]>("--namespace", "Filter: only generate types in these namespaces (prefix match)")
+        var namespaceOption = new Option<string[]>(
+            "--namespace",
+            "Filter: only generate types in these namespaces (prefix match)"
+        )
         {
-            AllowMultipleArgumentsPerToken = true
+            AllowMultipleArgumentsPerToken = true,
         };
         namespaceOption.AddAlias("-n");
 
         var assemblyOption = new Option<string[]>("--assembly", "Filter: only process these .winmd assemblies")
         {
-            AllowMultipleArgumentsPerToken = true
+            AllowMultipleArgumentsPerToken = true,
         };
         assemblyOption.AddAlias("-a");
 
-        var versionOption = new Option<string>("--ahk-version", () => "2.0", "AutoHotkey version to emit for (2.0 or 2.1)")
-            .FromAmong("2.0", "2.1");
+        var versionOption = new Option<string>(
+            "--ahk-version",
+            () => "2.0",
+            "AutoHotkey version to emit for (2.0 or 2.1)"
+        ).FromAmong("2.0", "2.1");
         versionOption.AddAlias("-v");
 
         var logLevelOption = new Option<LogLevel>("--log-level", () => LogLevel.Information, "Minimum log level");
         var logFileOption = new Option<FileInfo?>("--log-file", "Write log output to a file");
-        var maxParallelismOption = new Option<int>("--max-parallelism",
+        var maxParallelismOption = new Option<int>(
+            "--max-parallelism",
             () => Environment.ProcessorCount,
-            $"Maximum degree of parallelism for extraction and emission (default: CPU count)");
+            $"Maximum degree of parallelism for extraction and emission (default: CPU count)"
+        );
 
-        var rootCommand = new RootCommand("AhkWin32Structs Generator — generates AutoHotkey v2 projections of Win32 and WDK APIs")
+        var rootCommand = new RootCommand(
+            "AhkWin32Structs Generator — generates AutoHotkey v2 projections of Win32 and WDK APIs"
+        )
         {
             metadataDirArg,
             outputDirArg,
@@ -50,7 +66,7 @@ public class Program
             assemblyOption,
             logLevelOption,
             logFileOption,
-            maxParallelismOption
+            maxParallelismOption,
         };
 
         int exitCode = 0;
@@ -61,11 +77,28 @@ public class Program
                 {
                     "2.0" => AhkVersion.v20,
                     "2.1" => AhkVersion.v21,
-                    _ => throw new NotImplementedException($"Unknown AHK version \"{ahkVersion}\"")
+                    _ => throw new NotImplementedException($"Unknown AHK version \"{ahkVersion}\""),
                 };
-                exitCode = RunGenerator(metadataDir, outputDir, resolvedVersion, namespaceFilter ?? [], assemblyFilter ?? [], logLevel, logFile, maxParallelism);
+                exitCode = RunGenerator(
+                    metadataDir,
+                    outputDir,
+                    resolvedVersion,
+                    namespaceFilter ?? [],
+                    assemblyFilter ?? [],
+                    logLevel,
+                    logFile,
+                    maxParallelism
+                );
             },
-            metadataDirArg, outputDirArg, versionOption, namespaceOption, assemblyOption, logLevelOption, logFileOption, maxParallelismOption);
+            metadataDirArg,
+            outputDirArg,
+            versionOption,
+            namespaceOption,
+            assemblyOption,
+            logLevelOption,
+            logFileOption,
+            maxParallelismOption
+        );
 
         rootCommand.Invoke(args);
         return exitCode;
@@ -79,7 +112,8 @@ public class Program
         string[] assemblyFilter,
         LogLevel logLevel,
         FileInfo? logFile,
-        int maxParallelism = 0)
+        int maxParallelism = 0
+    )
     {
         using var loggerFactory = LoggerFactory.Create(builder =>
         {
@@ -106,8 +140,11 @@ public class Program
         // See https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.paralleloptions.maxdegreeofparallelism?view=net-10.0
         if (maxParallelism == 0 || maxParallelism < -1)
         {
-            logger.LogWarning("Invalid --max-parallelism ({ARG}), using CPU count ({CPUS})",
-                maxParallelism, Environment.ProcessorCount);
+            logger.LogWarning(
+                "Invalid --max-parallelism ({ARG}), using CPU count ({CPUS})",
+                maxParallelism,
+                Environment.ProcessorCount
+            );
             maxParallelism = Environment.ProcessorCount;
         }
         logger.LogInformation("Max parallelism: {MaxParallelism}", maxParallelism);
@@ -136,31 +173,42 @@ public class Program
         // Transforms
         var overrideApplier = new OverrideApplier(
             new OverrideReader(loggerFactory.CreateLogger<OverrideReader>(), maxParallelism),
-            loggerFactory.CreateLogger<OverrideApplier>());
+            loggerFactory.CreateLogger<OverrideApplier>()
+        );
         overrideApplier.Apply(registry, Path.Join(metadataPath, "overrides"));
 
         var extensionApplier = new ExtensionApplier(
             new ExtensionReader(loggerFactory.CreateLogger<ExtensionReader>(), maxParallelism),
-            loggerFactory.CreateLogger<ExtensionApplier>());
+            loggerFactory.CreateLogger<ExtensionApplier>()
+        );
         extensionApplier.Apply(registry, Path.Join(metadataPath, "extensions"));
 
         // Emit
-        ITypeEmitter[] emitters = [
+        ITypeEmitter[] emitters =
+        [
             ahkVersion is AhkVersion.v21 ? new EnumEmitter21() : new EnumEmitter(),
             ahkVersion is AhkVersion.v21 ? new HandleEmitter21() : new HandleEmitter(),
             ahkVersion is AhkVersion.v21 ? new StructEmitter21(registry) : new StructEmitter(registry),
-            ahkVersion switch {
+            ahkVersion switch
+            {
                 AhkVersion.v20 => new ApiTypeEmitter(registry),
                 AhkVersion.v21 => new ApiTypeEmitter21(registry),
-                _ => throw new NotImplementedException($"Unknown AHK version \"{ahkVersion}\"")
+                _ => throw new NotImplementedException($"Unknown AHK version \"{ahkVersion}\""),
             },
-            new ComInterfaceEmitter(registry, ahkVersion)
+            new ComInterfaceEmitter(registry, ahkVersion),
         ];
         if (ahkVersion is AhkVersion.v21)
             emitters = [.. emitters, new ApiConstantsEmitter21(), new NativeTypedefEmitter21()];
-        var pipeline = new TypeEmissionPipeline(emitters, loggerFactory.CreateLogger<TypeEmissionPipeline>(), maxParallelism);
-        var (emitted, _, errors) = pipeline.EmitAll(registry, outputPath,
-            namespaceFilter.Length > 0 ? namespaceFilter : null);
+        var pipeline = new TypeEmissionPipeline(
+            emitters,
+            loggerFactory.CreateLogger<TypeEmissionPipeline>(),
+            maxParallelism
+        );
+        var (emitted, _, errors) = pipeline.EmitAll(
+            registry,
+            outputPath,
+            namespaceFilter.Length > 0 ? namespaceFilter : null
+        );
 
         // Write version.ini
         WriteVersionInfo(loader, metadataPath, outputPath, logger);
@@ -181,7 +229,8 @@ public class Program
         foreach (var (name, _, reader) in loader.GetPrimaryAssemblies())
         {
             string displayName = name.EndsWith(".winmd", StringComparison.OrdinalIgnoreCase)
-                ? name[..^".winmd".Length] : name;
+                ? name[..^".winmd".Length]
+                : name;
             AssemblyName asmName = reader.GetAssemblyDefinition().GetAssemblyName();
             versionInfo.AppendLine($"{displayName} = {asmName.Version}");
         }

--- a/Generator/Program.cs
+++ b/Generator/Program.cs
@@ -156,6 +156,8 @@ public class Program
             },
             new ComInterfaceEmitter(registry, ahkVersion)
         ];
+        if (ahkVersion is AhkVersion.v21)
+            emitters = [.. emitters, new ApiConstantsEmitter21()];
         var pipeline = new TypeEmissionPipeline(emitters, loggerFactory.CreateLogger<TypeEmissionPipeline>(), maxParallelism);
         var (emitted, _, errors) = pipeline.EmitAll(registry, outputPath,
             namespaceFilter.Length > 0 ? namespaceFilter : null);

--- a/Generator/Program.cs
+++ b/Generator/Program.cs
@@ -154,7 +154,7 @@ public class Program
                 AhkVersion.v21 => new ApiTypeEmitter21(registry),
                 _ => throw new NotImplementedException($"Unknown AHK version \"{ahkVersion}\"")
             },
-            new ComInterfaceEmitter(registry)
+            new ComInterfaceEmitter(registry, ahkVersion)
         ];
         var pipeline = new TypeEmissionPipeline(emitters, loggerFactory.CreateLogger<TypeEmissionPipeline>(), maxParallelism);
         var (emitted, _, errors) = pipeline.EmitAll(registry, outputPath,

--- a/Generator/Program.cs
+++ b/Generator/Program.cs
@@ -195,7 +195,9 @@ public class Program
                 AhkVersion.v21 => new ApiTypeEmitter21(registry),
                 _ => throw new NotImplementedException($"Unknown AHK version \"{ahkVersion}\""),
             },
-            new ComInterfaceEmitter(registry, ahkVersion),
+            ahkVersion is AhkVersion.v21
+                ? new ComInterfaceEmitter21(registry)
+                : new ComInterfaceEmitter(registry),
         ];
         if (ahkVersion is AhkVersion.v21)
             emitters = [.. emitters, new ApiConstantsEmitter21(), new NativeTypedefEmitter21()];

--- a/Generator/Transform/AlsoUsableForResolver.cs
+++ b/Generator/Transform/AlsoUsableForResolver.cs
@@ -1,0 +1,48 @@
+namespace AhkWin32.Generator.Transform;
+
+using AhkWin32.Generator.Model;
+using AhkWin32.Generator.Model.Types;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Some types in the Win32 metadata are implicitly convertible to other types. This is noted with the [AlsoUsableFor]
+/// attribute, which carries the name of the type which the type the attribute applies to can be converted. This
+/// transform inverts this relationship, so every type which <em>can be converted to</em> knows which type(s) can
+/// convert to it.
+/// </summary>
+class AlsoUsableForResolver(ILogger logger)
+{
+    private readonly ILogger _logger = logger;
+
+    public void Apply(TypeRegistry registry)
+    {
+        foreach (var typedef in registry.GetAll().Where(t => t.AlsoUsableFor is not null))
+        {
+            _logger.LogTrace("Resolving [AlsoUsableFor] for {fqn}", typedef.FQN);
+
+            foreach (string name in typedef.AlsoUsableFor ?? [])
+            {
+                string targetFqn = $"{typedef.Namespace}.{name}";
+                Win32Type? target = registry.Resolve(targetFqn, typedef.Arch);
+                if (target is null)
+                {
+                    _logger.LogError(
+                        "'{name}' is also usable for '{target}', but failed to resolve '{fqn}'",
+                        typedef.FQN,
+                        name,
+                        targetFqn
+                    );
+                    continue;
+                }
+
+                AddConvertible(target, typedef);
+            }
+        }
+    }
+
+    private void AddConvertible(Win32Type to, Win32Type from)
+    {
+        to.ConvertibleFrom ??= [];
+        to.ConvertibleFrom.Add(from);
+    }
+}

--- a/Generator/Transform/CyclicPointerBreaker.cs
+++ b/Generator/Transform/CyclicPointerBreaker.cs
@@ -1,0 +1,293 @@
+namespace AhkWin32.Generator.Transform;
+
+using System.Diagnostics;
+using AhkWin32.Generator.Model;
+using AhkWin32.Generator.Model.Members;
+using AhkWin32.Generator.Model.Types;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Detects struct import cycles and marks the cuttable pointer edges so the emitter can break
+/// them with lazy accessors.
+///
+/// <para>
+/// Under v2.1, a struct's class initialization eagerly evaluates the type specifier of every
+/// field, including <c>X.Ptr</c> pointer fields. When two structs reference each other and at
+/// least one embeds the other <i>by value</i>, eagerly evaluating the pointer side deadlocks
+/// against the value side being mid-construction, producing a fatal, uncatchable
+/// "Cannot add typed property" load error.
+/// </para>
+///
+/// <para>
+/// A pure value-embed cycle is impossible (it would have infinite size), so every struct cycle
+/// contains at least one pointer edge. A pointer is always <c>A_PtrSize</c> regardless of its
+/// pointee (the C "forward declaration" principle), so making pointer fields resolve their
+/// pointee lazily (at call time, not class-init time) is always sufficient to break the cycle.
+/// This pass builds the load-time struct dependency graph, finds strongly-connected components,
+/// and flags every pointer-to-struct field whose pointee is in the same non-trivial SCC via
+/// <see cref="FieldMember.EmitAsLazyPointer"/>.
+/// </para>
+/// </summary>
+public sealed class CyclicPointerBreaker(ILogger<CyclicPointerBreaker> logger)
+{
+    private readonly ILogger<CyclicPointerBreaker> _logger = logger;
+
+    /// <summary>A pointer-to-struct field that could be cut to break a cycle.</summary>
+    private readonly record struct SoftEdge(FieldMember Field, string OwnerFqn, string PointeeFqn);
+
+    public void Apply(TypeRegistry registry)
+    {
+        var watch = Stopwatch.StartNew();
+
+        // Adjacency over struct FQNs (hard value-embed edges + soft pointer edges), plus the list
+        // of soft edges with their owning FieldMember so we can mark them once SCCs are known.
+        var graph = new Dictionary<string, HashSet<string>>();
+        var softEdges = new List<SoftEdge>();
+
+        foreach (StructType structType in registry.GetAll<StructType>())
+        {
+            string ownerFqn = structType.FQN;
+            graph.TryAdd(ownerFqn, []);
+            CollectEdges(registry, structType, ownerFqn, structType.Members, graph, softEdges);
+        }
+
+        if (softEdges.Count == 0)
+            return;
+
+        // Strongly-connected components over the combined graph.
+        Dictionary<string, int> sccId = ComputeSccs(graph, out int[] sccSize);
+
+        // Mark soft edges that stay within a single non-trivial SCC. Track the SCCs we actually
+        // broke this way so we can warn about any nontrivial SCC left with no scalar soft edge.
+        int markedFields = 0;
+        var brokenSccs = new HashSet<int>();
+        var cyclicSoftSccs = new HashSet<int>();
+
+        foreach (SoftEdge edge in softEdges)
+        {
+            if (
+                !sccId.TryGetValue(edge.OwnerFqn, out int owner) || !sccId.TryGetValue(edge.PointeeFqn, out int pointee)
+            )
+                continue;
+            if (owner != pointee || sccSize[owner] <= 1)
+                continue;
+
+            cyclicSoftSccs.Add(owner);
+            if (!edge.Field.EmitAsLazyPointer)
+            {
+                _logger.LogTrace(
+                    "Marking {ownerFqn}.{field} ({pointerFqn}*) as a lazy pointer",
+                    edge.OwnerFqn,
+                    edge.Field.Name,
+                    edge.PointeeFqn
+                );
+                edge.Field.EmitAsLazyPointer = true;
+                markedFields++;
+            }
+            brokenSccs.Add(owner);
+        }
+
+        watch.Stop();
+
+        _logger.LogInformation(
+            "Marked {FieldCount} pointer field(s) lazy across {SccCount} cyclic struct cluster(s) in {elapsed:F1}s",
+            markedFields,
+            brokenSccs.Count,
+            watch.Elapsed.TotalSeconds
+        );
+
+        WarnUnbrokenCycles(graph, sccId, sccSize, cyclicSoftSccs);
+    }
+
+    /// <summary>
+    /// Walk a struct's fields (recursing through embedded nested structs, whose field type
+    /// specifiers are also evaluated during the enclosing struct's class init) and record hard
+    /// (value-embed) and soft (pointer-to-struct) edges to other registered structs.
+    /// </summary>
+    private static void CollectEdges(
+        TypeRegistry registry,
+        StructType owner,
+        string ownerFqn,
+        IReadOnlyList<FieldMember> fields,
+        Dictionary<string, HashSet<string>> graph,
+        List<SoftEdge> softEdges
+    )
+    {
+        foreach (FieldMember field in fields)
+        {
+            // Nested struct definitions are emitted inside the enclosing class, so their field
+            // type specifiers run during the enclosing struct's init too — recurse for edges.
+            if (field.EmbeddedStruct is not null)
+                CollectEdges(registry, owner, ownerFqn, field.EmbeddedStruct.Members, graph, softEdges);
+
+            switch (field.Type)
+            {
+                // Soft edge: pointer-to-struct. Cuttable via a lazy accessor.
+                case PointerType { Pointee: StructRef ptrSr } when IsRegisteredStruct(registry, ptrSr.FQN):
+                    AddEdge(graph, ownerFqn, ptrSr.FQN);
+                    if (ptrSr.FQN != ownerFqn)
+                        softEdges.Add(new SoftEdge(field, ownerFqn, ptrSr.FQN));
+                    break;
+
+                // Hard edge: value-embedded struct (scalar or array). Cannot be cut.
+                case StructRef sr when IsRegisteredStruct(registry, sr.FQN):
+                    AddEdge(graph, ownerFqn, sr.FQN);
+                    break;
+
+                case ArrayType { ElementType: StructRef arrSr } when IsRegisteredStruct(registry, arrSr.FQN):
+                    AddEdge(graph, ownerFqn, arrSr.FQN);
+                    break;
+
+                // Array-of-pointer-to-struct is a soft edge in principle, but lazy emission for
+                // arrays is out of scope for v1. Still record the dependency so SCCs are accurate;
+                // WarnUnbrokenCycles surfaces any cluster that only such edges could break.
+                case ArrayType { ElementType: PointerType { Pointee: StructRef arrPtrSr } }
+                    when IsRegisteredStruct(registry, arrPtrSr.FQN):
+                    AddEdge(graph, ownerFqn, arrPtrSr.FQN);
+                    break;
+            }
+        }
+    }
+
+    private static bool IsRegisteredStruct(TypeRegistry registry, string fqn) => registry.Contains<StructType>(fqn);
+
+    private static void AddEdge(Dictionary<string, HashSet<string>> graph, string from, string to)
+    {
+        if (from == to)
+            return; // self edges never deadlock and never form a nontrivial SCC
+        if (!graph.TryGetValue(from, out HashSet<string>? targets))
+            graph[from] = targets = [];
+        targets.Add(to);
+        graph.TryAdd(to, []);
+    }
+
+    /// <summary>
+    /// Iterative <a href="https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm">Tarjan strongly-connected-components</a>.
+    /// Iterative to avoid stack overflow on the long dependency chains present in the metadata. Returns a node -&gt;
+    /// component-id map and fills <paramref name="sccSize"/> indexed by component id.
+    /// </summary>
+    private static Dictionary<string, int> ComputeSccs(Dictionary<string, HashSet<string>> graph, out int[] sccSize)
+    {
+        var index = new Dictionary<string, int>();
+        var lowlink = new Dictionary<string, int>();
+        var onStack = new HashSet<string>();
+        var tarjanStack = new Stack<string>();
+        var component = new Dictionary<string, int>();
+        var sizes = new List<int>();
+        int nextIndex = 0;
+        int nextScc = 0;
+
+        // Each work item is a node plus an enumerator cursor over its successors.
+        foreach (string root in graph.Keys)
+        {
+            if (index.ContainsKey(root))
+                continue;
+
+            var callStack = new Stack<(string Node, List<string> Succ, int Cursor)>();
+            index[root] = lowlink[root] = nextIndex++;
+            tarjanStack.Push(root);
+            onStack.Add(root);
+            callStack.Push((root, [.. graph[root]], 0));
+
+            while (callStack.Count > 0)
+            {
+                (string node, List<string> succ, int cursor) = callStack.Pop();
+
+                bool recursed = false;
+                while (cursor < succ.Count)
+                {
+                    string w = succ[cursor];
+                    cursor++;
+                    if (!index.ContainsKey(w))
+                    {
+                        // "Recurse" into w: save current frame, push child frame.
+                        callStack.Push((node, succ, cursor));
+                        index[w] = lowlink[w] = nextIndex++;
+                        tarjanStack.Push(w);
+                        onStack.Add(w);
+                        callStack.Push((w, graph.TryGetValue(w, out HashSet<string>? ws) ? [.. ws] : [], 0));
+                        recursed = true;
+                        break;
+                    }
+                    else if (onStack.Contains(w))
+                    {
+                        lowlink[node] = Math.Min(lowlink[node], index[w]);
+                    }
+                }
+
+                if (recursed)
+                    continue;
+
+                // Done with node: if it's a root of an SCC, pop the component.
+                if (lowlink[node] == index[node])
+                {
+                    int size = 0;
+                    while (true)
+                    {
+                        string member = tarjanStack.Pop();
+                        onStack.Remove(member);
+                        component[member] = nextScc;
+                        size++;
+                        if (member == node)
+                            break;
+                    }
+                    sizes.Add(size);
+                    nextScc++;
+                }
+
+                // Propagate lowlink to the parent frame (the next item on the call stack).
+                if (callStack.Count > 0)
+                {
+                    (string parent, List<string> psucc, int pcursor) = callStack.Pop();
+                    lowlink[parent] = Math.Min(lowlink[parent], lowlink[node]);
+                    callStack.Push((parent, psucc, pcursor));
+                }
+            }
+        }
+
+        sccSize = [.. sizes];
+        return component;
+    }
+
+    /// <summary>
+    /// Warn about any nontrivial SCC that no scalar soft edge could break (e.g. its only pointer
+    /// edges are array-of-pointer, currently unhandled). Such a cluster may still fail to load.
+    /// </summary>
+    private void WarnUnbrokenCycles(
+        Dictionary<string, HashSet<string>> graph,
+        Dictionary<string, int> sccId,
+        int[] sccSize,
+        HashSet<int> brokenSccs
+    )
+    {
+        // Group nodes by SCC for nontrivial components only.
+        var membersByScc = new Dictionary<int, List<string>>();
+        foreach ((string fqn, int id) in sccId)
+        {
+            if (sccSize[id] <= 1)
+                continue;
+            if (!membersByScc.TryGetValue(id, out List<string>? members))
+                membersByScc[id] = members = [];
+            members.Add(fqn);
+        }
+
+        foreach ((int id, List<string> members) in membersByScc)
+        {
+            if (brokenSccs.Contains(id))
+            {
+                _logger.LogDebug(
+                    "Cyclic struct cluster ({Size}): {Members}",
+                    members.Count,
+                    string.Join(", ", members)
+                );
+                continue;
+            }
+
+            _logger.LogWarning(
+                "Cyclic struct cluster of {Size} has no scalar pointer edge to cut and may fail to load: {Members}",
+                members.Count,
+                string.Join(", ", members)
+            );
+        }
+    }
+}

--- a/Generator/Transform/ExtensionApplier.cs
+++ b/Generator/Transform/ExtensionApplier.cs
@@ -43,8 +43,13 @@ public sealed class ExtensionApplier
             {
                 type.Extensions.AddRange(extensions);
                 foreach (var ext in extensions)
-                foreach (string req in ext.Requirements)
-                    type.Imports.AddType(req);
+                foreach (var (importFqn, names) in ext.Imports)
+                {
+                    if (names.Count == 0)
+                        type.Imports.AddType(importFqn);
+                    else
+                        type.Imports.AddFunctions(importFqn, names);
+                }
             }
 
             matchedTypes++;

--- a/Generator/Transform/ExtensionApplier.cs
+++ b/Generator/Transform/ExtensionApplier.cs
@@ -43,7 +43,8 @@ public sealed class ExtensionApplier
             {
                 type.Extensions.AddRange(extensions);
                 foreach (var ext in extensions)
-                    type.ReferencedTypes.AddRange(ext.Requirements);
+                    foreach (string req in ext.Requirements)
+                        type.Imports.AddType(req);
             }
 
             matchedTypes++;

--- a/Generator/Transform/ExtensionApplier.cs
+++ b/Generator/Transform/ExtensionApplier.cs
@@ -43,16 +43,19 @@ public sealed class ExtensionApplier
             {
                 type.Extensions.AddRange(extensions);
                 foreach (var ext in extensions)
-                    foreach (string req in ext.Requirements)
-                        type.Imports.AddType(req);
+                foreach (string req in ext.Requirements)
+                    type.Imports.AddType(req);
             }
 
             matchedTypes++;
             totalExtensions += extensions.Count;
         }
 
-        _logger.LogInformation("Applied {ExtCount} extension(s) to {TypeCount} type(s){Unmatched}",
-            totalExtensions, matchedTypes,
-            unmatchedFqns > 0 ? $" ({unmatchedFqns} unmatched FQN(s))" : "");
+        _logger.LogInformation(
+            "Applied {ExtCount} extension(s) to {TypeCount} type(s){Unmatched}",
+            totalExtensions,
+            matchedTypes,
+            unmatchedFqns > 0 ? $" ({unmatchedFqns} unmatched FQN(s))" : ""
+        );
     }
 }

--- a/Generator/Transform/ExtensionReader.cs
+++ b/Generator/Transform/ExtensionReader.cs
@@ -38,43 +38,59 @@ public sealed class ExtensionReader
         var watch = Stopwatch.StartNew();
 
         // Sort files for deterministic output ordering
-        string[] files = [.. Directory.GetFiles(extensionDirectoryPath)
-            .Where(f => Path.GetExtension(f).ToLowerInvariant() is ".yml" or ".yaml")
-            .OrderBy(f => Path.GetFileName(f), StringComparer.OrdinalIgnoreCase)];
+        string[] files =
+        [
+            .. Directory
+                .GetFiles(extensionDirectoryPath)
+                .Where(f => Path.GetExtension(f).ToLowerInvariant() is ".yml" or ".yaml")
+                .OrderBy(f => Path.GetFileName(f), StringComparer.OrdinalIgnoreCase),
+        ];
 
-        Parallel.ForEach(files, new ParallelOptions { MaxDegreeOfParallelism = _maxParallelism }, path =>
-        {
-            ExtensionDto dto;
-            try
+        Parallel.ForEach(
+            files,
+            new ParallelOptions { MaxDegreeOfParallelism = _maxParallelism },
+            path =>
             {
-                dto = deserializer.Deserialize<ExtensionDto>(File.ReadAllText(path));
-            }
-            catch (Exception ex) when (ex is YamlException or IOException)
-            {
-                _logger.LogError(ex, "Failed to deserialize extension \"{file}\"", Path.GetFileName(path));
-                return;
-            }
-
-            var extensionCode = new ExtensionCode(dto.Code, dto.Requires ?? []);
-
-            foreach (string fqn in dto.AddTo)
-            {
-                if (!extensions.TryGetValue(fqn, out List<ExtensionCode>? list))
+                ExtensionDto dto;
+                try
                 {
-                    list = [];
-                    extensions[fqn] = list;
+                    dto = deserializer.Deserialize<ExtensionDto>(File.ReadAllText(path));
+                }
+                catch (Exception ex) when (ex is YamlException or IOException)
+                {
+                    _logger.LogError(ex, "Failed to deserialize extension \"{file}\"", Path.GetFileName(path));
+                    return;
                 }
 
-                list.Add(extensionCode);
-            }
+                var extensionCode = new ExtensionCode(dto.Code, dto.Requires ?? []);
 
-            _logger.LogDebug("Loaded extension from {FileName}: {FqnCount} target(s), {ReqCount} requirement(s)",
-                Path.GetFileName(path), dto.AddTo.Count, dto.Requires?.Count ?? 0);
-        });
+                foreach (string fqn in dto.AddTo)
+                {
+                    if (!extensions.TryGetValue(fqn, out List<ExtensionCode>? list))
+                    {
+                        list = [];
+                        extensions[fqn] = list;
+                    }
+
+                    list.Add(extensionCode);
+                }
+
+                _logger.LogDebug(
+                    "Loaded extension from {FileName}: {FqnCount} target(s), {ReqCount} requirement(s)",
+                    Path.GetFileName(path),
+                    dto.AddTo.Count,
+                    dto.Requires?.Count ?? 0
+                );
+            }
+        );
 
         watch.Stop();
-        _logger.LogInformation("Loaded extensions for {fqns} types from {files} files in {time:F1}s", 
-            extensions.Count, files.Length, watch.Elapsed.TotalSeconds);
+        _logger.LogInformation(
+            "Loaded extensions for {fqns} types from {files} files in {time:F1}s",
+            extensions.Count,
+            files.Length,
+            watch.Elapsed.TotalSeconds
+        );
 
         return extensions.ToFrozenDictionary();
     }

--- a/Generator/Transform/ExtensionReader.cs
+++ b/Generator/Transform/ExtensionReader.cs
@@ -3,6 +3,7 @@ namespace AhkWin32.Generator.Transform;
 using System.Collections.Concurrent;
 using System.Collections.Frozen;
 using System.Diagnostics;
+using AhkWin32.Generator.Metadata;
 using AhkWin32.Generator.Model;
 using Microsoft.Extensions.Logging;
 using YamlDotNet.Core;
@@ -14,6 +15,8 @@ using YamlDotNet.Serialization;
 /// </summary>
 public sealed class ExtensionReader
 {
+    private const string SkipMarker = "skip";
+
     private readonly ILogger<ExtensionReader> _logger;
     private readonly int _maxParallelism;
 
@@ -25,7 +28,7 @@ public sealed class ExtensionReader
 
     /// <summary>
     /// Load all extension YAML files from the given directory.
-    /// Returns a dictionary mapping FQN → list of ExtensionCode blocks.
+    /// Returns a dictionary mapping FQN -> list of ExtensionCode blocks.
     /// </summary>
     public FrozenDictionary<string, List<ExtensionCode>> LoadExtensions(string extensionDirectoryPath)
     {
@@ -37,7 +40,6 @@ public sealed class ExtensionReader
 
         var watch = Stopwatch.StartNew();
 
-        // Sort files for deterministic output ordering
         string[] files =
         [
             .. Directory
@@ -62,7 +64,16 @@ public sealed class ExtensionReader
                     return;
                 }
 
-                var extensionCode = new ExtensionCode(dto.Code, dto.Requires ?? []);
+                ExtensionCode extensionCode;
+                try
+                {
+                    extensionCode = BuildExtensionCode(dto, Path.GetFileName(path));
+                }
+                catch (FormatException ex)
+                {
+                    _logger.LogError(ex, "Invalid extension \"{file}\": {message}", Path.GetFileName(path), ex.Message);
+                    return;
+                }
 
                 foreach (string fqn in dto.AddTo)
                 {
@@ -76,10 +87,11 @@ public sealed class ExtensionReader
                 }
 
                 _logger.LogDebug(
-                    "Loaded extension from {FileName}: {FqnCount} target(s), {ReqCount} requirement(s)",
+                    "Loaded extension from {FileName}: {FqnCount} target(s), {ImpCount} import(s), versions=[{Versions}]",
                     Path.GetFileName(path),
                     dto.AddTo.Count,
-                    dto.Requires?.Count ?? 0
+                    dto.Imports?.Count ?? 0,
+                    string.Join(",", extensionCode.CodeByVersion.Keys)
                 );
             }
         );
@@ -95,16 +107,62 @@ public sealed class ExtensionReader
         return extensions.ToFrozenDictionary();
     }
 
+    private static ExtensionCode BuildExtensionCode(ExtensionDto dto, string fileName)
+    {
+        Dictionary<AhkVersion, string> codeByVersion = [];
+        AddIfNotSkipped(codeByVersion, AhkVersion.v20, dto.Code.V20, "v20", fileName);
+        AddIfNotSkipped(codeByVersion, AhkVersion.v21, dto.Code.V21, "v21", fileName);
+
+        if (codeByVersion.Count == 0)
+            throw new FormatException($"extension \"{fileName}\" must target at least one of v20 or v21");
+
+        Dictionary<string, IReadOnlyList<string>> imports = [];
+        if (dto.Imports != null)
+        {
+            foreach (var (fqn, names) in dto.Imports)
+                imports[fqn] = (IReadOnlyList<string>?)names ?? [];
+        }
+
+        return new ExtensionCode(codeByVersion, imports);
+    }
+
+    private static void AddIfNotSkipped(
+        Dictionary<AhkVersion, string> map,
+        AhkVersion version,
+        string value,
+        string key,
+        string fileName
+    )
+    {
+        if (value == SkipMarker)
+            return;
+        if (string.IsNullOrWhiteSpace(value))
+            throw new FormatException($"extension \"{fileName}\" has empty code block for {key}");
+        map[version] = value;
+    }
+
     /// <summary>DTO for YamlDotNet deserialization of extension YAML files.</summary>
     private class ExtensionDto
     {
         [YamlMember(Alias = "add-to", ApplyNamingConventions = false)]
         public required List<string> AddTo { get; set; }
 
-        [YamlMember(Alias = "requires", ApplyNamingConventions = false)]
-        public List<string>? Requires { get; set; }
+        /// <summary>
+        /// FQN -> function-name list. Null or empty list means "whole-file include".
+        /// </summary>
+        [YamlMember(Alias = "imports", ApplyNamingConventions = false)]
+        public Dictionary<string, List<string>?>? Imports { get; set; }
 
         [YamlMember(Alias = "code", ApplyNamingConventions = false)]
-        public required string Code { get; set; }
+        public required CodeDto Code { get; set; }
+    }
+
+    private class CodeDto
+    {
+        [YamlMember(Alias = "v20", ApplyNamingConventions = false)]
+        public required string V20 { get; set; }
+
+        [YamlMember(Alias = "v21", ApplyNamingConventions = false)]
+        public required string V21 { get; set; }
     }
 }

--- a/Generator/Transform/OverrideApplier.cs
+++ b/Generator/Transform/OverrideApplier.cs
@@ -254,12 +254,8 @@ public sealed class OverrideApplier
                 var cloned = CloneMethod(sourceMethod, targetApi.Namespace);
                 targetApi.Methods.Add(cloned);
 
-                // Add referenced types from the cloned method
-                foreach (string refType in cloned.ReferencedTypes)
-                {
-                    if (!targetApi.ReferencedTypes.Contains(refType))
-                        targetApi.ReferencedTypes.Add(refType);
-                }
+                // Add imports from the cloned method
+                targetApi.Imports.MergeFrom(cloned.Imports);
 
                 _logger.LogDebug("Cloned method {Method} from {Source} to {Target}",
                     addRef.MethodName, addRef.SourceFQN, ov.FQN);
@@ -293,7 +289,7 @@ public sealed class OverrideApplier
             ReturnValueDoc = source.ReturnValueDoc,
             SupportedOSPlatform = source.SupportedOSPlatform,
             ShouldThrowOnHResult = source.ShouldThrowOnHResult,
-            ReferencedTypes = source.ReferencedTypes
+            Imports = source.Imports
         };
     }
 }

--- a/Generator/Transform/OverrideApplier.cs
+++ b/Generator/Transform/OverrideApplier.cs
@@ -43,8 +43,7 @@ public sealed class OverrideApplier
                 int removed = registry.Remove(ov.FQN);
                 if (removed > 0)
                 {
-                    _logger.LogDebug("Removed type {FQN} ({Count} variant(s)) via skip override",
-                        ov.FQN, removed);
+                    _logger.LogDebug("Removed type {FQN} ({Count} variant(s)) via skip override", ov.FQN, removed);
                     skipped += removed;
                 }
                 else
@@ -75,9 +74,12 @@ public sealed class OverrideApplier
             applied++;
         }
 
-        _logger.LogInformation("Applied {Applied} override(s), skipped {Skipped} type(s){Unmatched}",
-            applied, skipped,
-            unmatched > 0 ? $", {unmatched} unmatched" : "");
+        _logger.LogInformation(
+            "Applied {Applied} override(s), skipped {Skipped} type(s){Unmatched}",
+            applied,
+            skipped,
+            unmatched > 0 ? $", {unmatched} unmatched" : ""
+        );
     }
 
     private void ApplyTypeOverride(Win32Type type, TypeOverride ov)
@@ -88,13 +90,15 @@ public sealed class OverrideApplier
             if (type is StructType structType)
             {
                 structType.StructSizeFieldName = ov.StructSizeField;
-                _logger.LogDebug("Set StructSizeFieldName={Field} on {FQN}",
-                    ov.StructSizeField, ov.FQN);
+                _logger.LogDebug("Set StructSizeFieldName={Field} on {FQN}", ov.StructSizeField, ov.FQN);
             }
             else
             {
-                _logger.LogWarning("struct-size-field override on non-struct type {FQN} ({Kind})",
-                    ov.FQN, type.GetType().Name);
+                _logger.LogWarning(
+                    "struct-size-field override on non-struct type {FQN} ({Kind})",
+                    ov.FQN,
+                    type.GetType().Name
+                );
             }
         }
 
@@ -111,47 +115,51 @@ public sealed class OverrideApplier
         }
     }
 
-    private void ApplyFieldOverrides(StructType structType,
-        IReadOnlyDictionary<string, FieldOverride> fieldOverrides, string typeFqn)
+    private void ApplyFieldOverrides(
+        StructType structType,
+        IReadOnlyDictionary<string, FieldOverride> fieldOverrides,
+        string typeFqn
+    )
     {
         foreach (var (fieldName, fieldOv) in fieldOverrides)
         {
-            var field = structType.Members.FirstOrDefault(f =>
-                f.Name.Equals(fieldName, StringComparison.Ordinal));
+            var field = structType.Members.FirstOrDefault(f => f.Name.Equals(fieldName, StringComparison.Ordinal));
 
             if (field is null)
             {
-                _logger.LogWarning("Field override targets non-existent field {Type}.{Field}",
-                    typeFqn, fieldName);
+                _logger.LogWarning("Field override targets non-existent field {Type}.{Field}", typeFqn, fieldName);
                 continue;
             }
 
             if (fieldOv.AddAttributes != MemberFlags.None)
             {
                 field.Flags |= fieldOv.AddAttributes;
-                _logger.LogDebug("Added {Flags} to {Type}.{Field}",
-                    fieldOv.AddAttributes, typeFqn, fieldName);
+                _logger.LogDebug("Added {Flags} to {Type}.{Field}", fieldOv.AddAttributes, typeFqn, fieldName);
             }
         }
     }
 
-    private void ApplyMethodOverrides(ApiType apiType,
-        IReadOnlyDictionary<string, MethodOverride> methodOverrides, string typeFqn)
+    private void ApplyMethodOverrides(
+        ApiType apiType,
+        IReadOnlyDictionary<string, MethodOverride> methodOverrides,
+        string typeFqn
+    )
     {
         foreach (var (methodName, methodOv) in methodOverrides)
         {
             // Skip method: remove from the method list
             if (methodOv.Skip)
             {
-                int removed = apiType.Methods.RemoveAll(m =>
-                    m.Name.Equals(methodName, StringComparison.Ordinal));
+                int removed = apiType.Methods.RemoveAll(m => m.Name.Equals(methodName, StringComparison.Ordinal));
 
                 if (removed > 0)
-                    _logger.LogDebug("Removed method {Type}.{Method} via skip override",
-                        typeFqn, methodName);
+                    _logger.LogDebug("Removed method {Type}.{Method} via skip override", typeFqn, methodName);
                 else
-                    _logger.LogWarning("Method skip override targets non-existent method {Type}.{Method}",
-                        typeFqn, methodName);
+                    _logger.LogWarning(
+                        "Method skip override targets non-existent method {Type}.{Method}",
+                        typeFqn,
+                        methodName
+                    );
                 continue;
             }
 
@@ -159,13 +167,11 @@ public sealed class OverrideApplier
             if (methodOv.Parameters is not { Count: > 0 })
                 continue;
 
-            var method = apiType.Methods.FirstOrDefault(m =>
-                m.Name.Equals(methodName, StringComparison.Ordinal));
+            var method = apiType.Methods.FirstOrDefault(m => m.Name.Equals(methodName, StringComparison.Ordinal));
 
             if (method is null)
             {
-                _logger.LogWarning("Method override targets non-existent method {Type}.{Method}",
-                    typeFqn, methodName);
+                _logger.LogWarning("Method override targets non-existent method {Type}.{Method}", typeFqn, methodName);
                 continue;
             }
 
@@ -173,27 +179,38 @@ public sealed class OverrideApplier
         }
     }
 
-    private void ApplyParameterOverrides(MethodMember method,
+    private void ApplyParameterOverrides(
+        MethodMember method,
         IReadOnlyDictionary<string, ParameterOverride> paramOverrides,
-        string typeFqn, string methodName)
+        string typeFqn,
+        string methodName
+    )
     {
         foreach (var (paramName, paramOv) in paramOverrides)
         {
-            var param = method.Parameters.FirstOrDefault(p =>
-                p.Name.Equals(paramName, StringComparison.Ordinal));
+            var param = method.Parameters.FirstOrDefault(p => p.Name.Equals(paramName, StringComparison.Ordinal));
 
             if (param is null)
             {
-                _logger.LogWarning("Parameter override targets non-existent parameter {Type}.{Method}.{Param}",
-                    typeFqn, methodName, paramName);
+                _logger.LogWarning(
+                    "Parameter override targets non-existent parameter {Type}.{Method}.{Param}",
+                    typeFqn,
+                    methodName,
+                    paramName
+                );
                 continue;
             }
 
             if (paramOv.AddAttributes != ParameterFlags.None)
             {
                 param.Attributes |= paramOv.AddAttributes;
-                _logger.LogDebug("Added {Flags} to {Type}.{Method}.{Param}",
-                    paramOv.AddAttributes, typeFqn, methodName, paramName);
+                _logger.LogDebug(
+                    "Added {Flags} to {Type}.{Method}.{Param}",
+                    paramOv.AddAttributes,
+                    typeFqn,
+                    methodName,
+                    paramName
+                );
             }
         }
     }
@@ -224,12 +241,16 @@ public sealed class OverrideApplier
             }
 
             var sourceMethod = sourceApi.Methods.FirstOrDefault(m =>
-                m.Name.Equals(addRef.MethodName, StringComparison.Ordinal));
+                m.Name.Equals(addRef.MethodName, StringComparison.Ordinal)
+            );
 
             if (sourceMethod is null)
             {
-                _logger.LogWarning("add-methods: method {Method} not found in {SourceFQN}",
-                    addRef.MethodName, addRef.SourceFQN);
+                _logger.LogWarning(
+                    "add-methods: method {Method} not found in {SourceFQN}",
+                    addRef.MethodName,
+                    addRef.SourceFQN
+                );
                 continue;
             }
 
@@ -245,8 +266,11 @@ public sealed class OverrideApplier
                 // Check if method already exists in target
                 if (targetApi.Methods.Any(m => m.Name.Equals(addRef.MethodName, StringComparison.Ordinal)))
                 {
-                    _logger.LogDebug("Method {Method} already exists in {FQN} — skipping add-methods",
-                        addRef.MethodName, ov.FQN);
+                    _logger.LogDebug(
+                        "Method {Method} already exists in {FQN} — skipping add-methods",
+                        addRef.MethodName,
+                        ov.FQN
+                    );
                     continue;
                 }
 
@@ -257,8 +281,12 @@ public sealed class OverrideApplier
                 // Add imports from the cloned method
                 targetApi.Imports.MergeFrom(cloned.Imports);
 
-                _logger.LogDebug("Cloned method {Method} from {Source} to {Target}",
-                    addRef.MethodName, addRef.SourceFQN, ov.FQN);
+                _logger.LogDebug(
+                    "Cloned method {Method} from {Source} to {Target}",
+                    addRef.MethodName,
+                    addRef.SourceFQN,
+                    ov.FQN
+                );
             }
         }
     }
@@ -289,7 +317,7 @@ public sealed class OverrideApplier
             ReturnValueDoc = source.ReturnValueDoc,
             SupportedOSPlatform = source.SupportedOSPlatform,
             ShouldThrowOnHResult = source.ShouldThrowOnHResult,
-            Imports = source.Imports
+            Imports = source.Imports,
         };
     }
 }

--- a/Generator/Transform/OverrideApplier.cs
+++ b/Generator/Transform/OverrideApplier.cs
@@ -113,6 +113,41 @@ public sealed class OverrideApplier
         {
             ApplyMethodOverrides(apiType, ov.Methods, ov.FQN);
         }
+
+        // value-accessor (native typedefs and handles only — they share the v2.1 __value emitter)
+        if (ov.ValueAccessor is { } va)
+        {
+            ApplyValueAccessor(type, va, ov.FQN);
+        }
+    }
+
+    private void ApplyValueAccessor(Win32Type type, ValueAccessorOverride va, string typeFqn)
+    {
+        switch (type)
+        {
+            case NativeTypedefType typedef:
+                typedef.ValueGetterExpr = va.Getter;
+                typedef.ValueSetterCoerceExpr = va.SetterCoerce;
+                break;
+            case HandleType handle:
+                handle.ValueGetterExpr = va.Getter;
+                handle.ValueSetterCoerceExpr = va.SetterCoerce;
+                break;
+            default:
+                _logger.LogWarning(
+                    "value-accessor override on unsupported type {FQN} ({Kind}) — only native typedefs and handles are supported",
+                    typeFqn,
+                    type.GetType().Name
+                );
+                return;
+        }
+
+        _logger.LogDebug(
+            "Set value-accessor (getter={HasGetter}, setter-coerce={HasCoerce}) on {FQN}",
+            va.Getter is not null,
+            va.SetterCoerce is not null,
+            typeFqn
+        );
     }
 
     private void ApplyFieldOverrides(

--- a/Generator/Transform/OverrideReader.cs
+++ b/Generator/Transform/OverrideReader.cs
@@ -40,53 +40,71 @@ public sealed class OverrideReader
 
         var watch = Stopwatch.StartNew();
 
-        string[] files = [.. Directory.GetFiles(overrideDirectoryPath)
-            .Where(f => Path.GetExtension(f).ToLowerInvariant() is ".yml" or ".yaml")
-            .OrderBy(f => Path.GetFileName(f), StringComparer.OrdinalIgnoreCase)];
+        string[] files =
+        [
+            .. Directory
+                .GetFiles(overrideDirectoryPath)
+                .Where(f => Path.GetExtension(f).ToLowerInvariant() is ".yml" or ".yaml")
+                .OrderBy(f => Path.GetFileName(f), StringComparer.OrdinalIgnoreCase),
+        ];
 
-        Parallel.ForEach(files, new ParallelOptions { MaxDegreeOfParallelism = _maxParallelism }, path =>
-        {
-            List<OverrideEntryDto> entries;
-            try
+        Parallel.ForEach(
+            files,
+            new ParallelOptions { MaxDegreeOfParallelism = _maxParallelism },
+            path =>
             {
-                entries = deserializer.Deserialize<List<OverrideEntryDto>>(File.ReadAllText(path));
-            }
-            catch (Exception ex) when (ex is YamlException or IOException)
-            {
-                _logger.LogError(ex, "Failed to deserialize override file \"{File}\"", Path.GetFileName(path));
-                return;
-            }
-
-            if (entries == null)
-            {
-                _logger.LogDebug("Override file {File} is empty", Path.GetFileName(path));
-                return;
-            }
-
-            foreach (OverrideEntryDto entry in entries)
-            {
-                if (string.IsNullOrWhiteSpace(entry.Type))
+                List<OverrideEntryDto> entries;
+                try
                 {
-                    _logger.LogWarning("Override entry in {File} missing 'type' field — skipping", Path.GetFileName(path));
-                    continue;
+                    entries = deserializer.Deserialize<List<OverrideEntryDto>>(File.ReadAllText(path));
+                }
+                catch (Exception ex) when (ex is YamlException or IOException)
+                {
+                    _logger.LogError(ex, "Failed to deserialize override file \"{File}\"", Path.GetFileName(path));
+                    return;
                 }
 
-                TypeOverride parsed = ParseEntry(entry, Path.GetFileName(path));
-
-                if (!overrides.TryAdd(parsed.FQN, parsed))
+                if (entries == null)
                 {
-                    _logger.LogWarning("Duplicate override for type {FQN} in {File} — last wins",
-                        parsed.FQN, Path.GetFileName(path));
-                    overrides[parsed.FQN] = parsed;
+                    _logger.LogDebug("Override file {File} is empty", Path.GetFileName(path));
+                    return;
                 }
-            }
 
-            _logger.LogDebug("Loaded {Count} override(s) from {File}", entries.Count, Path.GetFileName(path));
-        });
+                foreach (OverrideEntryDto entry in entries)
+                {
+                    if (string.IsNullOrWhiteSpace(entry.Type))
+                    {
+                        _logger.LogWarning(
+                            "Override entry in {File} missing 'type' field — skipping",
+                            Path.GetFileName(path)
+                        );
+                        continue;
+                    }
+
+                    TypeOverride parsed = ParseEntry(entry, Path.GetFileName(path));
+
+                    if (!overrides.TryAdd(parsed.FQN, parsed))
+                    {
+                        _logger.LogWarning(
+                            "Duplicate override for type {FQN} in {File} — last wins",
+                            parsed.FQN,
+                            Path.GetFileName(path)
+                        );
+                        overrides[parsed.FQN] = parsed;
+                    }
+                }
+
+                _logger.LogDebug("Loaded {Count} override(s) from {File}", entries.Count, Path.GetFileName(path));
+            }
+        );
 
         watch.Stop();
-        _logger.LogInformation("Loaded {Count} override(s) from {Files} file(s) in {Time:F1}s",
-            overrides.Count, files.Length, watch.Elapsed.TotalSeconds);
+        _logger.LogInformation(
+            "Loaded {Count} override(s) from {Files} file(s) in {Time:F1}s",
+            overrides.Count,
+            files.Length,
+            watch.Elapsed.TotalSeconds
+        );
 
         return new OverrideSet(overrides.ToFrozenDictionary());
     }
@@ -119,14 +137,17 @@ public sealed class OverrideReader
                     foreach (var (paramName, paramDto) in methodDto.Parameters)
                     {
                         ParameterFlags addFlags = ParseParameterFlags(
-                            paramDto.AddAttributes, fileName, entry.Type!, methodName, paramName);
+                            paramDto.AddAttributes,
+                            fileName,
+                            entry.Type!,
+                            methodName,
+                            paramName
+                        );
                         parameters[paramName] = new ParameterOverride(addFlags);
                     }
                 }
 
-                methods[methodName] = new MethodOverride(
-                    methodDto.Skip ?? false,
-                    parameters);
+                methods[methodName] = new MethodOverride(methodDto.Skip ?? false, parameters);
             }
         }
 
@@ -139,8 +160,11 @@ public sealed class OverrideReader
             {
                 if (string.IsNullOrWhiteSpace(addDto.From) || string.IsNullOrWhiteSpace(addDto.Name))
                 {
-                    _logger.LogWarning("add-methods entry in {File} for {Type} missing 'from' or 'name' — skipping",
-                        fileName, entry.Type);
+                    _logger.LogWarning(
+                        "add-methods entry in {File} for {Type} missing 'from' or 'name' — skipping",
+                        fileName,
+                        entry.Type
+                    );
                     continue;
                 }
                 addMethods.Add(new AddMethodRef(addDto.From, addDto.Name));
@@ -153,10 +177,16 @@ public sealed class OverrideReader
             StructSizeField: entry.StructSizeField,
             Fields: fields,
             Methods: methods,
-            AddMethods: addMethods);
+            AddMethods: addMethods
+        );
     }
 
-    private MemberFlags ParseMemberFlags(List<string>? attributeNames, string fileName, string typeFqn, string memberName)
+    private MemberFlags ParseMemberFlags(
+        List<string>? attributeNames,
+        string fileName,
+        string typeFqn,
+        string memberName
+    )
     {
         if (attributeNames is null or { Count: 0 })
             return MemberFlags.None;
@@ -167,14 +197,24 @@ public sealed class OverrideReader
             if (Enum.TryParse<MemberFlags>(name, ignoreCase: true, out var flag))
                 result |= flag;
             else
-                _logger.LogWarning("Unknown MemberFlags attribute '{Name}' for {Type}.{Member} in {File}",
-                    name, typeFqn, memberName, fileName);
+                _logger.LogWarning(
+                    "Unknown MemberFlags attribute '{Name}' for {Type}.{Member} in {File}",
+                    name,
+                    typeFqn,
+                    memberName,
+                    fileName
+                );
         }
         return result;
     }
 
-    private ParameterFlags ParseParameterFlags(List<string>? attributeNames, string fileName,
-        string typeFqn, string methodName, string paramName)
+    private ParameterFlags ParseParameterFlags(
+        List<string>? attributeNames,
+        string fileName,
+        string typeFqn,
+        string methodName,
+        string paramName
+    )
     {
         if (attributeNames is null or { Count: 0 })
             return ParameterFlags.None;
@@ -185,8 +225,14 @@ public sealed class OverrideReader
             if (Enum.TryParse<ParameterFlags>(name, ignoreCase: true, out var flag))
                 result |= flag;
             else
-                _logger.LogWarning("Unknown ParameterFlags attribute '{Name}' for {Type}.{Method}.{Param} in {File}",
-                    name, typeFqn, methodName, paramName, fileName);
+                _logger.LogWarning(
+                    "Unknown ParameterFlags attribute '{Name}' for {Type}.{Method}.{Param} in {File}",
+                    name,
+                    typeFqn,
+                    methodName,
+                    paramName,
+                    fileName
+                );
         }
         return result;
     }

--- a/Generator/Transform/OverrideReader.cs
+++ b/Generator/Transform/OverrideReader.cs
@@ -171,13 +171,19 @@ public sealed class OverrideReader
             }
         }
 
+        // Parse value-accessor
+        ValueAccessorOverride? valueAccessor = null;
+        if (entry.ValueAccessor is { } va && (va.Getter is not null || va.SetterCoerce is not null))
+            valueAccessor = new ValueAccessorOverride(va.Getter, va.SetterCoerce);
+
         return new TypeOverride(
             FQN: entry.Type!,
             Skip: entry.Skip ?? false,
             StructSizeField: entry.StructSizeField,
             Fields: fields,
             Methods: methods,
-            AddMethods: addMethods
+            AddMethods: addMethods,
+            ValueAccessor: valueAccessor
         );
     }
 
@@ -258,6 +264,18 @@ public sealed class OverrideReader
 
         [YamlMember(Alias = "add-methods", ApplyNamingConventions = false)]
         public List<AddMethodDto>? AddMethods { get; set; }
+
+        [YamlMember(Alias = "value-accessor", ApplyNamingConventions = false)]
+        public ValueAccessorDto? ValueAccessor { get; set; }
+    }
+
+    private class ValueAccessorDto
+    {
+        [YamlMember(Alias = "getter", ApplyNamingConventions = false)]
+        public string? Getter { get; set; }
+
+        [YamlMember(Alias = "setter-coerce", ApplyNamingConventions = false)]
+        public string? SetterCoerce { get; set; }
     }
 
     private class FieldOverrideDto

--- a/Generator/Transform/OverrideSet.cs
+++ b/Generator/Transform/OverrideSet.cs
@@ -36,8 +36,17 @@ public sealed record TypeOverride(
     string? StructSizeField,
     IReadOnlyDictionary<string, FieldOverride>? Fields,
     IReadOnlyDictionary<string, MethodOverride>? Methods,
-    IReadOnlyList<AddMethodRef>? AddMethods
+    IReadOnlyList<AddMethodRef>? AddMethods,
+    ValueAccessorOverride? ValueAccessor
 );
+
+/// <summary>
+/// Customization of the generated <c>__value</c> accessor for a single-field type (native typedef
+/// or handle). <see cref="Getter"/> restores a <c>__value</c> getter (<c>$field</c> alias);
+/// <see cref="SetterCoerce"/> transforms the raw-value else branch of the setter (<c>$value</c>
+/// alias). Either may be null. v2.1 emission only.
+/// </summary>
+public sealed record ValueAccessorOverride(string? Getter, string? SetterCoerce);
 
 /// <summary>
 /// Override for a struct/type field — adds attribute flags.

--- a/Generator/Transform/OverrideSet.cs
+++ b/Generator/Transform/OverrideSet.cs
@@ -18,8 +18,7 @@ public sealed class OverrideSet
         _byFqn = byFqn;
     }
 
-    public TypeOverride? GetOverride(string fqn)
-        => _byFqn.TryGetValue(fqn, out var ov) ? ov : null;
+    public TypeOverride? GetOverride(string fqn) => _byFqn.TryGetValue(fqn, out var ov) ? ov : null;
 
     public bool HasOverride(string fqn) => _byFqn.ContainsKey(fqn);
 
@@ -37,7 +36,8 @@ public sealed record TypeOverride(
     string? StructSizeField,
     IReadOnlyDictionary<string, FieldOverride>? Fields,
     IReadOnlyDictionary<string, MethodOverride>? Methods,
-    IReadOnlyList<AddMethodRef>? AddMethods);
+    IReadOnlyList<AddMethodRef>? AddMethods
+);
 
 /// <summary>
 /// Override for a struct/type field — adds attribute flags.
@@ -47,9 +47,7 @@ public sealed record FieldOverride(MemberFlags AddAttributes);
 /// <summary>
 /// Override for a method — can skip the method or override its parameters.
 /// </summary>
-public sealed record MethodOverride(
-    bool Skip,
-    IReadOnlyDictionary<string, ParameterOverride>? Parameters);
+public sealed record MethodOverride(bool Skip, IReadOnlyDictionary<string, ParameterOverride>? Parameters);
 
 /// <summary>
 /// Override for a method parameter — adds attribute flags.

--- a/Generator/Transform/OwnedHandleResolver.cs
+++ b/Generator/Transform/OwnedHandleResolver.cs
@@ -1,0 +1,62 @@
+namespace AhkWin32.Generator.Transform;
+
+using AhkWin32.Generator.Model;
+using AhkWin32.Generator.Model.Members;
+using AhkWin32.Generator.Model.Types;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Marks handle types that need an <c>OwnedWith(freeFunc)</c> factory. A returned or <c>[Out]</c>
+/// handle whose call-site <c>[RAIIFree]</c> differs from the handle type's default free function
+/// (e.g. a <c>HANDLE</c> closed with <c>FindClose</c> instead of <c>CloseHandle</c>) must be boxed
+/// as a runtime subclass that frees via that specific function, rather than the plain <c>.Owned</c>.
+/// Setting <see cref="HandleType.NeedsOwnedWith"/> lets the emitter generate that factory only on the
+/// handful of handles that actually use it, instead of every freeable handle.
+///
+/// This is a transform, not extraction, because the divergence test needs each handle type's
+/// resolved default <c>[RAIIFree]</c> - which may not be extracted yet when a referencing method is.
+/// </summary>
+class OwnedHandleResolver(ILogger logger)
+{
+    private readonly ILogger _logger = logger;
+
+    public void Apply(TypeRegistry registry)
+    {
+        foreach (var type in registry.GetAll())
+        {
+            IEnumerable<MethodMember> methods = type switch
+            {
+                ApiType api => api.Methods,
+                ComInterfaceType com => com.Methods,
+                _ => [],
+            };
+
+            foreach (var method in methods)
+            {
+                // A directly-returned handle, or an [Out] pointer-to-handle: the same shapes the
+                // emitter boxes via OwnedWith.
+                if (method.HasReturnValue && method.Parameters[0] is { Type: HandleRef rh } ret)
+                    MarkIfDivergent(registry, ret, rh.FQN);
+
+                if (method.OutputParameter is { Type: PointerType { Pointee: HandleRef ph } } outp)
+                    MarkIfDivergent(registry, outp, ph.FQN);
+            }
+        }
+    }
+
+    private void MarkIfDivergent(TypeRegistry registry, ParameterMember param, string handleFqn)
+    {
+        // Borrowed ([DoNotRelease]) or no call-site RAIIFree -> uses the default free, no factory.
+        if (!param.ScriptOwned || param.RAIIFree is not { } raii)
+            return;
+
+        if (registry.Resolve(handleFqn, Architecture.All) is not HandleType ht || ht.FreeFunc is null)
+            return;
+
+        if (raii != ht.FreeFunc && !ht.NeedsOwnedWith)
+        {
+            _logger.LogTrace("{handle} needs an OwnedWith factory (context free {free})", handleFqn, raii.Name);
+            ht.NeedsOwnedWith = true;
+        }
+    }
+}

--- a/Generator/Transform/ReservedNameConfig.cs
+++ b/Generator/Transform/ReservedNameConfig.cs
@@ -16,7 +16,7 @@ public static class ReservedNameConfig
     {
         IDeserializer deserializer = new DeserializerBuilder().Build();
         List<string> names = deserializer.Deserialize<List<string>>(File.ReadAllText(configPath));
-        
+
         return new HashSet<string>(names, StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/Generator/Transform/SyntheticTypeProvider.cs
+++ b/Generator/Transform/SyntheticTypeProvider.cs
@@ -1,0 +1,73 @@
+namespace AhkWin32.Generator.Transform;
+
+using AhkWin32.Generator.Model;
+using AhkWin32.Generator.Model.Types;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Injects hand-declared synthetic types into the <see cref="TypeRegistry"/> — types that
+/// have no Win32 metadata definition but that we want to participate fully in type
+/// resolution, imports, and emission (rather than being special-cased like System.Guid).
+///
+/// <para>
+/// Currently the only entry is <c>WCHAR</c>: Win32 metadata defines <c>CHAR</c> as a
+/// NativeTypedef but has no <c>WCHAR</c>/<c>TCHAR</c> equivalent (CLR <c>char</c> arrays
+/// carry no typedef). Registering <c>WCHAR</c> as a NativeTypedef over <c>UInt16</c> lets
+/// <see cref="Emit.Emitters.NativeTypedefEmitter21"/> emit <c>WCHAR.ahk</c> for free and
+/// gives Unicode fixed-char-array fields a real per-type hook for string-assignment magic
+/// (attached via the <c>WCHAR</c> extension).
+/// </para>
+///
+/// <para>v2.1 only — the v2.0 emitter handles fixed char arrays via StringType/StrGet/StrPut.</para>
+/// </summary>
+public sealed class SyntheticTypeProvider(ILogger<SyntheticTypeProvider> logger)
+{
+    private readonly ILogger<SyntheticTypeProvider> _logger = logger;
+
+    /// <summary>
+    /// Register synthetic types into the registry. Must run after extraction and before
+    /// the override/extension transforms so extensions can attach to the synthetic types.
+    /// </summary>
+    public void Apply(TypeRegistry registry)
+    {
+        RegisterWchar(registry);
+    }
+
+    /// <summary>
+    /// Register <c>Windows.Win32.Foundation.WCHAR</c> as a NativeTypedef over <c>UInt16</c>,
+    /// mirroring the assembly/version of the existing <c>CHAR</c> typedef so it lands in the
+    /// same namespace and is consistent with the emitted metadata.
+    /// </summary>
+    private void RegisterWchar(TypeRegistry registry)
+    {
+        const string charFqn = "Windows.Win32.Foundation.CHAR";
+        const string wcharFqn = "Windows.Win32.Foundation.WCHAR";
+
+        if (registry.Contains(wcharFqn))
+        {
+            _logger.LogDebug("{Fqn} already present; skipping synthetic registration", wcharFqn);
+            return;
+        }
+
+        var charType = registry.Resolve<NativeTypedefType>(charFqn, Architecture.All);
+        if (charType is null)
+        {
+            _logger.LogWarning("{Fqn} not found in registry; cannot derive synthetic WCHAR", charFqn);
+            return;
+        }
+
+        var wchar = new NativeTypedefType
+        {
+            Identity = TypeIdentity.Universal(wcharFqn),
+            Name = "WCHAR",
+            CanonicalName = "WCHAR",
+            AssemblyName = charType.AssemblyName,
+            MetadataVersion = charType.MetadataVersion,
+            Underlying = new PrimitiveType("UInt16"),
+            Description = "A 16-bit Unicode (UTF-16) character.",
+        };
+
+        registry.Register(wchar);
+        _logger.LogInformation("Registered synthetic type {Fqn} (NativeTypedef over UInt16)", wcharFqn);
+    }
+}

--- a/Generator/model/Architecture.cs
+++ b/Generator/model/Architecture.cs
@@ -6,9 +6,9 @@ namespace AhkWin32.Generator.Model;
 [Flags]
 public enum Architecture : uint
 {
-    None  = 0,
-    X86   = 1,
-    X64   = 2,
+    None = 0,
+    X86 = 1,
+    X64 = 2,
     Arm64 = 4,
-    All   = X86 | X64 | Arm64
+    All = X86 | X64 | Arm64,
 }

--- a/Generator/model/ConstantValue.cs
+++ b/Generator/model/ConstantValue.cs
@@ -54,9 +54,7 @@ public sealed record StructConstantValue(
     IReadOnlyList<StructFieldInit>? FieldInits
 ) : ConstantValue
 {
-    public override string AsAhk => IsHandle
-        ? $"{StructName}({{Value: {HandleValue}}}, false)"
-        : StructName;
+    public override string AsAhk => IsHandle ? $"{StructName}({{Value: {HandleValue}}}, false)" : StructName;
 
     public override string AhkTypeName => StructName;
 }
@@ -84,8 +82,10 @@ public enum StructFieldInitKind
 {
     /// <summary>Simple assignment: prefix.field := value</summary>
     Direct,
+
     /// <summary>Array element: prefix.field[index] := value</summary>
     ArrayElement,
+
     /// <summary>GUID pointer: create static guid, assign .ptr</summary>
-    GuidPointer
+    GuidPointer,
 }

--- a/Generator/model/ConstantValue.cs
+++ b/Generator/model/ConstantValue.cs
@@ -63,8 +63,8 @@ public sealed record StructConstantValue(
 /// A single field initialization entry for a struct constant.
 /// </summary>
 public sealed record StructFieldInit(
-    /// <summary>Dot-separated path to the field (e.g., "value.subStruct.field").</summary>
-    string FieldPath,
+    /// <summary>Path to the field (e.g., ["subStruct", "field"]).</summary>
+    IReadOnlyList<string> FieldPath,
     /// <summary>Pre-formatted AHK value string.</summary>
     string Value,
     /// <summary>The kind of initialization.</summary>
@@ -85,6 +85,9 @@ public enum StructFieldInitKind
 
     /// <summary>Array element: prefix.field[index] := value</summary>
     ArrayElement,
+
+    /// <summary> A GUID embedded in the struct.</summary>
+    Guid,
 
     /// <summary>GUID pointer: create static guid, assign .ptr</summary>
     GuidPointer,

--- a/Generator/model/Enums.cs
+++ b/Generator/model/Enums.cs
@@ -7,7 +7,7 @@ public enum StringEncoding
 {
     None,
     Ansi,
-    Unicode
+    Unicode,
 }
 
 /// <summary>
@@ -20,7 +20,7 @@ public enum CallingConvention
     CDecl,
     ThisCall,
     FastCall,
-    WinApi
+    WinApi,
 }
 
 /// <summary>
@@ -31,7 +31,7 @@ public enum StructLayoutKind
 {
     Sequential,
     Explicit,
-    Auto
+    Auto,
 }
 
 /// <summary>
@@ -41,10 +41,10 @@ public enum StructLayoutKind
 [Flags]
 public enum ParameterDirection
 {
-    None     = 0,
-    In       = 1,
-    Out      = 2,
-    Optional = 4
+    None = 0,
+    In = 1,
+    Out = 2,
+    Optional = 4,
 }
 
 /// <summary>
@@ -54,14 +54,14 @@ public enum ParameterDirection
 [Flags]
 public enum ParameterFlags
 {
-    None              = 0,
-    Reserved          = 1,
-    Constant          = 2,
-    SizedBuffer       = 4,
-    ComOutPtr         = 8,
-    RetVal            = 16,
-    DoNotRelease      = 32,
+    None = 0,
+    Reserved = 1,
+    Constant = 2,
+    SizedBuffer = 4,
+    ComOutPtr = 8,
+    RetVal = 16,
+    DoNotRelease = 32,
     HasIgnoreIfReturn = 64,
-    HasRAIIFree       = 128,
-    HasFreeWith       = 256
+    HasRAIIFree = 128,
+    HasFreeWith = 256,
 }

--- a/Generator/model/ExtensionCode.cs
+++ b/Generator/model/ExtensionCode.cs
@@ -1,12 +1,22 @@
 namespace AhkWin32.Generator.Model;
 
+using AhkWin32.Generator.Metadata;
+
 /// <summary>
 /// A block of extension code to be appended to a type's generated output.
 /// Pre-resolved from YAML extension files during extraction.
 /// </summary>
 public sealed record ExtensionCode(
-    /// <summary>The raw AHK code to inject.</summary>
-    string Code,
-    /// <summary>FQN strings of types required by this extension (for #Include generation).</summary>
-    IReadOnlyList<string> Requirements
+    /// <summary>
+    /// Per-version AHK code to inject. A version absent from the map means the extension
+    /// is explicitly opted-out for that target (the yml file said `skip`).
+    /// </summary>
+    IReadOnlyDictionary<AhkVersion, string> CodeByVersion,
+    /// <summary>
+    /// Imports required by this extension's code. Keys are FQNs. An empty value list means
+    /// "whole-file include" (routed to <see cref="ImportCollection.AddType"/>); a non-empty
+    /// list names specific functions from an Apis container (routed to
+    /// <see cref="ImportCollection.AddFunctions"/>).
+    /// </summary>
+    IReadOnlyDictionary<string, IReadOnlyList<string>> Imports
 );

--- a/Generator/model/ImportCollection.cs
+++ b/Generator/model/ImportCollection.cs
@@ -15,6 +15,8 @@ public sealed class ImportCollection
 
     public bool AddType(string fqn) => _types.Add(fqn);
 
+    public int AddTypes(IEnumerable<string> fqns) => fqns.Count(_types.Add);
+
     public bool HasType(string fqn) => _types.Contains(fqn);
 
     public IEnumerable<string> GetTypes() => _types;
@@ -24,6 +26,9 @@ public sealed class ImportCollection
         var fns = _functions.GetOrAdd(apisFqn, _ => []);
         return fns.Add(fnName);
     }
+
+    public int AddFunctions(string apisFqn, IEnumerable<string> fns) =>
+        fns.Count(fn => AddFunction(apisFqn, fn));
 
     public IEnumerable<string> GetFunctionNamespaces() => _functions.Keys;
 

--- a/Generator/model/ImportCollection.cs
+++ b/Generator/model/ImportCollection.cs
@@ -27,8 +27,7 @@ public sealed class ImportCollection
         return fns.Add(fnName);
     }
 
-    public int AddFunctions(string apisFqn, IEnumerable<string> fns) =>
-        fns.Count(fn => AddFunction(apisFqn, fn));
+    public int AddFunctions(string apisFqn, IEnumerable<string> fns) => fns.Count(fn => AddFunction(apisFqn, fn));
 
     public IEnumerable<string> GetFunctionNamespaces() => _functions.Keys;
 

--- a/Generator/model/ImportCollection.cs
+++ b/Generator/model/ImportCollection.cs
@@ -1,0 +1,66 @@
+using System.Collections.Concurrent;
+using ConcurrentCollections;
+
+namespace AhkWin32.Generator.Model;
+
+/// <summary>
+/// A thread-safe container for information about types and functions that need to be imported.
+/// Type imports map to a whole file (e.g., a struct's .ahk file). Function imports name specific
+/// free functions inside an Apis file, needed for v2.1 where functions aren't class members.
+/// </summary>
+public sealed class ImportCollection
+{
+    private readonly ConcurrentHashSet<string> _types = [];
+    private readonly ConcurrentDictionary<string, ConcurrentHashSet<string>> _functions = [];
+
+    public bool AddType(string fqn) => _types.Add(fqn);
+
+    public bool HasType(string fqn) => _types.Contains(fqn);
+
+    public IEnumerable<string> GetTypes() => _types;
+
+    public bool AddFunction(string apisFqn, string fnName)
+    {
+        var fns = _functions.GetOrAdd(apisFqn, _ => []);
+        return fns.Add(fnName);
+    }
+
+    public IEnumerable<string> GetFunctionNamespaces() => _functions.Keys;
+
+    public IEnumerable<string> GetFunctionsForNamespace(string apisFqn)
+    {
+        if (_functions.TryGetValue(apisFqn, out var fns))
+            return fns;
+
+        throw new KeyNotFoundException($"Import collection contains no functions for namespace {apisFqn}");
+    }
+
+    /// <summary>
+    /// FQNs of every distinct file that needs to be included. For v2 emitters: union of
+    /// type FQNs and function-Apis FQNs (one #Include per file).
+    /// </summary>
+    public IEnumerable<string> GetIncludeTargets() => _types.Concat(_functions.Keys).Distinct();
+
+    /// <summary>
+    /// Merge another collection's contents into this one.
+    /// </summary>
+    public void MergeFrom(ImportCollection other)
+    {
+        foreach (string fqn in other._types)
+            _types.Add(fqn);
+        foreach (var (apisFqn, fns) in other._functions)
+        {
+            foreach (string fn in fns)
+                AddFunction(apisFqn, fn);
+        }
+    }
+
+    /// <summary>
+    /// Merge other collections' contents into this one.
+    /// </summary>
+    public void MergeFrom(IEnumerable<ImportCollection> others)
+    {
+        foreach (var collection in others)
+            MergeFrom(collection);
+    }
+}

--- a/Generator/model/MemberFlags.cs
+++ b/Generator/model/MemberFlags.cs
@@ -6,13 +6,13 @@ namespace AhkWin32.Generator.Model;
 [Flags]
 public enum MemberFlags
 {
-    None           = 0,
-    Deprecated     = 1,
-    Reserved       = 2,
-    Alignment      = 4,
-    Union          = 8,
-    Anonymous      = 16,
-    Ansi           = 32,
-    Unicode        = 64,
-    NativeBitField = 128
+    None = 0,
+    Deprecated = 1,
+    Reserved = 2,
+    Alignment = 4,
+    Union = 8,
+    Anonymous = 16,
+    Ansi = 32,
+    Unicode = 64,
+    NativeBitField = 128,
 }

--- a/Generator/model/Members/ConstantMember.cs
+++ b/Generator/model/Members/ConstantMember.cs
@@ -29,8 +29,8 @@ public sealed class ConstantMember
     public bool NeedsGuid { get; init; }
 
     /// <summary>
-    /// FQNs of types referenced by this constant (e.g., struct types for struct constants).
-    /// Used for #Include generation.
+    /// Types and functions referenced by this constant (e.g., struct types for struct constants).
+    /// Used for #Include / #Import generation.
     /// </summary>
-    public IReadOnlyList<string> ReferencedTypes { get; init; } = [];
+    public ImportCollection Imports { get; init; } = new();
 }

--- a/Generator/model/Members/FieldMember.cs
+++ b/Generator/model/Members/FieldMember.cs
@@ -51,6 +51,14 @@ public sealed class FieldMember
     /// <summary>Whether this field represents a nested struct (anonymous union or named nested type).</summary>
     public bool IsNested { get; init; }
 
+    /// <summary>
+    /// Set by <see cref="Transform.CyclicPointerBreaker"/> for a pointer-to-struct field that lies
+    /// on an import cycle. Such a field is emitted (under v2.1) as a backing IntPtr plus a dynamic
+    /// accessor that resolves the pointee only at call time, instead of an eager <c>X.Ptr</c> typed
+    /// property — breaking the load-time dependency cycle that would otherwise be fatal.
+    /// </summary>
+    public bool EmitAsLazyPointer { get; set; }
+
     // Convenience
     public bool IsReserved => Flags.HasFlag(MemberFlags.Reserved);
     public bool IsAlignment => Flags.HasFlag(MemberFlags.Alignment);

--- a/Generator/model/Members/MethodMember.cs
+++ b/Generator/model/Members/MethodMember.cs
@@ -70,6 +70,13 @@ public class MethodMember
     }
 
     /// <summary>
+    /// Returns an IEnumerable of all the method's input parameters
+    /// </summary>
+    public IEnumerable<ParameterMember> InputParameters => Parameters
+        .Skip(1)    // Skip the return type
+        .Where(p => !p.IsReserved && p != OutputParameter);
+
+    /// <summary>
     /// All parameters, including the return value at index 0.
     /// Parameters[0] is always the return type (may be Void).
     /// Parameters[1..] are the actual function parameters.

--- a/Generator/model/Members/MethodMember.cs
+++ b/Generator/model/Members/MethodMember.cs
@@ -94,6 +94,8 @@ public class MethodMember
     /// </summary>
     public ParameterMember? OutputParameter { get; init; }
 
+    public Architecture SupportedArchitecture { get; init; }
+
     // --- Inline documentation ---
 
     /// <summary>Summary description text.</summary>

--- a/Generator/model/Members/MethodMember.cs
+++ b/Generator/model/Members/MethodMember.cs
@@ -116,7 +116,7 @@ public class MethodMember
     public bool ShouldThrowOnHResult { get; init; }
 
     /// <summary>
-    /// FQNs of types referenced by this method (for #Include generation).
+    /// Types and functions referenced by this method (for #Include / #Import generation).
     /// </summary>
-    public IReadOnlyList<string> ReferencedTypes { get; init; } = [];
+    public ImportCollection Imports { get; init; } = new();
 }

--- a/Generator/model/Members/MethodMember.cs
+++ b/Generator/model/Members/MethodMember.cs
@@ -55,12 +55,15 @@ public class MethodMember
         get
         {
             if (!IsVariadic)
-                throw new InvalidOperationException($"Cannot get variadic param name for non-variadic method {Namespace}.{Name}");
+                throw new InvalidOperationException(
+                    $"Cannot get variadic param name for non-variadic method {Namespace}.{Name}"
+                );
 
             var paramNames = new HashSet<string>(
                 Parameters.Skip(1).Select(p => p.Name),
-                StringComparer.OrdinalIgnoreCase);
-            
+                StringComparer.OrdinalIgnoreCase
+            );
+
             string name = "args";
             while (paramNames.Contains(name))
                 name = "_" + name;
@@ -72,9 +75,10 @@ public class MethodMember
     /// <summary>
     /// Returns an IEnumerable of all the method's input parameters
     /// </summary>
-    public IEnumerable<ParameterMember> InputParameters => Parameters
-        .Skip(1)    // Skip the return type
-        .Where(p => !p.IsReserved && p != OutputParameter);
+    public IEnumerable<ParameterMember> InputParameters =>
+        Parameters
+            .Skip(1) // Skip the return type
+            .Where(p => !p.IsReserved && p != OutputParameter);
 
     /// <summary>
     /// All parameters, including the return value at index 0.
@@ -113,8 +117,7 @@ public class MethodMember
     // --- Pre-computed flags ---
 
     /// <summary>Whether the function has a non-void return value.</summary>
-    public bool HasReturnValue => Parameters.Count > 0
-        && Parameters[0].Type is not PrimitiveType { Name: "Void" };
+    public bool HasReturnValue => Parameters.Count > 0 && Parameters[0].Type is not PrimitiveType { Name: "Void" };
 
     /// <summary>
     /// Whether this method's HRESULT return should throw automatically.

--- a/Generator/model/Members/ParameterMember.cs
+++ b/Generator/model/Members/ParameterMember.cs
@@ -72,7 +72,17 @@ public sealed class ParameterMember
     public bool IsStruct => Type is StructRef;
     public bool IsHandle => Type is HandleRef;
 
-    public bool IsPtrToPrimitive => Type is PointerType { Pointee: PrimitiveType or PointerType or NativeTypedefRef or HResultType or EnumRef or FunctionPointerType };
+    public bool IsPtrToPrimitive =>
+        Type
+            is PointerType
+            {
+                Pointee: PrimitiveType
+                    or PointerType
+                    or NativeTypedefRef
+                    or HResultType
+                    or EnumRef
+                    or FunctionPointerType
+            };
     public bool IsPtrToCom => Type is PointerType { Pointee: ComRef };
     public bool IsPtrToStruct => Type is PointerType { Pointee: StructRef };
     public bool IsPtrToHandle => Type is PointerType { Pointee: HandleRef };
@@ -82,14 +92,15 @@ public sealed class ParameterMember
     /// Get the type name from the resolved type (for NativeTypedef, Handle, Struct, COM types).
     /// Returns null for primitive/pointer types without a named referent.
     /// </summary>
-    public string? TypeDefName => Type switch
-    {
-        NativeTypedefRef n => n.Name,
-        HandleRef h         => h.Name,
-        StructRef s         => s.Name,
-        ComRef c            => c.Name,
-        _                   => null
-    };
+    public string? TypeDefName =>
+        Type switch
+        {
+            NativeTypedefRef n => n.Name,
+            HandleRef h => h.Name,
+            StructRef s => s.Name,
+            ComRef c => c.Name,
+            _ => null,
+        };
 
     /// <summary>Get the pointee type, if this is a pointer.</summary>
     public ResolvedType? Pointee => (Type as PointerType)?.Pointee;

--- a/Generator/model/Members/ParameterMember.cs
+++ b/Generator/model/Members/ParameterMember.cs
@@ -72,7 +72,7 @@ public sealed class ParameterMember
     public bool IsStruct => Type is StructRef;
     public bool IsHandle => Type is HandleRef;
 
-    public bool IsPtrToPrimitive => Type is PointerType { Pointee: PrimitiveType or PointerType or NativeTypedefType or HResultType or EnumRef or FunctionPointerType };
+    public bool IsPtrToPrimitive => Type is PointerType { Pointee: PrimitiveType or PointerType or NativeTypedefRef or HResultType or EnumRef or FunctionPointerType };
     public bool IsPtrToCom => Type is PointerType { Pointee: ComRef };
     public bool IsPtrToStruct => Type is PointerType { Pointee: StructRef };
     public bool IsPtrToHandle => Type is PointerType { Pointee: HandleRef };
@@ -84,7 +84,7 @@ public sealed class ParameterMember
     /// </summary>
     public string? TypeDefName => Type switch
     {
-        NativeTypedefType n => n.Name,
+        NativeTypedefRef n => n.Name,
         HandleRef h         => h.Name,
         StructRef s         => s.Name,
         ComRef c            => c.Name,

--- a/Generator/model/ResolvedType.cs
+++ b/Generator/model/ResolvedType.cs
@@ -29,56 +29,60 @@ public abstract record ResolvedType
 /// </summary>
 public sealed record PrimitiveType(string Name) : ResolvedType
 {
-    public override string DisplayName => Name.ToLowerInvariant() switch
-    {
-        "single" or "double"    => "Float",
-        "boolean"               => "Boolean",
-        "void"                  => "Void",
-        "intptr" or "uintptr"   => "Pointer",
-        _                       => "Integer"
-    };
+    public override string DisplayName =>
+        Name.ToLowerInvariant() switch
+        {
+            "single" or "double" => "Float",
+            "boolean" => "Boolean",
+            "void" => "Void",
+            "intptr" or "uintptr" => "Pointer",
+            _ => "Integer",
+        };
 
-    public override string DllCallType => Name.ToLowerInvariant() switch
-    {
-        "single"                                              => "float",
-        "boolean" or "int32"                                  => "int",
-        "double"                                              => "double",
-        "int64"                                               => "int64",
-        "uint32"                                              => "uint",
-        "uint64"                                              => "uint",
-        "int16"                                               => "short",
-        "uint16"                                              => "ushort",
-        "byte" or "sbyte" or "char"                           => "char",
-        "uintptr" or "intptr" or "void" or "ptr" or "typehandle" => "ptr",
-        _                                                     => "ptr" // pointer-sized NativeTypedef
-    };
+    public override string DllCallType =>
+        Name.ToLowerInvariant() switch
+        {
+            "single" => "float",
+            "boolean" or "int32" => "int",
+            "double" => "double",
+            "int64" => "int64",
+            "uint32" => "uint",
+            "uint64" => "uint",
+            "int16" => "short",
+            "uint16" => "ushort",
+            "byte" or "sbyte" or "char" => "char",
+            "uintptr" or "intptr" or "void" or "ptr" or "typehandle" => "ptr",
+            _ => "ptr", // pointer-sized NativeTypedef
+        };
 
-    public override string TypeSpecifier => Name.ToLowerInvariant() switch
-    {
-        "single"                                              => "Float32",
-        "boolean" or "int32"                                  => "Int32",
-        "double"                                              => "Float64",
-        "int64"                                               => "Int64",
-        "uint32"                                              => "UInt32",
-        "uint64"                                              => "Int64",   // Ahk doesn't support u64s
-        "int16"                                               => "Int16",
-        "uint16"                                              => "UInt16",
-        "byte" or "sbyte" or "char"                           => "Int8",
-        "uchar"                                               => "UInt8",
-        "uintptr" or "intptr" or "void" or "ptr" or "typehandle" => "IntPtr",
+    public override string TypeSpecifier =>
+        Name.ToLowerInvariant() switch
+        {
+            "single" => "Float32",
+            "boolean" or "int32" => "Int32",
+            "double" => "Float64",
+            "int64" => "Int64",
+            "uint32" => "UInt32",
+            "uint64" => "Int64", // Ahk doesn't support u64s
+            "int16" => "Int16",
+            "uint16" => "UInt16",
+            "byte" or "sbyte" or "char" => "Int8",
+            "uchar" => "UInt8",
+            "uintptr" or "intptr" or "void" or "ptr" or "typehandle" => "IntPtr",
 
-        // Should not use pointer-sized NativeTypedefs, we should use the typedefs themselves
-        _ => throw new NotSupportedException($"Unknown primitive type '{Name}'")
-    };
+            // Should not use pointer-sized NativeTypedefs, we should use the typedefs themselves
+            _ => throw new NotSupportedException($"Unknown primitive type '{Name}'"),
+        };
 
-    public override int Width => Name.ToLowerInvariant() switch
-    {
-        "single" or "boolean" or "int32" or "uint32"                       => 4,
-        "double" or "int64" or "uint64" or "intptr" or "uintptr" or "void" or "ptr" => 8,
-        "int16" or "uint16" or "char"                                      => 2,
-        "byte" or "sbyte"                                                  => 1,
-        _                                                                  => 8
-    };
+    public override int Width =>
+        Name.ToLowerInvariant() switch
+        {
+            "single" or "boolean" or "int32" or "uint32" => 4,
+            "double" or "int64" or "uint64" or "intptr" or "uintptr" or "void" or "ptr" => 8,
+            "int16" or "uint16" or "char" => 2,
+            "byte" or "sbyte" => 1,
+            _ => 8,
+        };
 }
 
 /// <summary>
@@ -86,9 +90,7 @@ public sealed record PrimitiveType(string Name) : ResolvedType
 /// </summary>
 public sealed record PointerType(ResolvedType? Pointee) : ResolvedType
 {
-    public override string DisplayName => Pointee is null
-        ? "Pointer"
-        : $"Pointer<{Pointee.DisplayName}>";
+    public override string DisplayName => Pointee is null ? "Pointer" : $"Pointer<{Pointee.DisplayName}>";
 
     public override string DllCallType => "ptr";
 
@@ -97,33 +99,35 @@ public sealed record PointerType(ResolvedType? Pointee) : ResolvedType
     /// Used for method parameters where typed pointer marshalling is desired.
     /// Matches the old GetDllCallType(useNakedPointer: false) behavior.
     /// </summary>
-    public string TypedDllCallType => Pointee switch
-    {
-        PointerType                                                          => "ptr*",
-        ComRef                                                               => "ptr*",
-        FunctionPointerType                                                  => "ptr*",
-        PrimitiveType p when p.Name.Equals("Void", StringComparison.OrdinalIgnoreCase) => "ptr",
-        PrimitiveType p                                                      => p.DllCallType + "*",
-        NativeTypedefRef n                                                  => n.DllCallType + "*",
-        EnumRef e                                                            => e.UnderlyingType.DllCallType + "*",
-        HResultType                                                          => "int*",
-        _                                                                    => "ptr"
-    };
+    public string TypedDllCallType =>
+        Pointee switch
+        {
+            PointerType => "ptr*",
+            ComRef => "ptr*",
+            FunctionPointerType => "ptr*",
+            PrimitiveType p when p.Name.Equals("Void", StringComparison.OrdinalIgnoreCase) => "ptr",
+            PrimitiveType p => p.DllCallType + "*",
+            NativeTypedefRef n => n.DllCallType + "*",
+            EnumRef e => e.UnderlyingType.DllCallType + "*",
+            HResultType => "int*",
+            _ => "ptr",
+        };
 
     /// <summary>
     /// AHK v2.1 type specifier. For pointers to named types (struct/handle/COM/typedef/enum)
     /// emit the typed `Pointee.Ptr` form so DllCall and field reads honour the pointee type;
     /// for void/opaque/function/primitive pointers fall back to the generic IntPtr.
     /// </summary>
-    public override string TypeSpecifier => Pointee switch
-    {
-        StructRef s         => $"{s.Name}.Ptr",
-        HandleRef h         => $"{h.Name}.Ptr",
-        ComRef c            => $"{c.Name}.Ptr",
-        NativeTypedefRef n  => $"{n.Name}.Ptr",
-        EnumRef e           => $"{e.Name}.Ptr",
-        _                   => "IntPtr"
-    };
+    public override string TypeSpecifier =>
+        Pointee switch
+        {
+            StructRef s => $"{s.Name}.Ptr",
+            HandleRef h => $"{h.Name}.Ptr",
+            ComRef c => $"{c.Name}.Ptr",
+            NativeTypedefRef n => $"{n.Name}.Ptr",
+            EnumRef e => $"{e.Name}.Ptr",
+            _ => "IntPtr",
+        };
 
     public override int Width => 8;
 }
@@ -147,8 +151,8 @@ public sealed record StringType(int Length, StringEncoding Encoding) : ResolvedT
 {
     public override string DisplayName => "String";
     public override string DllCallType => "ptr";
-    public override string TypeSpecifier => throw new NotSupportedException(
-        "Not supported for v2.1 - Use fixed-size UCHAR or CHAR arrays instead");
+    public override string TypeSpecifier =>
+        throw new NotSupportedException("Not supported for v2.1 - Use fixed-size UCHAR or CHAR arrays instead");
     public override int Width => Length * (Encoding == StringEncoding.Ansi ? 1 : 2);
 }
 
@@ -161,8 +165,8 @@ public sealed record StructRef(string FQN, string Name) : ResolvedType
     public override string DisplayName => Name;
     public override string DllCallType => "ptr";
     public override string TypeSpecifier => Name;
-    public override int Width => throw new InvalidOperationException(
-        $"Width of StructRef '{FQN}' must be resolved from the TypeRegistry");
+    public override int Width =>
+        throw new InvalidOperationException($"Width of StructRef '{FQN}' must be resolved from the TypeRegistry");
 }
 
 /// <summary>
@@ -228,7 +232,7 @@ public sealed record FunctionPointerType(string Name, string Signature) : Resolv
 {
     public override string DisplayName => $"Pointer<{Name}>";
     public override string DllCallType => "ptr";
-    public override string TypeSpecifier => "IntPtr";   // TODO we can have function pointer types now!
+    public override string TypeSpecifier => "IntPtr"; // TODO we can have function pointer types now!
     public override int Width => 8;
 }
 

--- a/Generator/model/ResolvedType.cs
+++ b/Generator/model/ResolvedType.cs
@@ -104,7 +104,7 @@ public sealed record PointerType(ResolvedType? Pointee) : ResolvedType
         FunctionPointerType                                                  => "ptr*",
         PrimitiveType p when p.Name.Equals("Void", StringComparison.OrdinalIgnoreCase) => "ptr",
         PrimitiveType p                                                      => p.DllCallType + "*",
-        NativeTypedefType n                                                  => n.DllCallType + "*",
+        NativeTypedefRef n                                                  => n.DllCallType + "*",
         EnumRef e                                                            => e.UnderlyingType.DllCallType + "*",
         HResultType                                                          => "int*",
         _                                                                    => "ptr"
@@ -227,7 +227,7 @@ public sealed record FunctionPointerType(string Name, string Signature) : Resolv
 /// A NativeTypedef — a named alias for another type (e.g., DWORD -> UInt32).
 /// Carries both the alias name and the underlying resolved type.
 /// </summary>
-public sealed record NativeTypedefType(string Name, string FQN, ResolvedType Underlying) : ResolvedType
+public sealed record NativeTypedefRef(string Name, string FQN, ResolvedType Underlying) : ResolvedType
 {
     public override string DisplayName => Name;
     public override string DllCallType => Underlying.DllCallType;

--- a/Generator/model/ResolvedType.cs
+++ b/Generator/model/ResolvedType.cs
@@ -111,10 +111,19 @@ public sealed record PointerType(ResolvedType? Pointee) : ResolvedType
     };
 
     /// <summary>
-    /// Always throw - these are used for function calls but can't be struct members.
+    /// AHK v2.1 type specifier. For pointers to named types (struct/handle/COM/typedef/enum)
+    /// emit the typed `Pointee.Ptr` form so DllCall and field reads honour the pointee type;
+    /// for void/opaque/function/primitive pointers fall back to the generic IntPtr.
     /// </summary>
-    public override string TypeSpecifier => throw new InvalidOperationException(
-        "PointerTypes cannot be embedded in structures and thus do not have type specifiers");
+    public override string TypeSpecifier => Pointee switch
+    {
+        StructRef s         => $"{s.Name}.Ptr",
+        HandleRef h         => $"{h.Name}.Ptr",
+        ComRef c            => $"{c.Name}.Ptr",
+        NativeTypedefRef n  => $"{n.Name}.Ptr",
+        EnumRef e           => $"{e.Name}.Ptr",
+        _                   => "IntPtr"
+    };
 
     public override int Width => 8;
 }

--- a/Generator/model/ResolvedType.cs
+++ b/Generator/model/ResolvedType.cs
@@ -1,3 +1,5 @@
+using System.Reflection.Metadata;
+
 namespace AhkWin32.Generator.Model;
 
 /// <summary>
@@ -12,6 +14,11 @@ public abstract record ResolvedType
 
     /// <summary>AHK DllCall type string (e.g., "int", "ptr", "int*").</summary>
     public abstract string DllCallType { get; }
+
+    /// <summary>
+    /// AHK v2.1 type specifier - see https://www.autohotkey.com/docs/alpha/Structs.htm#type-specs
+    /// </summary>
+    public abstract string TypeSpecifier { get; }
 
     /// <summary>Size in bytes (64-bit). 0 if not statically known (StructRef, ArrayType).</summary>
     public abstract int Width { get; }
@@ -44,6 +51,24 @@ public sealed record PrimitiveType(string Name) : ResolvedType
         "byte" or "sbyte" or "char"                           => "char",
         "uintptr" or "intptr" or "void" or "ptr" or "typehandle" => "ptr",
         _                                                     => "ptr" // pointer-sized NativeTypedef
+    };
+
+    public override string TypeSpecifier => Name.ToLowerInvariant() switch
+    {
+        "single"                                              => "Float32",
+        "boolean" or "int32"                                  => "Int32",
+        "double"                                              => "Float64",
+        "int64"                                               => "Int64",
+        "uint32"                                              => "UInt32",
+        "uint64"                                              => "Int64",   // Ahk doesn't support u64s
+        "int16"                                               => "Int16",
+        "uint16"                                              => "UInt16",
+        "byte" or "sbyte" or "char"                           => "Int8",
+        "uchar"                                               => "UInt8",
+        "uintptr" or "intptr" or "void" or "ptr" or "typehandle" => "IntPtr",
+
+        // Should not use pointer-sized NativeTypedefs, we should use the typedefs themselves
+        _ => throw new NotSupportedException($"Unknown primitive type '{Name}'")
     };
 
     public override int Width => Name.ToLowerInvariant() switch
@@ -85,6 +110,12 @@ public sealed record PointerType(ResolvedType? Pointee) : ResolvedType
         _                                                                    => "ptr"
     };
 
+    /// <summary>
+    /// Always throw - these are used for function calls but can't be struct members.
+    /// </summary>
+    public override string TypeSpecifier => throw new InvalidOperationException(
+        "PointerTypes cannot be embedded in structures and thus do not have type specifiers");
+
     public override int Width => 8;
 }
 
@@ -95,6 +126,7 @@ public sealed record ArrayType(ResolvedType ElementType, int Length) : ResolvedT
 {
     public override string DisplayName => $"Array<{ElementType.DisplayName}>";
     public override string DllCallType => "ptr";
+    public override string TypeSpecifier => $"{ElementType.TypeSpecifier}[{Length}]";
     public override int Width => Length * ElementType.Width;
 }
 
@@ -106,6 +138,8 @@ public sealed record StringType(int Length, StringEncoding Encoding) : ResolvedT
 {
     public override string DisplayName => "String";
     public override string DllCallType => "ptr";
+    public override string TypeSpecifier => throw new NotSupportedException(
+        "Not supported for v2.1 - Use fixed-size UCHAR or CHAR arrays instead");
     public override int Width => Length * (Encoding == StringEncoding.Ansi ? 1 : 2);
 }
 
@@ -117,6 +151,7 @@ public sealed record StructRef(string FQN, string Name) : ResolvedType
 {
     public override string DisplayName => Name;
     public override string DllCallType => "ptr";
+    public override string TypeSpecifier => Name;
     public override int Width => throw new InvalidOperationException(
         $"Width of StructRef '{FQN}' must be resolved from the TypeRegistry");
 }
@@ -128,6 +163,7 @@ public sealed record EnumRef(string FQN, string Name, PrimitiveType UnderlyingTy
 {
     public override string DisplayName => Name;
     public override string DllCallType => UnderlyingType.DllCallType;
+    public override string TypeSpecifier => Name;
     public override int Width => UnderlyingType.Width;
 }
 
@@ -138,6 +174,7 @@ public sealed record ComRef(string FQN, string Name) : ResolvedType
 {
     public override string DisplayName => Name;
     public override string DllCallType => "ptr";
+    public override string TypeSpecifier => Name;
     public override int Width => 8;
 }
 
@@ -148,6 +185,7 @@ public sealed record HandleRef(string FQN, string Name) : ResolvedType
 {
     public override string DisplayName => Name;
     public override string DllCallType => "ptr";
+    public override string TypeSpecifier => Name;
     public override int Width => 8;
 }
 
@@ -158,6 +196,7 @@ public sealed record HResultType() : ResolvedType
 {
     public override string DisplayName => "HRESULT";
     public override string DllCallType => "int";
+    public override string TypeSpecifier => "HRESULT";
     public override int Width => 4;
 }
 
@@ -168,6 +207,7 @@ public sealed record NtStatusType() : ResolvedType
 {
     public override string DisplayName => "NTSTATUS";
     public override string DllCallType => "int";
+    public override string TypeSpecifier => "NTSTATUS";
     public override int Width => 4;
 }
 
@@ -179,6 +219,7 @@ public sealed record FunctionPointerType(string Name, string Signature) : Resolv
 {
     public override string DisplayName => $"Pointer<{Name}>";
     public override string DllCallType => "ptr";
+    public override string TypeSpecifier => "IntPtr";   // TODO we can have function pointer types now!
     public override int Width => 8;
 }
 
@@ -190,5 +231,6 @@ public sealed record NativeTypedefType(string Name, string FQN, ResolvedType Und
 {
     public override string DisplayName => Name;
     public override string DllCallType => Underlying.DllCallType;
+    public override string TypeSpecifier => Name;
     public override int Width => Underlying.Width;
 }

--- a/Generator/model/TypeRegistry.cs
+++ b/Generator/model/TypeRegistry.cs
@@ -48,6 +48,9 @@ public class TypeRegistry
         return null;
     }
 
+    /// <summary>
+    /// Resolve a type of the given type <c>T</c> by FQN for a target architecture.
+    /// </summary>
     public T? Resolve<T>(string fqn, Architecture target)
         where T : Win32Type
     {

--- a/Generator/model/TypeRegistry.cs
+++ b/Generator/model/TypeRegistry.cs
@@ -48,7 +48,8 @@ public class TypeRegistry
         return null;
     }
 
-    public T? Resolve<T>(string fqn, Architecture target) where T : Win32Type
+    public T? Resolve<T>(string fqn, Architecture target)
+        where T : Win32Type
     {
         if (_byFqn.TryGetValue(fqn, out var variants))
         {
@@ -58,7 +59,7 @@ public class TypeRegistry
                 return t;
 
             // Fall back to universal
-            return variants.OfType<T>().FirstOrDefault(v => v is {Arch: Architecture.All}, null);
+            return variants.OfType<T>().FirstOrDefault(v => v is { Arch: Architecture.All }, null);
         }
         return null;
     }
@@ -71,7 +72,8 @@ public class TypeRegistry
     }
 
     /// <summary>Get a type by exact identity (FQN + arch).</summary>
-    public T? Get<T>(TypeIdentity identity) where T : Win32Type
+    public T? Get<T>(TypeIdentity identity)
+        where T : Win32Type
     {
         _types.TryGetValue(identity, out var type);
         return type is T t ? t : null;
@@ -84,11 +86,10 @@ public class TypeRegistry
     }
 
     /// <summary>Get all architecture variants of a specific kind for a given FQN.</summary>
-    public IReadOnlyList<T> GetAllVariants<T>(string fqn) where T : Win32Type
+    public IReadOnlyList<T> GetAllVariants<T>(string fqn)
+        where T : Win32Type
     {
-        return _byFqn.TryGetValue(fqn, out var list)
-            ? [.. list.OfType<T>()]
-            : [];
+        return _byFqn.TryGetValue(fqn, out var list) ? [.. list.OfType<T>()] : [];
     }
 
     /// <summary>Get all types in a given namespace.</summary>
@@ -98,12 +99,11 @@ public class TypeRegistry
     }
 
     /// <summary>Get all types of a specific kind in a given namespace.</summary>
-    public IEnumerable<T> GetByNamespace<T>(string ns) where T : Win32Type
+    public IEnumerable<T> GetByNamespace<T>(string ns)
+        where T : Win32Type
     {
-        return _types.Values
-            .Where(t => t.Namespace == ns)
-            .OfType<T>();
-    } 
+        return _types.Values.Where(t => t.Namespace == ns).OfType<T>();
+    }
 
     /// <summary>Get all types from a given source assembly.</summary>
     public IEnumerable<Win32Type> GetByAssembly(string assembly)
@@ -112,15 +112,15 @@ public class TypeRegistry
     }
 
     /// <summary>Get all types of a specific kind from a given source assembly.</summary>
-    public IEnumerable<T> GetByAsembly<T>(string assembly) where T : Win32Type
+    public IEnumerable<T> GetByAsembly<T>(string assembly)
+        where T : Win32Type
     {
-        return _types.Values
-            .Where(t => t.AssemblyName == assembly)
-            .OfType<T>();
+        return _types.Values.Where(t => t.AssemblyName == assembly).OfType<T>();
     }
 
     /// <summary>Get all types of a specific kind.</summary>
-    public IEnumerable<T> GetAll<T>() where T : Win32Type
+    public IEnumerable<T> GetAll<T>()
+        where T : Win32Type
     {
         return _types.Values.OfType<T>();
     }
@@ -167,13 +167,13 @@ public class TypeRegistry
     public bool Contains(string fqn) => _byFqn.ContainsKey(fqn);
 
     /// <summary>Check if a type of a specific kind with the given FQN exists.</summary>
-    public bool Contains<T>(string fqn) where T : Win32Type => 
-        _byFqn.TryGetValue(fqn, out var list) && list.OfType<T>().Any();
+    public bool Contains<T>(string fqn)
+        where T : Win32Type => _byFqn.TryGetValue(fqn, out var list) && list.OfType<T>().Any();
 
     /// <summary>Check if a type with the given identity exists.</summary>
     public bool Contains(TypeIdentity identity) => _types.ContainsKey(identity);
 
     /// <summary>Check if a type of a specific kind with the given identity exists.</summary>
-    public bool Contains<T>(TypeIdentity identity) where T : Win32Type
-        => _types.TryGetValue(identity, out var type) && type is T;
+    public bool Contains<T>(TypeIdentity identity)
+        where T : Win32Type => _types.TryGetValue(identity, out var type) && type is T;
 }

--- a/Generator/model/TypeRegistry.cs
+++ b/Generator/model/TypeRegistry.cs
@@ -48,11 +48,33 @@ public class TypeRegistry
         return null;
     }
 
+    public T? Resolve<T>(string fqn, Architecture target) where T : Win32Type
+    {
+        if (_byFqn.TryGetValue(fqn, out var variants))
+        {
+            // Prefer exact architecture match
+            T? exact = variants.OfType<T>().FirstOrDefault(v => v != null && v.Arch.HasFlag(target), null);
+            if (exact is T t)
+                return t;
+
+            // Fall back to universal
+            return variants.OfType<T>().FirstOrDefault(v => v is {Arch: Architecture.All}, null);
+        }
+        return null;
+    }
+
     /// <summary>Get a type by exact identity (FQN + arch).</summary>
     public Win32Type? Get(TypeIdentity identity)
     {
         _types.TryGetValue(identity, out var type);
         return type;
+    }
+
+    /// <summary>Get a type by exact identity (FQN + arch).</summary>
+    public T? Get<T>(TypeIdentity identity) where T : Win32Type
+    {
+        _types.TryGetValue(identity, out var type);
+        return type is T t ? t : null;
     }
 
     /// <summary>Get all architecture variants for a given FQN.</summary>
@@ -61,16 +83,40 @@ public class TypeRegistry
         return _byFqn.TryGetValue(fqn, out var list) ? list : [];
     }
 
+    /// <summary>Get all architecture variants of a specific kind for a given FQN.</summary>
+    public IReadOnlyList<T> GetAllVariants<T>(string fqn) where T : Win32Type
+    {
+        return _byFqn.TryGetValue(fqn, out var list)
+            ? [.. list.OfType<T>()]
+            : [];
+    }
+
     /// <summary>Get all types in a given namespace.</summary>
     public IEnumerable<Win32Type> GetByNamespace(string ns)
     {
         return _types.Values.Where(t => t.Namespace == ns);
     }
 
+    /// <summary>Get all types of a specific kind in a given namespace.</summary>
+    public IEnumerable<T> GetByNamespace<T>(string ns) where T : Win32Type
+    {
+        return _types.Values
+            .Where(t => t.Namespace == ns)
+            .OfType<T>();
+    } 
+
     /// <summary>Get all types from a given source assembly.</summary>
     public IEnumerable<Win32Type> GetByAssembly(string assembly)
     {
         return _types.Values.Where(t => t.AssemblyName == assembly);
+    }
+
+    /// <summary>Get all types of a specific kind from a given source assembly.</summary>
+    public IEnumerable<T> GetByAsembly<T>(string assembly) where T : Win32Type
+    {
+        return _types.Values
+            .Where(t => t.AssemblyName == assembly)
+            .OfType<T>();
     }
 
     /// <summary>Get all types of a specific kind.</summary>
@@ -120,6 +166,14 @@ public class TypeRegistry
     /// <summary>Check if a type with the given FQN exists.</summary>
     public bool Contains(string fqn) => _byFqn.ContainsKey(fqn);
 
+    /// <summary>Check if a type of a specific kind with the given FQN exists.</summary>
+    public bool Contains<T>(string fqn) where T : Win32Type => 
+        _byFqn.TryGetValue(fqn, out var list) && list.OfType<T>().Any();
+
     /// <summary>Check if a type with the given identity exists.</summary>
     public bool Contains(TypeIdentity identity) => _types.ContainsKey(identity);
+
+    /// <summary>Check if a type of a specific kind with the given identity exists.</summary>
+    public bool Contains<T>(TypeIdentity identity) where T : Win32Type
+        => _types.TryGetValue(identity, out var type) && type is T;
 }

--- a/Generator/model/Types/HandleType.cs
+++ b/Generator/model/Types/HandleType.cs
@@ -18,4 +18,18 @@ public sealed class HandleType : StructType
     /// Null if no RAII free function is defined or if it has != 2 parameters.
     /// </summary>
     public FreeFuncRef? FreeFunc { get; init; }
+
+    /// <summary>
+    /// Optional AHK expression for a restored <c>__value</c> getter, where <c>$field</c> resolves
+    /// to <c>this.&lt;member&gt;</c>. Null = no getter (default; preserves type identity). Set in
+    /// Transform from a <c>value-accessor</c> override.
+    /// </summary>
+    public string? ValueGetterExpr { get; set; }
+
+    /// <summary>
+    /// Optional AHK expression that transforms a raw incoming value in the <c>__value</c> setter's
+    /// else branch, where <c>$value</c> resolves to the setter's <c>value</c>. Null = store the
+    /// value unchanged. Set in Transform from a <c>value-accessor</c> override.
+    /// </summary>
+    public string? ValueSetterCoerceExpr { get; set; }
 }

--- a/Generator/model/Types/HandleType.cs
+++ b/Generator/model/Types/HandleType.cs
@@ -20,6 +20,14 @@ public sealed class HandleType : StructType
     public FreeFuncRef? FreeFunc { get; init; }
 
     /// <summary>
+    /// True when some function returns or outputs this handle owned with a context-specific
+    /// <c>[RAIIFree]</c> that differs from <see cref="FreeFunc"/>, so the emitter must generate an
+    /// <c>OwnedWith(freeFunc)</c> factory. Set in Transform by <c>OwnedHandleResolver</c> (it needs
+    /// every handle's resolved default free function, so it can't be computed during extraction).
+    /// </summary>
+    public bool NeedsOwnedWith { get; set; }
+
+    /// <summary>
     /// Optional AHK expression for a restored <c>__value</c> getter, where <c>$field</c> resolves
     /// to <c>this.&lt;member&gt;</c>. Null = no getter (default; preserves type identity). Set in
     /// Transform from a <c>value-accessor</c> override.

--- a/Generator/model/Types/NativeTypedefType.cs
+++ b/Generator/model/Types/NativeTypedefType.cs
@@ -13,4 +13,19 @@ public sealed class NativeTypedefType : Win32Type
 {
     /// <summary>The underlying primitive/pointer type backing this typedef.</summary>
     public required ResolvedType Underlying { get; init; }
+
+    /// <summary>
+    /// Optional AHK expression for a restored <c>__value</c> getter (e.g. BOOL <c>!!$field</c>),
+    /// where <c>$field</c> resolves to <c>this.value</c>. Null = no getter (default; preserves
+    /// type identity). Set in Transform from a <c>value-accessor</c> override.
+    /// </summary>
+    public string? ValueGetterExpr { get; set; }
+
+    /// <summary>
+    /// Optional AHK expression that transforms a raw incoming value in the <c>__value</c> setter's
+    /// else branch (e.g. BOOL <c>!!$value</c>), where <c>$value</c> resolves to the setter's
+    /// <c>value</c>. Null = store the value unchanged. Set in Transform from a
+    /// <c>value-accessor</c> override.
+    /// </summary>
+    public string? ValueSetterCoerceExpr { get; set; }
 }

--- a/Generator/model/Types/NativeTypedefType.cs
+++ b/Generator/model/Types/NativeTypedefType.cs
@@ -1,0 +1,16 @@
+namespace AhkWin32.Generator.Model.Types;
+
+using AhkWin32.Generator.Model;
+
+/// <summary>
+/// A NativeTypedef declared in the metadata (e.g. BOOL, NTSTATUS, BSTR, DWORD).
+/// In Win32 metadata these are types marked [NativeTypedefAttribute] with a single
+/// field carrying the underlying value. Emitted in v2.1 as a `struct` with a
+/// `value` field plus `__value` get/set so DllCall and assignment treat the
+/// instance transparently as the underlying value.
+/// </summary>
+public sealed class NativeTypedefType : Win32Type
+{
+    /// <summary>The underlying primitive/pointer type backing this typedef.</summary>
+    public required ResolvedType Underlying { get; init; }
+}

--- a/Generator/model/Types/Win32Type.cs
+++ b/Generator/model/Types/Win32Type.cs
@@ -70,4 +70,15 @@ public abstract class Win32Type
     public bool IsAnsi => Flags.HasFlag(MemberFlags.Ansi);
     public bool IsUnicode => Flags.HasFlag(MemberFlags.Unicode);
     public bool IsAnonymous => Flags.HasFlag(MemberFlags.Anonymous);
+
+    /// <summary>
+    /// List of the names of the types that this type can be converted to implicitly.
+    /// The type is guaranteed to be in the same namespace as this type.
+    /// </summary>
+    public IReadOnlyList<string>? AlsoUsableFor { get; init; }
+
+    /// <summary>
+    /// List of resolved types which can be implicitly converted to this type.
+    /// </summary>
+    public IList<Win32Type>? ConvertibleFrom { get; set; }
 }

--- a/Generator/model/Types/Win32Type.cs
+++ b/Generator/model/Types/Win32Type.cs
@@ -33,10 +33,10 @@ public abstract class Win32Type
     public List<ExtensionCode> Extensions { get; init; } = [];
 
     /// <summary>
-    /// FQNs of types referenced by this type (for #Include generation).
-    /// Mutable because transforms in Phase 2 may add to it.
+    /// Types and functions referenced by this type. Drives #Include (v2) and #Import (v2.1)
+    /// emission. Mutable because transforms in Phase 2 may add to it.
     /// </summary>
-    public List<string> ReferencedTypes { get; init; } = [];
+    public ImportCollection Imports { get; init; } = new();
 
     // --- Inline documentation (pre-resolved from ApiDetails + attributes) ---
 

--- a/metadata/ahk-reserved-names.yml
+++ b/metadata/ahk-reserved-names.yml
@@ -20,6 +20,8 @@
 - do
 - while
 - unset
+- "true"
+- "false"
 # Built-In class names: https://www.autohotkey.com/docs/v2/ObjList.htm
 - Any
 - Object

--- a/metadata/extensions/BSTR.yml
+++ b/metadata/extensions/BSTR.yml
@@ -2,9 +2,16 @@
 
 add-to:
   - Windows.Win32.Foundation.BSTR
-requires:
-  - Windows.Win32.Foundation.Apis
-code: |
+
+imports:
+  Windows.Win32.Foundation.Apis:
+    - SysStringLen
+    - SysStringByteLen
+    - SysAllocString
+    - SysReallocString
+
+code:
+  v20: |
     /**
      * @readonly The length of the allocated string in characters, not including the null terminator
      * @type {Integer}
@@ -31,6 +38,44 @@ code: |
      */
     ReAlloc(str){
         result := Foundation.SysReallocString(this, str)
+        if(result == 0)
+            throw MemoryError("Not enough memory to reallocate string")
+    }
+
+    /**
+     * Gets the value of the BSTR as a native AHK string
+     * @returns {String}
+     */
+    ToString(){
+        return StrGet(this.value, this.length, "UTF-16")
+    }
+  v21: |
+    /**
+     * @readonly The length of the allocated string in characters, not including the null terminator
+     * @type {Integer}
+     */
+    length => SysStringLen(this)
+
+    /**
+     * @readonly The length of the allocated string in bytes, not including the null terminator
+     * @type {Integer}
+     */
+    byteLength => SysStringByteLen(this)
+
+    /**
+     * Creates a new BSTR from an existing AHK string
+     * @param {String | Integer} str the string to allocate, or a pointer to a string to allocate
+     */
+    static Alloc(str){
+        return SysAllocString(str)
+    }
+
+    /**
+     * Changes the contents of the BSTR, resizing it if necessary
+     * @param {String} str the new contents of the BSTR
+     */
+    ReAlloc(str){
+        result := SysReallocString(this, str)
         if(result == 0)
             throw MemoryError("Not enough memory to reallocate string")
     }

--- a/metadata/extensions/CHAR.yml
+++ b/metadata/extensions/CHAR.yml
@@ -1,0 +1,32 @@
+add-to:
+  - Windows.Win32.Foundation.CHAR
+
+code:
+  # v2.0 has no typed `.Array`; fixed CHAR arrays are handled directly via StringType
+  # (StrGet/StrPut) by the v2.0 struct emitter, so there is nothing to attach here.
+  v20: skip
+  # Give CHAR[N] fields v2.0-style string ergonomics: assigning a String writes it with
+  # StrPut, and String()/ToString() reads it back with StrGet, while indexed element
+  # access (chars[i]) still works.
+  #
+  # Each `CHAR[N]` is a distinct, length-specific subclass of the shared `Struct.Array`
+  # (there is no per-element-type base to attach to), so the hooks are installed on each
+  # array class as it is first created, by overriding `__Item` (the property that builds
+  # `CHAR[N]`). Installing on the shared `Struct.Array` instead would clobber every other
+  # struct array (including WCHAR's, which needs UTF-16).
+  v21: |
+    static __Item[Length] {
+        get {
+            cls := super[Length]
+            if (!ObjHasOwnProp(cls.Prototype, "__StringArrayHooked")) {
+                DefineProp(cls.Prototype, "__value", {
+                    set: (this, value) => StrPut(value, this.Ptr, this.Length, "UTF-8")
+                })
+                DefineProp(cls.Prototype, "ToString", {
+                    Call: (this) => StrGet(this.Ptr, this.Length, "UTF-8")
+                })
+                DefineProp(cls.Prototype, "__StringArrayHooked", { value: true })
+            }
+            return cls
+        }
+    }

--- a/metadata/extensions/COLORREF.yml
+++ b/metadata/extensions/COLORREF.yml
@@ -1,12 +1,13 @@
 add-to:
   - Windows.Win32.Foundation.COLORREF
-requires: []
-code: |
+
+code:
+  v20: &shared |
     static GetRed(color) => color & 0xFF
     static GetGreen(color) => (color >> 8) & 0xFF
     static GetBlue(color) => (color >> 16) & 0xFF
 
-    static SetRed(color, value) => (color & 0xFFFFFF00) | value 
+    static SetRed(color, value) => (color & 0xFFFFFF00) | value
     static SetGreen(color, value) => (color & 0xFFFF00FF) | (value << 8)
     static SetBlue(color, value) => (color & 0xFF00FFFF) | (value << 16)
 
@@ -17,9 +18,9 @@ code: |
      * @returns {String} the RGB string
      */
     static ToRGBString(color){
-        return Format("0x{1:02X}{2:02X}{3:02X}", 
-            COLORREF.GetRed(color), 
-            COLORREF.GetGreen(color), 
+        return Format("0x{1:02X}{2:02X}{3:02X}",
+            COLORREF.GetRed(color),
+            COLORREF.GetGreen(color),
             COLORREF.GetBlue(color))
     }
 
@@ -43,3 +44,4 @@ code: |
      * @returns {String} the RGB string
      */
     ToRGBString() => COLORREF.ToRGBString(this.value)
+  v21: *shared

--- a/metadata/extensions/IUnknown.yml
+++ b/metadata/extensions/IUnknown.yml
@@ -2,7 +2,7 @@ add-to:
   - Windows.Win32.System.Com.IUnknown
 
 code:
-  v20: &shared |
+  v20: |
     /**
      * Determines whether or not this interface and some other interface refer to the
      * same underlying object by comparing the pointers retrieved from QueryInterface
@@ -39,4 +39,62 @@ code:
             this.Release()
         }
     }
-  v21: *shared
+  v21: |
+    /**
+     * Install the QueryInterface / AddRef / Release callbacks. Each slot honors a
+     * user-supplied override on `implObj` if present, otherwise falls back to the
+     * built-in `__Default*` implementation. The CallbackCreate paramCount is the
+     * COM-ABI count (declared parameters + 1 for the C++ this pointer).
+     */
+    Implement(implObj, flags := "") {
+        super.Implement(implObj, flags)
+
+        qi := implObj.HasMethod("QueryInterface", 3) ?
+            GetMethod(implObj, "QueryInterface") :
+            ObjBindMethod(this, "_DefaultQueryInterface")
+        this.vtbl.QueryInterface := CallbackCreate(qi, flags, 3)
+
+        addRef := implObj.HasMethod("AddRef", 1) ?
+            GetMethod(implObj, "AddRef") :
+            ObjBindMethod(this, "_DefaultAddRef")
+        this.vtbl.AddRef := CallbackCreate(addRef, flags, 1)
+
+        release := implObj.HasMethod("Release", 1) ?
+            GetMethod(implObj, "Release") :
+            ObjBindMethod(this, "_DefaultRelease")
+        this.vtbl.Release := CallbackCreate(release, flags, 1)
+    }
+
+    /**
+     * Free the three IUnknown callback slots, then chain to super.
+     */
+    Dispose() {
+        super.Dispose()
+        CallbackFree(this.vtbl.QueryInterface)
+        CallbackFree(this.vtbl.AddRef)
+        CallbackFree(this.vtbl.Release)
+    }
+
+    /**
+     * Determines whether or not this interface and some other interface refer to the
+     * same underlying object by comparing pointers retrieved from QueryInterface.
+     * @param {IUnknown | ComObject} other the interface to compare this one to
+     */
+    Equals(other) {
+        if (!(other is IUnknown || other is ComObject))
+            throw TypeError("Expected a Win32ComInterface extending IUnknown or a ComObject, but got a(n) " . Type(other))
+
+        thisPtrBuf := Buffer(A_PtrSize)
+        this.QueryInterface(IUnknown.IID, thisPtrBuf)
+        thisPtr := NumGet(thisPtrBuf, "ptr")
+
+        otherPtr := 0
+        if (other is IUnknown) {
+            other.QueryInterface(IUnknown.IID, &otherPtr)
+            otherInterface := IUnknown(otherPtr)  ; auto-released on scope exit
+        } else {
+            otherPtr := ComObjQuery(other, String(IUnknown.IID)).ptr
+        }
+
+        return thisPtr == otherPtr
+    }

--- a/metadata/extensions/IUnknown.yml
+++ b/metadata/extensions/IUnknown.yml
@@ -49,19 +49,13 @@ code:
     Implement(implObj, flags := "") {
         super.Implement(implObj, flags)
 
-        qi := implObj.HasMethod("QueryInterface", 3) ?
-            GetMethod(implObj, "QueryInterface") :
-            ObjBindMethod(this, "_DefaultQueryInterface")
+        qi := GetMethod(implObj, "QueryInterface") ?? ObjBindMethod(this, "_DefaultQueryInterface")
         this.vtbl.QueryInterface := CallbackCreate(qi, flags, 3)
-
-        addRef := implObj.HasMethod("AddRef", 1) ?
-            GetMethod(implObj, "AddRef") :
-            ObjBindMethod(this, "_DefaultAddRef")
+    
+        addRef := GetMethod(implObj, "AddRef") ?? ObjBindMethod(this, "_DefaultAddRef")            
         this.vtbl.AddRef := CallbackCreate(addRef, flags, 1)
-
-        release := implObj.HasMethod("Release", 1) ?
-            GetMethod(implObj, "Release") :
-            ObjBindMethod(this, "_DefaultRelease")
+    
+        release := GetMethod(implObj, "Release") ?? ObjBindMethod(this, "_DefaultRelease")
         this.vtbl.Release := CallbackCreate(release, flags, 1)
     }
 

--- a/metadata/extensions/IUnknown.yml
+++ b/metadata/extensions/IUnknown.yml
@@ -1,11 +1,12 @@
 add-to:
   - Windows.Win32.System.Com.IUnknown
-requires: []
-code: |
+
+code:
+  v20: &shared |
     /**
      * Determines whether or not this interface and some other interface refer to the
      * same underlying object by comparing the pointers retrieved from QueryInterface
-     * @param {IUnknown | ComObject} other the interface to compare this one to. If 
+     * @param {IUnknown | ComObject} other the interface to compare this one to. If
      *          other is a native AHK ComObject, its IUnknown pointer is retrieved via
      *          `ComObjQuery`
      * @returns 1 if this and other refer to the same object, 0 if they don't
@@ -18,7 +19,7 @@ code: |
         thisPtrBuf := Buffer(A_PtrSize)
         this.QueryInterface(IUnknown.IID, thisPtrBuf)
         thisPtr := NumGet(thisPtrBuf, "ptr")
-        
+
         otherPtr := 0
 
         if(other is IUnknown){
@@ -38,3 +39,4 @@ code: |
             this.Release()
         }
     }
+  v21: *shared

--- a/metadata/extensions/NTSTATUS.yml
+++ b/metadata/extensions/NTSTATUS.yml
@@ -1,13 +1,18 @@
 add-to:
   - Windows.Win32.Foundation.NTSTATUS
-requires:
-  - Windows.Win32.System.LibraryLoader.Apis
-  - Windows.Win32.System.Diagnostics.Debug.Apis
-  - Windows.Win32.System.Diagnostics.Debug.FORMAT_MESSAGE_OPTIONS
-code: |
+
+imports:
+  Windows.Win32.System.Diagnostics.Debug.FORMAT_MESSAGE_OPTIONS:
+  Windows.Win32.System.LibraryLoader.Apis:
+    - LoadLibraryW
+  Windows.Win32.System.Diagnostics.Debug.Apis:
+    - FormatMessageW
+
+code:
+  v20: |
     /**
      * Determine if the given NTSTATUS value idicates success
-     * 
+     *
      * @param {Integer} status the status to check
      * @returns {Boolean} 1 if the status indicates success, 0 otherwise
      */
@@ -15,7 +20,7 @@ code: |
 
     /**
      * Determine if the given NTSTATUS value is informational
-     * 
+     *
      * @param {Integer} status the status to check
      * @returns {Boolean} 1 if the status is informational, 0 otherwise
      */
@@ -23,7 +28,7 @@ code: |
 
     /**
      * Determine if the given NTSTATUS value is a warning
-     * 
+     *
      * @param {Integer} status the status to check
      * @returns {Boolean} 1 if the status indicates a warning, 0 otherwise
      */
@@ -31,7 +36,7 @@ code: |
 
     /**
      * Determine if the given NTSTATUS value idicates success
-     * 
+     *
      * @param {Integer} status the status to check
      * @returns {Boolean} 1 if the status indicates success, 0 otherwise
      */
@@ -39,18 +44,18 @@ code: |
 
     /**
      * Get the error message assosciated with the specified `NTSTATUS` code. Prefer this (or `NTSTATUS.Throw`) over
-     * [`RtlNtStatusToDosError`](https://learn.microsoft.com/en-us/windows/win32/api/winternl/nf-winternl-rtlntstatustodoserror), 
-     * since many `NTSTATUS` error codes do not have equivalent `HRESULT` values. The conversion also 
+     * [`RtlNtStatusToDosError`](https://learn.microsoft.com/en-us/windows/win32/api/winternl/nf-winternl-rtlntstatustodoserror),
+     * since many `NTSTATUS` error codes do not have equivalent `HRESULT` values. The conversion also
      * [may or may not be](https://stackoverflow.com/questions/25566234/how-to-convert-specific-ntstatus-value-to-the-hresult#comment57039828_25567826)
      * spotty.
-     * 
+     *
      * @param {Integer} status an `NTSTATUS` code
      * @returns {String} the error message for the provided status code
      */
     static GetErrorMessage(status) {
         hMod := LibraryLoader.LoadLibraryW("NTDLL.DLL")
         msgBuf := Buffer(1024, 0)
-    
+
         chars := Debug.FormatMessageW(
             FORMAT_MESSAGE_OPTIONS.FORMAT_MESSAGE_FROM_HMODULE | FORMAT_MESSAGE_OPTIONS.FORMAT_MESSAGE_FROM_SYSTEM,
             hMod.value,
@@ -60,14 +65,14 @@ code: |
             msgBuf.Size // 2,
             0
         )
-    
+
         return StrGet(msgBuf, chars, "UTF-16")
     }
 
     /**
      * Throw an `OSError` for the given `NTSTATUS` value. Note this function does not check to see
      * if the value is actually an error.
-     * 
+     *
      * @param {Integer} status the status
      */
     static Throw(status) {
@@ -81,7 +86,91 @@ code: |
 
     /**
      * Throw an `OSError` for the given `NTSTATUS` value if it is an error
-     * 
+     *
+     * @param {Integer} status the status
+     */
+    static ThrowIfError(status) {
+        if(NTSTATUS.IsError(status))
+            NTSTATUS.Throw(status)
+    }
+  v21: |
+    /**
+     * Determine if the given NTSTATUS value idicates success
+     *
+     * @param {Integer} status the status to check
+     * @returns {Boolean} 1 if the status indicates success, 0 otherwise
+     */
+    static IsSuccess(status) => status >= 0
+
+    /**
+     * Determine if the given NTSTATUS value is informational
+     *
+     * @param {Integer} status the status to check
+     * @returns {Boolean} 1 if the status is informational, 0 otherwise
+     */
+    static IsInformational(status) => status >>> 30 == 1
+
+    /**
+     * Determine if the given NTSTATUS value is a warning
+     *
+     * @param {Integer} status the status to check
+     * @returns {Boolean} 1 if the status indicates a warning, 0 otherwise
+     */
+    static IsWarning(status) => status >>> 30 == 2
+
+    /**
+     * Determine if the given NTSTATUS value idicates success
+     *
+     * @param {Integer} status the status to check
+     * @returns {Boolean} 1 if the status indicates success, 0 otherwise
+     */
+    static IsError(status) => status >>> 30 == 3
+
+    /**
+     * Get the error message assosciated with the specified `NTSTATUS` code. Prefer this (or `NTSTATUS.Throw`) over
+     * [`RtlNtStatusToDosError`](https://learn.microsoft.com/en-us/windows/win32/api/winternl/nf-winternl-rtlntstatustodoserror),
+     * since many `NTSTATUS` error codes do not have equivalent `HRESULT` values. The conversion also
+     * [may or may not be](https://stackoverflow.com/questions/25566234/how-to-convert-specific-ntstatus-value-to-the-hresult#comment57039828_25567826)
+     * spotty.
+     *
+     * @param {Integer} status an `NTSTATUS` code
+     * @returns {String} the error message for the provided status code
+     */
+    static GetErrorMessage(status) {
+        hMod := LoadLibraryW("NTDLL.DLL")
+        msgBuf := Buffer(1024, 0)
+
+        chars := FormatMessageW(
+            FORMAT_MESSAGE_OPTIONS.FORMAT_MESSAGE_FROM_HMODULE | FORMAT_MESSAGE_OPTIONS.FORMAT_MESSAGE_FROM_SYSTEM,
+            hMod.value,
+            status,
+            0,
+            msgBuf,
+            msgBuf.Size // 2,
+            0
+        )
+
+        return StrGet(msgBuf, chars, "UTF-16")
+    }
+
+    /**
+     * Throw an `OSError` for the given `NTSTATUS` value. Note this function does not check to see
+     * if the value is actually an error.
+     *
+     * @param {Integer} status the status
+     */
+    static Throw(status) {
+        err := OSError(, -1)
+
+        err.Number := status
+        err.Message := Format("(NTSTATUS: 0x{1:X}) {2}", status, NTSTATUS.GetErrorMessage(status))
+
+        throw err
+    }
+
+    /**
+     * Throw an `OSError` for the given `NTSTATUS` value if it is an error
+     *
      * @param {Integer} status the status
      */
     static ThrowIfError(status) {

--- a/metadata/extensions/POINT.yml
+++ b/metadata/extensions/POINT.yml
@@ -1,8 +1,9 @@
 add-to:
   - Windows.Win32.Foundation.POINT
   - Windows.Win32.Foundation.POINTL
-requires: []
-code: |
+
+code:
+  v20: &shared |
     /**
      * Many Win32 APIs take points as 64-bit integer value types.
      * This will return the POINT in a compatible format
@@ -12,3 +13,4 @@ code: |
     ToString() {
         return Format("({1}, {2})", this.x, this.y)
     }
+  v21: *shared

--- a/metadata/extensions/PSTR.yml
+++ b/metadata/extensions/PSTR.yml
@@ -1,7 +1,8 @@
 add-to:
   - Windows.Win32.Foundation.PSTR
-requires: []
-code: |
+
+code:
+  v20: &shared |
     /**
      * Creates and returns a `Buffer` containing a copy of `str` in ANSI encoding which can be passed
      * as an argument to functins requiring `PSTR`s.
@@ -9,7 +10,7 @@ code: |
      * @param {Integer} buffLen the length of the buffer to encode the string in. If unset, the returned
      *      buffer is exactly the number of bytes required to fit `str`. This can be used if the function
      *      you intend to call will modify the string in-place.
-     * @returns {Buffer} a `Buffer` containing `str` encoded in ANSI  
+     * @returns {Buffer} a `Buffer` containing `str` encoded in ANSI
      */
     static Alloc(str, buffLen?) {
         if(!(str is String))
@@ -28,3 +29,4 @@ code: |
         StrPut(str, buf, "CP0")
         return buf
     }
+  v21: *shared

--- a/metadata/extensions/PSTR.yml
+++ b/metadata/extensions/PSTR.yml
@@ -4,8 +4,14 @@ add-to:
 code:
   v20: &shared |
     /**
+     * Extracts the String pointed at by this `PSTR` to an AutoHotkey string
+     * @returns {String}
+     */
+    ToString() => StrGet(this.value, "UTF-8")
+
+    /**
      * Creates and returns a `Buffer` containing a copy of `str` in ANSI encoding which can be passed
-     * as an argument to functins requiring `PSTR`s.
+     * as an argument to functions requiring `PSTR`s.
      * @param {String} str the string to encode
      * @param {Integer} buffLen the length of the buffer to encode the string in. If unset, the returned
      *      buffer is exactly the number of bytes required to fit `str`. This can be used if the function

--- a/metadata/extensions/PWSTR.yml
+++ b/metadata/extensions/PWSTR.yml
@@ -4,8 +4,14 @@ add-to:
 code:
   v20: &shared |
     /**
+     * Extracts the String pointed at by this `PWSTR` to an AutoHotkey string
+     * @returns {String}
+     */
+    ToString() => StrGet(this.value, "UTF-16")
+
+    /**
      * Creates and returns a `Buffer` containing a copy of `str` in UTF-16 encoding which can be passed
-     * as an argument to functins requiring `PWSTR`s.
+     * as an argument to functions requiring `PWSTR`s.
      * @param {String} str the string to encode
      * @param {Integer} buffLen the length of the buffer to encode the string in. If unset, the returned
      *      buffer is exactly the number of bytes required to fit `str`. This can be used if the function

--- a/metadata/extensions/PWSTR.yml
+++ b/metadata/extensions/PWSTR.yml
@@ -1,7 +1,8 @@
 add-to:
   - Windows.Win32.Foundation.PWSTR
-requires: []
-code: |
+
+code:
+  v20: &shared |
     /**
      * Creates and returns a `Buffer` containing a copy of `str` in UTF-16 encoding which can be passed
      * as an argument to functins requiring `PWSTR`s.
@@ -9,7 +10,7 @@ code: |
      * @param {Integer} buffLen the length of the buffer to encode the string in. If unset, the returned
      *      buffer is exactly the number of bytes required to fit `str`. This can be used if the function
      *      you intend to call will modify the string in-place.
-     * @returns {Buffer} a `Buffer` containing `str` encoded in UTF-16  
+     * @returns {Buffer} a `Buffer` containing `str` encoded in UTF-16
      */
     static Alloc(str, buffLen?) {
         if(!(str is String))
@@ -28,3 +29,4 @@ code: |
         StrPut(str, buf, "UTF-16")
         return buf
     }
+  v21: *shared

--- a/metadata/extensions/README.md
+++ b/metadata/extensions/README.md
@@ -8,27 +8,41 @@ Extensions are custom code added to generated types. Extensions can be added to 
 ## Extension Definition Files
 Extensions are defined in [YAML](https://yaml.org/) files. The generator will read files in this directory (or the /extensions subdirectory of whichever directory is passed in as its metadata directory) with the extensions `.yml` and `.yaml`. The file format is as follows (example is a snippet of the [RECT / RECTL](./RECT.yml) extension definition):
 ```yaml
-# Fully qualified names of types to which the extensions should be added
+# Fully qualified names of types to which the extensions should be added.
 add-to:
   - Windows.Win32.Foundation.RECT
   - Windows.Win32.Foundation.RECTL
 
-# Fully qualified names of types for which #Include directives must be added
-# The generator will resolve these to relative paths when it runs
-requires:
-  - Windows.Win32.Graphics.Gdi.Apis
-  - Windows.Win32.Foundation.POINT
+# Imports the extension code needs.
+#   - Value is `null` / empty list  -> whole-file include of that FQN.
+#   - Value is a list of names      -> import those specific functions from the
+#                                      named Apis FQN. In v2.1 this becomes
+#                                      `#Import "..." { Name1, Name2 }` merged
+#                                      with any other imports the type already
+#                                      needed; in v2.0 it falls back to a
+#                                      whole-file include of the Apis file.
+imports:
+  Windows.Win32.Foundation.POINT:
+  Windows.Win32.Graphics.Gdi.Apis:
+    - IsRectEmpty
+    - IntersectRect
 
-# The code to add to the generated type. Code is added to the body of the generated class
-code: |
-    height => this.top - this.bottom
-
-    width => this.right - this.left
-
-    area => this.width * this.height
-
+# Code to add to the generated type's body. Must supply both `v20` and `v21`;
+# either may be the literal value `skip` to opt out for that target. When the
+# two bodies are identical, use a YAML anchor (`&shared` / `*shared`).
+#
+# v2.0 reaches free functions through their Apis class (`Gdi.IsRectEmpty(...)`).
+# v2.1 imports them by name and calls them bare (`IsRectEmpty(...)`).
+code:
+  v20: |
+    isEmpty => Gdi.IsRectEmpty(this)
+    ...
+  v21: |
+    isEmpty => IsRectEmpty(this)
     ...
 ```
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md#writing-extensions) for the full schema, more examples (shared body via anchor, opting out of a version), and the rationale behind the per-version split.
 
 ### Aliases
 The generator suports the following aliases, using the `$Name` convention (like bash or PowerShell - this is because `%%` is valid AHK syntax and would make parsing a nightmare). All aliases are case-sensitive:

--- a/metadata/extensions/RECT.yml
+++ b/metadata/extensions/RECT.yml
@@ -3,10 +3,21 @@
 add-to:
   - Windows.Win32.Foundation.RECT
   - Windows.Win32.Foundation.RECTL
-requires:
-  - Windows.Win32.Graphics.Gdi.Apis
-  - Windows.Win32.Foundation.POINT
-code: |
+
+imports:
+  Windows.Win32.Foundation.POINT:
+  Windows.Win32.Graphics.Gdi.Apis:
+    - IsRectEmpty
+    - IntersectRect
+    - UnionRect
+    - SubtractRect
+    - EqualRect
+    - OffsetRect
+    - InflateRect
+    - PtInRect
+
+code:
+  v20: |
     height => this.bottom - this.top
 
     width => this.right - this.left
@@ -30,7 +41,7 @@ code: |
     }
 
     /**
-     * Creates the union of two rectangles. The union is the smallest rectangle that 
+     * Creates the union of two rectangles. The union is the smallest rectangle that
      * contains both source rectangles.
      *
      * @param {RECT | RECTL} other rectangle to union this one with
@@ -43,7 +54,7 @@ code: |
     }
 
     /**
-     * Determines the coordinates of a rectangle formed by subtracting 
+     * Determines the coordinates of a rectangle formed by subtracting
      * one rectangle from this one
      *
      * @param {RECT | RECTL} other rectangle to subtract from this one
@@ -57,7 +68,7 @@ code: |
 
     /**
      * Determines whether the this rectangle is equal to another
-     * 
+     *
      * @param {RECT | RECTL} other rectangle to compare this one to
      * @returns {Boolean} a nonzero value of the rectangles are equal, 0 if they aren't
      */
@@ -106,6 +117,113 @@ code: |
         }
 
         return Gdi.PtInRect(this, pt.Value)
+    }
+
+    ToString(){
+        return Format("({1}, {2}) - ({3}, {4})",
+            this.left, this.top, this.right, this.bottom
+        )
+    }
+  v21: |
+    height => this.bottom - this.top
+
+    width => this.right - this.left
+
+    area => this.width * this.height
+
+    isEmpty => IsRectEmpty(this)
+
+    /**
+     * Calculates the intersection of two source rectangles and returns it as a
+     * new rectangle. If the rectangles do not intersect, the resulting rectangle
+     * is empty
+     *
+     * @param {RECT | RECTL} other rectangle to intersect with this one
+     * @returns {$Class} The intersection between this rectangle and `other`
+     */
+    Intersect(other) {
+        intersection := $Class()
+        IntersectRect(intersection, this, other)
+        return intersection
+    }
+
+    /**
+     * Creates the union of two rectangles. The union is the smallest rectangle that
+     * contains both source rectangles.
+     *
+     * @param {RECT | RECTL} other rectangle to union this one with
+     * @returns {$Class} the union between this rectangle and `other`
+     */
+    Union(other) {
+        union := $Class()
+        UnionRect(union, this, other)
+        return union
+    }
+
+    /**
+     * Determines the coordinates of a rectangle formed by subtracting
+     * one rectangle from this one
+     *
+     * @param {RECT | RECTL} other rectangle to subtract from this one
+     * @returns {$Class} the result of subtracting `other` from this
+     */
+    Subtract(other) {
+        diff := $Class()
+        SubtractRect(diff, this, other)
+        return diff
+    }
+
+    /**
+     * Determines whether the this rectangle is equal to another
+     *
+     * @param {RECT | RECTL} other rectangle to compare this one to
+     * @returns {Boolean} a nonzero value of the rectangles are equal, 0 if they aren't
+     */
+    Equals(other) {
+        return EqualRect(this, other)
+    }
+
+    /**
+     * Moves the rectangle by the specified offsets
+     *
+     * @param {Integer} dx the amount to shift the rectangle horizontally
+     * @param {Integer} dy the amount to shift the rectangle vertically
+     */
+    Offset(dx := 0, dy := 0) {
+        OffsetRect(this, dx, dy)
+    }
+
+    /**
+     * Increases or decreases the width and height of the rectangle
+     *
+     * @param {Integer} dx the amount to infalte or deflate horizontally
+     * @param {Integer} dy the amount to infalte or deflate vertically
+     */
+    Inflate(dx := 0, dy := 0) {
+        InflateRect(this, dx, dy)
+    }
+
+    /**
+     * Check whether a point lies inside the rectange. In one-parameter mode,
+     * interperets `ptOrXCoord` as a pointer to a `POINT` or equivalent struct;
+     * in two-parameter mode, constructs a `POINT` using the provided values.
+     *
+     * @param {POINT | Integer} ptOrXCoord In one-parameter mode, a pointer to a
+     *      POINT or equivalent structure. In two-parameter mode, the x coordinate
+     *      of the point to check
+     * @param {Integer} yCoord In two-parameter mode, the y coordinate of the point
+     *      to check
+     * @returns {Boolean} 1 if the point is inside the rectangle, 0 if it isn not
+     */
+    HitTest(ptOrXCoord, yCoord?){
+        if(IsSet(yCoord)){
+            pt := POINT({x: Integer(ptOrXCoord), y: Integer(yCoord)})
+        }
+        else{
+            pt := ptOrXCoord
+        }
+
+        return PtInRect(this, pt.Value)
     }
 
     ToString(){

--- a/metadata/extensions/RECT.yml
+++ b/metadata/extensions/RECT.yml
@@ -217,13 +217,15 @@ code:
      */
     HitTest(ptOrXCoord, yCoord?){
         if(IsSet(yCoord)){
-            pt := POINT({x: Integer(ptOrXCoord), y: Integer(yCoord)})
+            pt := POINT()
+            pt.x := Integer(ptOrXCoord)
+            pt.y := Integer(yCoord)
         }
         else{
             pt := ptOrXCoord
         }
 
-        return PtInRect(this, pt.Value)
+        return PtInRect(this, pt)
     }
 
     ToString(){

--- a/metadata/extensions/WCHAR.yml
+++ b/metadata/extensions/WCHAR.yml
@@ -1,0 +1,32 @@
+add-to:
+  - Windows.Win32.Foundation.WCHAR
+
+code:
+  # WCHAR only exists in v2.1 runs (registered as a synthetic NativeTypedef). In v2.0,
+  # Unicode fixed char arrays are handled directly via StringType (StrGet/StrPut).
+  v20: skip
+  # Give WCHAR[N] fields v2.0-style string ergonomics: assigning a String writes it with
+  # StrPut, and String()/ToString() reads it back with StrGet, while indexed element
+  # access (chars[i]) still works.
+  #
+  # Each `WCHAR[N]` is a distinct, length-specific subclass of the shared `Struct.Array`
+  # (there is no per-element-type base to attach to), so the hooks are installed on each
+  # array class as it is first created, by overriding `__Item` (the property that builds
+  # `WCHAR[N]`). Installing on the shared `Struct.Array` instead would clobber every other
+  # struct array (including CHAR's, which needs UTF-8).
+  v21: |
+    static __Item[Length] {
+        get {
+            cls := super[Length]
+            if (!ObjHasOwnProp(cls.Prototype, "__StringArrayHooked")) {
+                DefineProp(cls.Prototype, "__value", {
+                    set: (this, value) => StrPut(value, this.Ptr, this.Length, "UTF-16")
+                })
+                DefineProp(cls.Prototype, "ToString", {
+                    Call: (this) => StrGet(this.Ptr, this.Length, "UTF-16")
+                })
+                DefineProp(cls.Prototype, "__StringArrayHooked", { value: true })
+            }
+            return cls
+        }
+    }

--- a/metadata/overrides/BOOL.yml
+++ b/metadata/overrides/BOOL.yml
@@ -1,0 +1,11 @@
+# Win32 BOOL is a 4-byte integer that is conventionally 0/1 but accepts any nonzero as true.
+# Restore a __value getter and normalize on assignment so the v2.1 wrapper reads and writes like
+# an actual boolean: `b := 5` stores 1, and reading `b` yields 1.
+- type: Windows.Win32.Foundation.BOOL
+  value-accessor:
+    getter: "!!$field"
+    setter-coerce: "!!$value"
+- type: Windows.Win32.Foundation.BOOLEAN
+  value-accessor:
+    getter: "!!$field"
+    setter-coerce: "!!$value"

--- a/metadata/overrides/CHAR.yml
+++ b/metadata/overrides/CHAR.yml
@@ -1,0 +1,9 @@
+# Scalar CHAR (a single ANSI byte) — let `c := "a"` work by storing the character's ordinal, while
+# still accepting a raw integer. No getter is restored: a scalar CHAR keeps its identity so it
+# marshals as its byte value when passed by value to DllCall (a Chr() getter would marshal a string).
+#
+# This is independent of metadata/extensions/CHAR.yml, which gives CHAR[N] *array* fields their own
+# StrPut/StrGet __value via runtime DefineProp.
+- type: Windows.Win32.Foundation.CHAR
+  value-accessor:
+    setter-coerce: "$value is String ? Ord($value) : $value"

--- a/metadata/overrides/VARIANT_BOOL.yml
+++ b/metadata/overrides/VARIANT_BOOL.yml
@@ -1,0 +1,6 @@
+# OLE VARIANT_BOOL is a 2-byte integer where TRUE is -1 (0xFFFF) and FALSE is 0. It's more
+# useful to read as a primitive, since we can compare to Foundation.VARIANT_TRUE / VARIANT_FALSE
+# directly. Just insert a getter.
+- type: Windows.Win32.Foundation.VARIANT_BOOL
+  value-accessor:
+    getter: "$field"

--- a/metadata/overrides/WCHAR.yml
+++ b/metadata/overrides/WCHAR.yml
@@ -1,0 +1,8 @@
+# Scalar WCHAR (a single UTF-16 code unit) — let `c := "a"` work by storing the character's ordinal,
+# while still accepting a raw integer. No getter is restored (see CHAR.yml for the rationale).
+#
+# This is independent of metadata/extensions/WCHAR.yml, which gives WCHAR[N] *array* fields their own
+# StrPut/StrGet __value via runtime DefineProp.
+- type: Windows.Win32.Foundation.WCHAR
+  value-accessor:
+    setter-coerce: "$value is String ? Ord($value) : $value"


### PR DESCRIPTION
This PR adds initial support for generating AutoHotkey v2.1-compliant code - that is, structs, organized in modules, using `#Import` statements, and all that. It currently has feature parity with v2.0, but is *not* exploiting some of the new features that it could, for example generating delegats or using typed callbacks in COM interfaces.

This also *removes* a bunch of the v2.0 helper classes on which convenience methods used to live, so e.g. `HexDump` and `CopyTo` are gone from structs, since they just use the default AHK base.

Resolves #41
Resolves #42 
Resolves #43 
Resolves #44 
Resolves #45 
Resolves #47 